### PR TITLE
Use canonical filenames in source locations

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/utils.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/utils.rs
@@ -43,12 +43,12 @@ impl<'tcx> GotocCtx<'tcx> {
         let lo = smap.lookup_char_pos(sp.lo());
         let line = lo.line;
         let col = 1 + lo.col_display;
-        Location::new(
-            lo.file.name.prefer_remapped().to_string_lossy().to_string(),
-            self.fname_option(),
-            line,
-            Some(col),
-        )
+        let filename0 = lo.file.name.prefer_remapped().to_string_lossy().to_string();
+        let filename1 = match std::fs::canonicalize(filename0.clone()) {
+            Ok(pathbuf) => pathbuf.to_str().unwrap().to_string(),
+            Err(_) => filename0,
+        };
+        Location::new(filename1, self.fname_option(), line, Some(col))
     }
 
     /// Dereference a boxed type `std::boxed::Box<T>` to get a `*T`.


### PR DESCRIPTION
### Description of changes: 

This pull request ensures that all source locations contain absolute (physical) path names for file names.

This pull request partially resolves issue #131.  In particular, it addresses the issues "Source location use physical path names" and "Source locations are missing the working directory".  Because all source locations use absolute path names, the missing working directory is no longer an issue.  Because all source locations use physical path names, just like the path names supplied by the compiler, we can give a single (physical) source root to cbmc-viewer to generate an accurate report.

This pull request works by calling std::fs::canonicalize every time a source location is created.  This may be a LOT of references to the filesystem and may at some point be considered slow.  If this turns out to be slow, we can implement `codegen_span2` with memoization.

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
