### PR TITLE
Update CBMC version check to 5.30.0 (#164)

### DIFF
--- a/scripts/check-cbmc-version.py
+++ b/scripts/check-cbmc-version.py
@@ -47,7 +47,8 @@ def main():
 
     if desired_version > current_version:
         version_string = '.'.join([str(num) for num in current_version])
-        print(f'WARNING: CBMC version is {version_string}')
+        desired_version_string = '.'.join([str(num) for num in desired_version])
+        print(f'WARNING: CBMC version is {version_string}, expected at least {desired_version_string}')
         sys.exit(EXIT_CODE_MISMATCH)
 
 if __name__ == "__main__":

--- a/scripts/rmc-regression.sh
+++ b/scripts/rmc-regression.sh
@@ -15,7 +15,7 @@ export PATH=$SCRIPT_DIR:$PATH
 EXTRA_X_PY_BUILD_ARGS="${EXTRA_X_PY_BUILD_ARGS:-}"
 
 # Required dependencies
-check-cbmc-version.py --major 5 --minor 18
+check-cbmc-version.py --major 5 --minor 30
 
 # Formatting check
 ./x.py fmt --check


### PR DESCRIPTION
### Description of changes: 

If the user has an older version of CBMC installed, several regression tests fail. This commit updates the check and prints the expected version in the warning. 

### Resolved issues:

Resolves #164 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?
Regression test script warns on old version of CBMC, and passes on new version.
```
$ cbmc --version
5.28.0 (cbmc-5.28.0)
$ ./scripts/rmc-regression.sh 
WARNING: CBMC version is 5.28.0, expected at least 5.30.0
```

* Is this a refactor change?
No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
