### PR TITLE
Added --visualize flag to rmc and cargo-rmc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ If you encounter issues when using RMC we encourage you to
    [the cmake instructions from the CBMC repo](https://github.com/diffblue/cbmc/blob/develop/COMPILING.md#working-with-cmake).
    We recommend using `ninja` as the CBMC build system.
 
+1. Install [CBMC Viewer](https://github.com/awslabs/aws-viewer-for-cbmc/releases/latest).
+
 1. Configure RMC. 
    We recommend using the following options:
    ```

--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -22,10 +22,19 @@ def main():
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("--keep-temps", action="store_true")
     parser.add_argument("--mangler", default="v0")
+    parser.add_argument("--visualize", action="store_true")
+    parser.add_argument("--srcdir", default=".")
+    parser.add_argument("--wkdir", default=".")
     parser.add_argument("crate", help="crate to verify")
     parser.add_argument("cbmc_args", nargs=argparse.REMAINDER,
                         default=[], help="Pass through directly to CBMC")
     args = parser.parse_args()
+
+    # In the future we hope to make this configurable in the command line.
+    # For now, however, changing this from "main" breaks rmc.
+    # Issue: https://github.com/model-checking/rmc/issues/169
+    args.function = "main"
+
     if args.quiet:
         args.verbose = False
 
@@ -43,7 +52,15 @@ def main():
     if EXIT_CODE_SUCCESS != rmc.symbol_table_to_gotoc(jsons[0], cbmc_filename, args.verbose, args.keep_temps):
         return 1
 
-    return rmc.run_cbmc(cbmc_filename, args.cbmc_args, args.verbose, args.quiet)
+    if "--function" not in args.cbmc_args:
+        args.cbmc_args.extend(["--function", args.function])
+
+    if args.visualize:
+        return rmc.run_visualize(cbmc_filename, args.cbmc_args, \
+                                 args.verbose, args.quiet, args.keep_temps, \
+                                 args.function, args.srcdir, args.wkdir)
+    else:
+        return rmc.run_cbmc(cbmc_filename, args.cbmc_args, args.verbose, args.quiet)
 
 
 if __name__ == "__main__":

--- a/scripts/rmc
+++ b/scripts/rmc
@@ -24,9 +24,18 @@ def main():
     parser.add_argument("--gen-symbols", action="store_true")
     parser.add_argument("--allow-cbmc-verification-failure", action="store_true")
     parser.add_argument("--mangler", default="v0")
+    parser.add_argument("--visualize", action="store_true")
+    parser.add_argument("--srcdir", default=".")
+    parser.add_argument("--wkdir", default=".")
     parser.add_argument("cbmc_args", nargs=argparse.REMAINDER,
                         default=[], help="Pass through directly to CBMC")
     args = parser.parse_args()
+
+    # In the future we hope to make this configurable in the command line.
+    # For now, however, changing this from "main" breaks rmc.
+    # Issue: https://github.com/model-checking/rmc/issues/169
+    args.function = "main"
+    
     if args.quiet:
         args.verbose = False
 
@@ -57,10 +66,15 @@ def main():
             return 1
 
     if "--function" not in args.cbmc_args:
-        args.cbmc_args.extend(["--function", "main"])
+        args.cbmc_args.extend(["--function", args.function])
     
     args.cbmc_args.append(str(RMC_C_LIB))
-    retcode = rmc.run_cbmc(goto_filename, args.cbmc_args, args.verbose, args.quiet)
+    if args.visualize:
+        retcode = rmc.run_visualize(goto_filename, args.cbmc_args, \
+                                    args.verbose, args.quiet, args.keep_temps, \
+                                    args.function, args.srcdir, args.wkdir)
+    else:
+        retcode = rmc.run_cbmc(goto_filename, args.cbmc_args, args.verbose, args.quiet)
     if retcode == CBMC_VERIFICATION_FAILURE_EXIT_CODE and args.allow_cbmc_verification_failure:
         retcode = EXIT_CODE_SUCCESS
     return retcode


### PR DESCRIPTION
### Description of changes: 

This update allows you to add a `--visualize` flag to `rmc` and `cargo rmc` in order to generate a CBMC visualization for failure traces.

### Resolved issues:

### Call-outs:

### Testing:

* How is this change tested? Existing regression suite.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
