### PR TITLE
Avoid strict type comparison in statement assignment

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
@@ -160,8 +160,14 @@ impl Stmt {
                 lhs.typ(),
                 rhs.typ()
             );
-            let assert_stmt =
-                Stmt::assert_false("Reached assignment statement with unequal types", loc.clone());
+            let assert_stmt = Stmt::assert_false(
+                &format!(
+                    "Reached assignment statement with unequal types {:?} {:?}",
+                    lhs.typ(),
+                    rhs.typ()
+                ),
+                loc.clone(),
+            );
             let nondet_value = lhs.typ().nondet();
             let nondet_assign_stmt = stmt!(Assign { lhs, rhs: nondet_value }, loc.clone());
             return Stmt::block(vec![assert_stmt, nondet_assign_stmt]);

--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
@@ -3,6 +3,7 @@
 use self::StmtBody::*;
 use super::{BuiltinFn, Expr, Location};
 use std::fmt::Debug;
+use tracing::debug;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 /// Datatypes
@@ -150,7 +151,21 @@ macro_rules! stmt {
 impl Stmt {
     /// `lhs = rhs;`
     pub fn assign(lhs: Expr, rhs: Expr, loc: Location) -> Self {
-        assert_eq!(lhs.typ(), rhs.typ());
+        //Temporarily work around https://github.com/model-checking/rmc/issues/95
+        //by disabling the assert and soundly assigning nondet
+        //assert_eq!(lhs.typ(), rhs.typ());
+        if lhs.typ() != rhs.typ() {
+            debug!(
+                "WARNING: assign statement with unequal types lhs {:?} rhs {:?}",
+                lhs.typ(),
+                rhs.typ()
+            );
+            let assert_stmt =
+                Stmt::assert_false("Reached assignment statement with unequal types", loc.clone());
+            let nondet_value = lhs.typ().nondet();
+            let nondet_assign_stmt = stmt!(Assign { lhs, rhs: nondet_value }, loc.clone());
+            return Stmt::block(vec![assert_stmt, nondet_assign_stmt]);
+        }
         stmt!(Assign { lhs, rhs }, loc)
     }
 


### PR DESCRIPTION
### Description of changes: 

This PR is a workaround for issue #95 that replaces an assertion in statement assignment with an `assert_false` and nondet. assignment statements.

### Testing:

All regressions pass.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
