### PR TITLE
Adds confidence metric to goto expressions.

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/confidence.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/confidence.rs
@@ -1,0 +1,228 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use super::ExprValue::*;
+use super::{Expr, ExprValue, Stmt, StmtBody, SwitchCase, Symbol, SymbolTable, SymbolValues};
+/// The confidence we have that the this goto expression correctly represents the desired semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Confidence {
+    Low,
+    Medium,
+    High,
+    Default,
+}
+
+pub struct ConfidenceVisitor<'a> {
+    symbol_table: &'a SymbolTable,
+    required_confidence: Confidence,
+}
+
+impl ConfidenceVisitor<'a> {
+    pub fn new(
+        symbol_table: &'a SymbolTable,
+        required_confidence: Confidence,
+    ) -> ConfidenceVisitor<'a> {
+        Self { symbol_table, required_confidence }
+    }
+}
+impl ConfidenceVisitor<'_> {
+    pub fn visit_symbol_table(&mut self, st: &SymbolTable) -> SymbolTable {
+        let mut new_st = SymbolTable::raw(st.machine_model().clone());
+        for (_key, value) in st.iter() {
+            new_st.insert(self.visit_symbol(value));
+        }
+        new_st
+    }
+
+    pub fn visit_symbol(&mut self, symbol: &Symbol) -> Symbol {
+        let mut new_symbol = symbol.clone();
+        match &symbol.value {
+            SymbolValues::Expr(e) => {
+                new_symbol.value = SymbolValues::Expr(self.visit_expr(e));
+            }
+            SymbolValues::Stmt(s) => new_symbol.value = SymbolValues::Stmt(self.visit_stmt(s)),
+            SymbolValues::None => {}
+        };
+        new_symbol
+    }
+
+    pub fn visit_switchcase(&mut self, sc: &SwitchCase) -> SwitchCase {
+        SwitchCase::new(self.visit_expr(sc.case()), self.visit_stmt(sc.body()))
+    }
+
+    pub fn visit_stmt(&mut self, stmt: &Stmt) -> Stmt {
+        let loc = stmt.location().clone();
+        match stmt.body() {
+            StmtBody::Assign { lhs, rhs } => {
+                Stmt::assign(self.visit_expr(lhs), self.visit_expr(rhs), loc)
+            }
+            StmtBody::Assume { cond } => Stmt::assume(self.visit_expr(cond), loc),
+            StmtBody::AtomicBlock(body) => {
+                let body = body.iter().map(|x| self.visit_stmt(x)).collect();
+                Stmt::atomic_block(body).with_location(loc)
+            }
+            StmtBody::Block(body) => {
+                let body = body.iter().map(|x| self.visit_stmt(x)).collect();
+                Stmt::block(body).with_location(loc)
+            }
+            StmtBody::Break => stmt.clone(),
+            StmtBody::Continue => stmt.clone(),
+            StmtBody::Decl { lhs, value } => {
+                let lhs = self.visit_expr(lhs);
+                let value = value.as_ref().map(|x| self.visit_expr(x));
+                Stmt::decl(lhs, value, loc)
+            }
+            StmtBody::Expression(e) => Stmt::code_expression(self.visit_expr(e), loc),
+            StmtBody::For { init, cond, update, body } => {
+                let init = self.visit_stmt(init);
+                let cond = self.visit_expr(cond);
+                let update = self.visit_stmt(update);
+                let body = self.visit_stmt(body);
+                Stmt::for_loop(init, cond, update, body, loc)
+            }
+            StmtBody::FunctionCall { lhs, function, arguments } => {
+                let lhs = lhs.as_ref().map(|x| self.visit_expr(x));
+                let function = self.visit_expr(function);
+                let arguments = arguments.iter().map(|x| self.visit_expr(x)).collect();
+                Stmt::function_call(lhs, function, arguments, loc)
+            }
+            StmtBody::Goto(_) => stmt.clone(),
+            StmtBody::Ifthenelse { i, t, e } => {
+                let i = self.visit_expr(i);
+                let t = self.visit_stmt(t);
+                let e = e.as_ref().map(|x| self.visit_stmt(x));
+                Stmt::if_then_else(i, t, e, loc)
+            }
+            StmtBody::Label { label, body } => {
+                let body = self.visit_stmt(body);
+                body.with_label(label.to_string()).with_location(loc)
+            }
+            StmtBody::Return(e) => {
+                let e = e.as_ref().map(|x| self.visit_expr(x));
+                Stmt::ret(e, loc)
+            }
+            StmtBody::Skip => stmt.clone(),
+            StmtBody::Switch { control, cases, default } => {
+                let control = self.visit_expr(control);
+                let cases = cases.iter().map(|x| self.visit_switchcase(x)).collect();
+                let default = default.as_ref().map(|x| self.visit_stmt(x));
+                Stmt::switch(control, cases, default, loc)
+            }
+            StmtBody::While { cond, body } => {
+                let cond = self.visit_expr(cond);
+                let body = self.visit_stmt(body);
+                Stmt::while_loop(cond, body, loc)
+            }
+        }
+    }
+
+    pub fn visit_expr(&mut self, expr: &Expr) -> Expr {
+        let updated = match expr.value() {
+            AddressOf(e) => {
+                let e = self.visit_expr(e);
+                e.address_of()
+            }
+            Array { elems } => {
+                let elems = elems.iter().map(|x| self.visit_expr(x)).collect();
+                Expr::array_expr(expr.typ().clone(), elems)
+            }
+            ArrayOf { elem } => {
+                let elem = self.visit_expr(elem);
+                let width = elem.typ().width().unwrap();
+                elem.array_constant(width)
+            }
+            Assign { left, right } => {
+                let left = self.visit_expr(left);
+                let right = self.visit_expr(right);
+                left.assign_expr(right)
+            }
+            BinOp { op, lhs, rhs } => {
+                let lhs = self.visit_expr(lhs);
+                let rhs = self.visit_expr(rhs);
+                lhs.binop(*op, rhs)
+            }
+            BoolConstant(_) => expr.clone(),
+            ByteExtract { e, offset } => {
+                assert!(*offset == 0);
+                let e = self.visit_expr(e);
+                e.transmute_to(expr.typ().clone(), self.symbol_table)
+            }
+            CBoolConstant(_) => expr.clone(),
+            Dereference(e) => {
+                let e = self.visit_expr(e);
+                e.dereference()
+            }
+            DoubleConstant(_) => expr.clone(),
+            FloatConstant(_) => expr.clone(),
+            FunctionCall { function, arguments } => {
+                let function = self.visit_expr(function);
+                let arguments = arguments.iter().map(|x| self.visit_expr(x)).collect();
+                function.call(arguments)
+            }
+            If { c, t, e } => {
+                let c = self.visit_expr(c);
+                let t = self.visit_expr(t);
+                let e = self.visit_expr(e);
+                c.ternary(t, e)
+            }
+            Index { array, index } => {
+                let array = self.visit_expr(array);
+                let index = self.visit_expr(index);
+                array.index(index)
+            }
+            IntConstant(_) => expr.clone(),
+            Member { lhs, field } => {
+                let lhs = self.visit_expr(lhs);
+                lhs.member(field, self.symbol_table)
+            }
+            Nondet => expr.clone(),
+            PointerConstant(_) => expr.clone(),
+            SelfOp { op, e } => {
+                let e = self.visit_expr(e);
+                e.self_op(*op)
+            }
+            StatementExpression { statements } => {
+                let statements = statements.iter().map(|x| self.visit_stmt(x)).collect();
+                Expr::statement_expression(statements, expr.typ().clone())
+            }
+            StringConstant { .. } => expr.clone(),
+            Struct { values } => {
+                let fields = self.symbol_table.lookup_fields_in_type(expr.typ()).unwrap();
+                let values = values.iter().map(|x| self.visit_expr(x)).collect();
+                Expr::struct_expr_with_explicit_padding(expr.typ().clone(), fields, values)
+            }
+            ExprValue::Symbol { .. } => expr.clone(),
+            Typecast(e) => {
+                let e = self.visit_expr(e);
+                e.cast_to(expr.typ().clone())
+            }
+            Union { value, field } => {
+                todo!()
+            }
+            UnOp { op, e } => {
+                let e = self.visit_expr(e);
+                e.unop(*op)
+            }
+        }
+        .with_location(expr.location().clone())
+        .with_confidence(expr.confidence());
+        self.assert_confidence(updated)
+    }
+
+    pub fn assert_confidence(&mut self, expr: Expr) -> Expr {
+        if expr.confidence() < self.required_confidence {
+            let typ = expr.typ().clone();
+            let assert = Stmt::assert_false(
+                &format!(
+                    "Confidence {:?} is below required {:?}",
+                    expr.confidence(),
+                    self.required_confidence
+                ),
+                expr.location().clone(),
+            );
+            Expr::statement_expression(vec![assert, expr.as_stmt()], typ)
+        } else {
+            expr
+        }
+    }
+}

