### PR TITLE
Implemented __VERIFIER_assume hook

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
@@ -187,7 +187,7 @@ impl Stmt {
 
     /// `__CPROVER_assume(cond);`
     pub fn assume(cond: Expr, loc: Location) -> Self {
-        assert!(cond.typ().is_bool());
+        assert!(cond.typ().is_bool(), "Assume expected bool, got {:?}", cond);
         stmt!(Assume { cond }, loc)
     }
 

--- a/rust-tests/cbmc-reg/Assume/main.rs
+++ b/rust-tests/cbmc-reg/Assume/main.rs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+fn __VERIFIER_assume(cond: bool) {
+    unimplemented!()
+}
+
+fn __nondet<T>() -> T {
+    unimplemented!()
+}
+
+fn main() {
+    let i: i32 = __nondet();
+    __VERIFIER_assume(i < 10);
+    assert!(i < 20);
+}

--- a/rust-tests/cbmc-reg/Assume/main_fail.rs
+++ b/rust-tests/cbmc-reg/Assume/main_fail.rs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+fn __VERIFIER_assume(cond: bool) {
+    unimplemented!()
+}
+
+fn __nondet<T>() -> T {
+    unimplemented!()
+}
+
+fn main() {
+    let i: i32 = __nondet();
+    __VERIFIER_assume(i < 10);
+    assert!(i > 20);
+}


### PR DESCRIPTION
### Description of changes: 

RMC currently doesn't have an `assume` keyword. We need one if we want to write reasonable harnesses.

### Resolved issues:

Resolves #114

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Included regression test.

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
