### PR TITLE
Added check for cbmc-viewer version.

### DIFF
--- a/scripts/check-cbmc-viewer-version.py
+++ b/scripts/check-cbmc-viewer-version.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+import argparse
+import re
+import sys
+import subprocess
+
+
+EXIT_CODE_SUCCESS = 0
+EXIT_CODE_MISMATCH = 1
+EXIT_CODE_FAIL = 2
+
+
+def cbmc_viewer_version():
+    cmd = ["cbmc-viewer", "--version"]
+    try:
+        version = subprocess.run(cmd,
+                                 capture_output=True, text=True, check=True)
+    except (OSError, subprocess.SubprocessError) as error:
+        print(error)
+        print(f"Can't run command '{' '.join(cmd)}'")
+        sys.exit(EXIT_CODE_FAIL)
+
+    match = re.match("CBMC viewer ([0-9]+).([0-9]+)", version.stdout)
+    if not match:
+        print(f"Can't parse CBMC-viewer version string: '{version.stdout.strip()}'")
+        sys.exit(EXIT_CODE_FAIL)
+
+    return match.groups()
+
+def complete_version(*version):
+    numbers = [int(num) if num else 0 for num in version]
+    return (numbers + [0, 0])[:2]
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Check CBMC-viewer version matches major/minor')
+    parser.add_argument('--major', required=True)
+    parser.add_argument('--minor', required=True)
+    args = parser.parse_args()
+
+    current_version = complete_version(*cbmc_viewer_version())
+    desired_version = complete_version(args.major, args.minor)
+
+    if desired_version > current_version:
+        version_string = '.'.join([str(num) for num in current_version])
+        desired_version_string = '.'.join([str(num) for num in desired_version])
+        print(f'ERROR: CBMC-viewer version is {version_string}, expected at least {desired_version_string}')
+        sys.exit(EXIT_CODE_MISMATCH)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rmc-regression.sh
+++ b/scripts/rmc-regression.sh
@@ -16,6 +16,7 @@ EXTRA_X_PY_BUILD_ARGS="${EXTRA_X_PY_BUILD_ARGS:-}"
 
 # Required dependencies
 check-cbmc-version.py --major 5 --minor 30
+check-cbmc-viewer-version.py --major 2 --minor 5
 
 # Formatting check
 ./x.py fmt --check


### PR DESCRIPTION
### Description of changes: 

When running `rmc` with the `--visualize` flag, it now checks that you have a high enough version of `cbmc-viewer` installed. This is necessary, as version 1.x does not generate the trace report like 2.x does.

### Resolved issues:

### Call-outs:

### Testing:

* How is this change tested? Existing regression suite.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
