### PR TITLE
Add --gen-c flag to cargo-rmc.

### DIFF
--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -21,6 +21,7 @@ def main():
     parser.add_argument("--quiet", "-q", action="store_true")
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("--keep-temps", action="store_true")
+    parser.add_argument("--gen-c", action="store_true")
     parser.add_argument("--mangler", default="v0")
     parser.add_argument("--visualize", action="store_true")
     parser.add_argument("--srcdir", default=".")
@@ -49,8 +50,13 @@ def main():
         print("ERROR: unexpected number of json outputs")
         return 1
     cbmc_filename = "cbmc.out"
+    c_filename = "cbmc.c"
     if EXIT_CODE_SUCCESS != rmc.symbol_table_to_gotoc(jsons[0], cbmc_filename, args.verbose, args.keep_temps):
         return 1
+
+    if args.gen_c:
+        if EXIT_CODE_SUCCESS != rmc.goto_to_c(cbmc_filename, c_filename, args.verbose):
+            return 1
 
     if "--function" not in args.cbmc_args:
         args.cbmc_args.extend(["--function", args.function])


### PR DESCRIPTION
### Description of changes: 

This PR adds support for generating C-like file from Rust source code in a cargo project. The generated file is useful for debugging. This feature is already available in `rmc` and this change just adds support for it to `cargo-rmc`.

### Resolved issues:

None.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?
  * It's only tested manually
* Is this a refactor change?
  * No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