--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/mod.rs
@@ -3,14 +3,17 @@
 //! This module contains typesafe representations of CBMC's data structures
 
 mod builtin;
+mod confidence;
 mod expr;
 mod location;
 mod stmt;
 mod symbol;
 mod symbol_table;
 mod typ;
+mod visitor;
 
 pub use builtin::BuiltinFn;
+pub use confidence::{Confidence, ConfidenceVisitor};
 pub use expr::{
     ArithmeticOverflowResult, BinaryOperand, Expr, ExprValue, SelfOperand, UnaryOperand,
 };

--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/symbol_table.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/symbol_table.rs
@@ -14,6 +14,10 @@ pub struct SymbolTable {
 
 /// Constructors
 impl SymbolTable {
+    pub fn raw(machine_model: MachineModel) -> SymbolTable {
+        SymbolTable { machine_model, symbol_table: BTreeMap::new() }
+    }
+
     pub fn new(machine_model: MachineModel) -> SymbolTable {
         let mut symtab = SymbolTable { machine_model, symbol_table: BTreeMap::new() };
         env::machine_model_symbols(symtab.machine_model())

--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/machine_model.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/machine_model.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 /// Represents the machine specific information necessary to generate an Irep.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MachineModel {
     /// Is the architecture big endian?
     /// Minimum architectural alignment, in bytes

--- a/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use bitflags::_core::any::Any;
-use cbmc::goto_program::{Stmt, Symbol, SymbolTable};
+use cbmc::goto_program::{Confidence, ConfidenceVisitor, Stmt, Symbol, SymbolTable};
 use cbmc::{MachineModel, RoundingMode};
 use metadata::*;
 use rustc_codegen_ssa::traits::CodegenBackend;
@@ -311,7 +311,9 @@ impl CodegenBackend for GotocCodegenBackend {
             .downcast::<GotocCodegenResult>()
             .expect("in link: codegen_results is not a GotocCodegenResult");
         let symtab = result.symtab;
-        let irep_symtab = symtab.to_irep();
+        let mut confidence_visitor = ConfidenceVisitor::new(&symtab, Confidence::High);
+        let transformed_symtab = confidence_visitor.visit_symbol_table(&symtab);
+        let irep_symtab = transformed_symtab.to_irep();
         let json = irep_symtab.to_json();
         let pretty_json = json.pretty();
 


### PR DESCRIPTION
### Resolved issues:

 resolves #ISSUE-NUMBER

### Description of changes: 

This commit adds a `Confidence` enum, which represents the degree of
confidence the generator of the goto expression has that the expr
accurately represents the semantics of the underlying system being
represented in goto.  All expressions start with confidence `Default`,
which can be overriden using the `.with_confidence()` fluent builder.

This commit also adds a visitor which replaces low confidence Exprs
with an `assert(0); expr` statement expression. This ensures that
if low confidence expressions are dynamically used during a proof,
then CBMC will raise an assertion violation.

### Call-outs:

This visitor is currently hard-coded. Using a proper visitor pattern,
and possibly moving the assertion from the expression to the
containing statement is future work.

This is a draft PR: proper regression tests, and full documentation, are still needed.

### Testing:

 How is this change tested? I tried setting low confidence on an operation, and regressions failed with the expected assertion.

 Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
