### PR TITLE
Correctly handle the abort intrinsic

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/hooks.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/hooks.rs
@@ -221,15 +221,19 @@ impl<'tcx> GotocHook<'tcx> for Intrinsic {
         span: Option<Span>,
     ) -> Stmt {
         let loc = tcx.codegen_span_option2(span);
-        let p = assign_to.unwrap();
-        let target = target.unwrap();
-        Stmt::block(
-            vec![
-                tcx.codegen_intrinsic(instance, fargs, &p, span),
-                Stmt::goto(tcx.find_label(&target), loc.clone()),
-            ],
-            loc,
-        )
+        if (tcx.symbol_name(instance) == "abort") {
+            Stmt::assert_false("abort intrinsic reached", loc)
+        } else {
+            let p = assign_to.unwrap();
+            let target = target.unwrap();
+            Stmt::block(
+                vec![
+                    tcx.codegen_intrinsic(instance, fargs, &p, span),
+                    Stmt::goto(tcx.find_label(&target), loc.clone()),
+                ],
+                loc,
+            )
+        }
     }
 }
 

--- a/rust-tests/cbmc-reg/Intrinsics/abort_fail.rs
+++ b/rust-tests/cbmc-reg/Intrinsics/abort_fail.rs
@@ -1,0 +1,7 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+#![feature(core_intrinsics)]
+use std::intrinsics;
+fn main() {
+    intrinsics::abort();
+}


### PR DESCRIPTION
### Description of changes: 

Currently, we handle intrinsics using a hook.  This hook unwraps the target, then passes the result to `codegen_intrinsic`.
But `abort` doesn't have a target, so this fails. Short circuit this case so it works.

### Resolved issues:

Resolves #150 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? New regression test

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
