### PR TITLE
Added explicit Location parameter to various constructors for Expr and Stmt

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/expr.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/expr.rs
@@ -1173,14 +1173,12 @@ impl Expr {
 /// The statement constructors do typechecking, so we don't redundantly do that here.
 impl Expr {
     /// `self;`
-    pub fn as_stmt(self) -> Stmt {
-        let loc = self.location.clone();
+    pub fn as_stmt(self, loc: Location) -> Stmt {
         Stmt::code_expression(self, loc)
     }
 
     /// `self = rhs;`
-    pub fn assign(self, rhs: Expr) -> Stmt {
-        let loc = rhs.location.clone();
+    pub fn assign(self, rhs: Expr, loc: Location) -> Stmt {
         Stmt::assign(self, rhs, loc)
     }
 
@@ -1190,8 +1188,7 @@ impl Expr {
     }
 
     /// `return self;`
-    pub fn ret(self) -> Stmt {
-        let loc = self.location.clone();
+    pub fn ret(self, loc: Location) -> Stmt {
         Stmt::ret(Some(self), loc)
     }
 

--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
@@ -170,7 +170,7 @@ impl Stmt {
             );
             let nondet_value = lhs.typ().nondet();
             let nondet_assign_stmt = stmt!(Assign { lhs, rhs: nondet_value }, loc.clone());
-            return Stmt::block(vec![assert_stmt, nondet_assign_stmt]);
+            return Stmt::block(vec![assert_stmt, nondet_assign_stmt], loc);
         }
         stmt!(Assign { lhs, rhs }, loc)
     }
@@ -178,7 +178,9 @@ impl Stmt {
     /// `__CPROVER_assert(cond, msg);`
     pub fn assert(cond: Expr, msg: &str, loc: Location) -> Self {
         assert!(cond.typ().is_bool());
-        BuiltinFn::CProverAssert.call(vec![cond, Expr::string_constant(msg)], loc).as_stmt()
+        BuiltinFn::CProverAssert
+            .call(vec![cond, Expr::string_constant(msg)], loc.clone())
+            .as_stmt(loc)
     }
 
     pub fn assert_false(msg: &str, loc: Location) -> Self {
@@ -192,14 +194,12 @@ impl Stmt {
     }
 
     /// { ATOMIC_BEGIN stmt1; stmt2; ... ATOMIC_END }
-    pub fn atomic_block(stmts: Vec<Stmt>) -> Self {
-        let loc = if stmts.is_empty() { Location::none() } else { stmts[0].location().clone() };
+    pub fn atomic_block(stmts: Vec<Stmt>, loc: Location) -> Self {
         stmt!(AtomicBlock(stmts), loc)
     }
 
     /// `{ stmt1; stmt2; ... }`
-    pub fn block(stmts: Vec<Stmt>) -> Self {
-        let loc = if stmts.is_empty() { Location::none() } else { stmts[0].location().clone() };
+    pub fn block(stmts: Vec<Stmt>, loc: Location) -> Self {
         stmt!(Block(stmts), loc)
     }
 

--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/irep/to_irep.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/irep/to_irep.rs
@@ -237,7 +237,7 @@ impl ToIrep for ExprValue {
             ExprValue::SelfOp { op, e } => side_effect_irep(op.to_irep_id(), vec![e.to_irep(mm)]),
             ExprValue::StatementExpression { statements: ops } => side_effect_irep(
                 IrepId::StatementExpression,
-                vec![Stmt::block(ops.to_vec()).to_irep(mm)],
+                vec![Stmt::block(ops.to_vec(), Location::none()).to_irep(mm)],
             ),
             ExprValue::StringConstant { s } => Irep {
                 id: IrepId::StringConstant,

--- a/compiler/rustc_codegen_llvm/src/gotoc/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/metadata.rs
@@ -444,7 +444,7 @@ impl<'tcx> GotocCtx<'tcx> {
             Symbol::function(
                 &fn_name,
                 Type::code(vec![], Type::constructor()),
-                Some(Stmt::block(vec![body])), //TODO is this block needed?
+                Some(Stmt::block(vec![body], Location::none())), //TODO is this block needed?
                 Location::none(),
             )
             .with_is_file_local(true)
@@ -479,7 +479,7 @@ impl<'tcx> GotocCtx<'tcx> {
             ),
             // Assume false to block any further exploration of this path.
             Stmt::assume(Expr::bool_false(), loc.clone()),
-            t.nondet().as_stmt().with_location(loc.clone()), //TODO assume rust validity contraints
+            t.nondet().as_stmt(loc.clone()).with_location(loc.clone()), //TODO assume rust validity contraints
         ];
 
         Expr::statement_expression(body, t).with_location(loc)

--- a/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
@@ -114,7 +114,7 @@ impl<'tcx> GotocCtx<'tcx> {
 
             let loc = self.codegen_span2(&mir.span);
             let stmts = std::mem::replace(&mut self.current_fn_mut().block, vec![]);
-            let body = Stmt::block(stmts).with_location(loc);
+            let body = Stmt::block(stmts, loc);
             self.symbol_table.update_fn_declaration_with_definition(&name, body);
         }
         self.reset_current_fn();

--- a/compiler/rustc_codegen_llvm/src/gotoc/operand.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/operand.rs
@@ -273,13 +273,15 @@ impl<'tcx> GotocCtx<'tcx> {
             let var = tcx.gen_function_local_variable(2, &func_name, cgt.clone()).to_expr();
             let body = vec![
                 Stmt::decl(var.clone(), None, Location::none()),
-                var.clone().member("case", &tcx.symbol_table).assign(param.to_expr()),
-                var.clone().ret(),
+                var.clone()
+                    .member("case", &tcx.symbol_table)
+                    .assign(param.to_expr(), Location::none()),
+                var.clone().ret(Location::none()),
             ];
             Symbol::function(
                 &func_name,
                 Type::code(vec![param.to_function_parameter()], cgt),
-                Some(Stmt::block(body)),
+                Some(Stmt::block(body, Location::none())),
                 Location::none(),
             )
         });
@@ -474,10 +476,13 @@ impl<'tcx> GotocCtx<'tcx> {
         );
         let fn_name = Self::initializer_fn_name(&name);
         let temp_var = self.gen_function_local_variable(0, &fn_name, alloc_typ_ref).to_expr();
-        let body = Stmt::block(vec![
-            Stmt::decl(temp_var.clone(), Some(val), Location::none()),
-            var.assign(temp_var.transmute_to(var_typ, &self.symbol_table)),
-        ]);
+        let body = Stmt::block(
+            vec![
+                Stmt::decl(temp_var.clone(), Some(val), Location::none()),
+                var.assign(temp_var.transmute_to(var_typ, &self.symbol_table), Location::none()),
+            ],
+            Location::none(),
+        );
         self.register_initializer(&name, body);
 
         self.alloc_map.insert(alloc, name);
@@ -525,13 +530,14 @@ impl<'tcx> GotocCtx<'tcx> {
             let var = tcx.gen_function_local_variable(2, &fname, cgt.clone()).to_expr();
             let body = vec![
                 Stmt::decl(var.clone(), None, Location::none()),
-                tcx.codegen_get_niche(var.clone(), offset, target_ty).assign(param.to_expr()),
-                var.ret(),
+                tcx.codegen_get_niche(var.clone(), offset, target_ty)
+                    .assign(param.to_expr(), Location::none()),
+                var.ret(Location::none()),
             ];
             Symbol::function(
                 &fname,
                 Type::code(vec![param.to_function_parameter()], cgt),
-                Some(Stmt::block(body)),
+                Some(Stmt::block(body, Location::none())),
                 Location::none(),
             )
         });

--- a/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
@@ -184,21 +184,25 @@ impl<'tcx> GotocCtx<'tcx> {
                 Stmt::decl(idx.clone(), Some(Type::size_t().zero()), Location::none()),
             ];
 
-            let lbody = Stmt::block(vec![
-                tcx.codegen_idx_array(res.clone(), idx.clone()).assign(inp.to_expr()),
-            ]);
+            let lbody = Stmt::block(
+                vec![
+                    tcx.codegen_idx_array(res.clone(), idx.clone())
+                        .assign(inp.to_expr(), Location::none()),
+                ],
+                Location::none(),
+            );
             body.push(Stmt::for_loop(
                 Stmt::skip(Location::none()),
                 idx.clone().lt(tcx.codegen_const(sz, None)),
-                idx.postincr().as_stmt(),
+                idx.postincr().as_stmt(Location::none()),
                 lbody,
                 Location::none(),
             ));
-            body.push(res.ret());
+            body.push(res.ret(Location::none()));
             Symbol::function(
                 &func_name,
                 Type::code(vec![inp.to_function_parameter()], res_t),
-                Some(Stmt::block(body)),
+                Some(Stmt::block(body, Location::none())),
                 Location::none(),
             )
         });
@@ -820,7 +824,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     vtable_fields,
                     &ctx.symbol_table,
                 );
-                let body = var.assign(vtable);
+                let body = var.assign(vtable, Location::none());
                 Some(body)
             },
         )

--- a/compiler/rustc_codegen_llvm/src/gotoc/stubs/rust_stubber.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/stubs/rust_stubber.rs
@@ -120,10 +120,13 @@ pub trait RustStubber<'tcx> {
         let p = assign_to.unwrap();
         let fn_call = fctn.call(fargs);
         let target = target.unwrap();
-        Stmt::block(vec![
-            tcx.codegen_expr_to_place(&p, fn_call),
-            Stmt::goto(tcx.find_label(&target), Location::none()),
-        ])
+        Stmt::block(
+            vec![
+                tcx.codegen_expr_to_place(&p, fn_call),
+                Stmt::goto(tcx.find_label(&target), Location::none()),
+            ],
+            Location::none(),
+        )
     }
 
     fn find_cbmc_fn(&self, tcx: TyCtxt<'tcx>, stubbed_ty: Ty<'tcx>, name: &str) -> Option<DefId> {


### PR DESCRIPTION
### Description of changes: 

Currently: We infer location information from children of a node in a few constructors, rather than passing it as an explicit argument.

After update: These constructors require explicit passing of location. All calls to these constructors have been updated, and anywhere where location was not readily available, we pass `Location::none()`.

See #136 for instances of missing location information.

### Resolved issues:

### Call-outs:

### Testing:

* How is this change tested? Existing regression suite.

* Is this a refactor change? Yes.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
