### PR TITLE
Refactor: Cleanly seperate `CurrentFnCtx` from `GotocCtx`.

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/current_fn.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/current_fn.rs
@@ -1,0 +1,118 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::gotoc::GotocCtx;
+use crate::gotoc::Stmt;
+use rustc_hir::def_id::DefId;
+use rustc_middle::mir::BasicBlock;
+use rustc_middle::mir::Body;
+use rustc_middle::ty::Instance;
+use rustc_middle::ty::PolyFnSig;
+use rustc_middle::ty::TyCtxt;
+
+/// This structure represents useful data about the function we are currently compiling.
+pub struct CurrentFnCtx<'tcx> {
+    /// The GOTO block we are compiling into
+    pub block: Vec<Stmt>,
+    /// the current MIR basic block
+    current_bb: Option<BasicBlock>,
+    /// the codegen instance for the current function
+    instance: Instance<'tcx>,
+    /// the goto labels for all blocks
+    labels: Vec<String>,
+    /// the mir for the current instance
+    mir: &'tcx Body<'tcx>,
+    /// The symbol name of the current function
+    name: String,
+    /// The signature of the current function
+    sig: PolyFnSig<'tcx>,
+    /// A counter to enable creating temporary variables
+    temp_var_counter: u64,
+}
+
+/// Constructor
+impl CurrentFnCtx<'tcx> {
+    pub fn new(instance: Instance<'tcx>, gcx: &GotocCtx<'tcx>) -> Self {
+        Self {
+            block: vec![],
+            current_bb: None,
+            instance,
+            labels: vec![],
+            mir: gcx.tcx.instance_mir(instance.def),
+            name: gcx.symbol_name(instance),
+            sig: gcx.fn_sig_of_instance(instance),
+            temp_var_counter: 0,
+        }
+    }
+}
+
+/// Setters
+impl CurrentFnCtx<'tcx> {
+    /// Returns the current block, replacing it with an empty vector.
+    pub fn extract_block(&mut self) -> Vec<Stmt> {
+        std::mem::replace(&mut self.block, vec![])
+    }
+
+    pub fn get_and_incr_counter(&mut self) -> u64 {
+        let rval = self.temp_var_counter;
+        self.temp_var_counter += 1;
+        rval
+    }
+
+    pub fn push_onto_block(&mut self, s: Stmt) {
+        self.block.push(s)
+    }
+
+    pub fn reset_current_bb(&mut self) {
+        self.current_bb = None;
+    }
+
+    pub fn set_current_bb(&mut self, bb: BasicBlock) {
+        self.current_bb = Some(bb);
+    }
+
+    pub fn set_labels(&mut self, labels: Vec<String>) {
+        assert!(self.labels.is_empty());
+        self.labels = labels;
+    }
+}
+
+/// Getters
+impl CurrentFnCtx<'tcx> {
+    /// The basic block we are currently compiling
+    pub fn current_bb(&self) -> BasicBlock {
+        self.current_bb.unwrap()
+    }
+
+    /// The function we are currently compiling
+    pub fn instance(&self) -> Instance<'tcx> {
+        self.instance
+    }
+
+    /// The labels in the function we are currently compiling
+    pub fn labels(&self) -> &Vec<String> {
+        &self.labels
+    }
+
+    /// The MIR for the function we are currently compiling
+    pub fn mir(&self) -> &'tcx Body<'tcx> {
+        self.mir
+    }
+
+    /// The name of the function we are currently compiling
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    /// The signature of the function we are currently compiling
+    pub fn sig(&self) -> PolyFnSig<'tcx> {
+        self.sig
+    }
+}
+
+/// Utility functions
+impl CurrentFnCtx<'_> {
+    pub fn find_label(&self, bb: &BasicBlock) -> String {
+        self.labels[bb.index()].clone()
+    }
+}

--- a/compiler/rustc_codegen_llvm/src/gotoc/current_fn.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/current_fn.rs
@@ -13,14 +13,14 @@ use rustc_middle::ty::TyCtxt;
 /// This structure represents useful data about the function we are currently compiling.
 pub struct CurrentFnCtx<'tcx> {
     /// The GOTO block we are compiling into
-    pub block: Vec<Stmt>,
-    /// the current MIR basic block
+    block: Vec<Stmt>,
+    /// The current MIR basic block
     current_bb: Option<BasicBlock>,
-    /// the codegen instance for the current function
+    /// The codegen instance for the current function
     instance: Instance<'tcx>,
-    /// the goto labels for all blocks
+    /// The goto labels for all blocks
     labels: Vec<String>,
-    /// the mir for the current instance
+    /// The mir for the current instance
     mir: &'tcx Body<'tcx>,
     /// The symbol name of the current function
     name: String,

--- a/compiler/rustc_codegen_llvm/src/gotoc/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/metadata.rs
@@ -6,6 +6,7 @@ use super::cbmc::goto_program::{
     DatatypeComponent, Expr, Location, Stmt, Symbol, SymbolTable, Type,
 };
 use super::cbmc::utils::aggr_name;
+use crate::gotoc::current_fn::CurrentFnCtx;
 use crate::gotoc::hooks::{type_and_fn_hooks, GotocHooks, GotocTypeHooks};
 use rustc_data_structures::owning_ref::OwningRef;
 use rustc_data_structures::rustc_erase_owner;
@@ -14,7 +15,7 @@ use rustc_data_structures::sync::MetadataRef;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_middle::middle::cstore::MetadataLoader;
 use rustc_middle::mir::interpret::Allocation;
-use rustc_middle::mir::{BasicBlock, Body, HasLocalDecls, Local, Operand, Place, Rvalue};
+use rustc_middle::mir::{HasLocalDecls, Local, Operand, Place, Rvalue};
 use rustc_middle::ty::layout::{HasParamEnv, HasTyCtxt, TyAndLayout};
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{self, Instance, Ty, TyCtxt, TypeFoldable};
@@ -31,64 +32,6 @@ pub struct GotocCodegenResult {
 }
 
 pub struct GotocMetadataLoader();
-
-pub struct CurrentFnCtx<'tcx> {
-    // following fields are updated per function
-    /// the codegen instance for the current function
-    instance: Instance<'tcx>,
-    /// the def id for the current instance
-    _def_id: DefId,
-    /// the mir for the current instance
-    mir: &'tcx Body<'tcx>,
-    /// the goto labels for all blocks
-    labels: Vec<String>,
-    /// the block of the current function body
-    pub block: Vec<Stmt>,
-    /// the current basic block
-    pub current_bb: Option<BasicBlock>,
-    /// A counter to enable creating temporary variables
-    temp_var_counter: u64,
-}
-
-/// Constructor
-impl CurrentFnCtx<'tcx> {
-    pub fn new(instance: Instance<'tcx>, tcx: TyCtxt<'tcx>) -> Self {
-        Self {
-            instance,
-            mir: tcx.instance_mir(instance.def),
-            _def_id: instance.def_id(),
-            labels: vec![],
-            block: vec![],
-            current_bb: None,
-            temp_var_counter: 0,
-        }
-    }
-}
-
-/// Setters
-impl CurrentFnCtx<'tcx> {
-    pub fn get_and_incr_counter(&mut self) -> u64 {
-        let rval = self.temp_var_counter;
-        self.temp_var_counter += 1;
-        rval
-    }
-
-    pub fn set_current_bb(&mut self, bb: BasicBlock) {
-        self.current_bb = Some(bb);
-    }
-
-    pub fn set_labels(&mut self, labels: Vec<String>) {
-        assert!(self.labels.is_empty());
-        self.labels = labels;
-    }
-}
-
-/// Getters
-impl CurrentFnCtx<'tcx> {
-    pub fn labels(&self) -> &Vec<String> {
-        &self.labels
-    }
-}
 
 pub struct GotocCtx<'tcx> {
     /// the typing context
@@ -118,24 +61,8 @@ impl<'tcx> GotocCtx<'tcx> {
         }
     }
 
-    pub fn instance(&self) -> Instance<'tcx> {
-        self.current_fn().instance
-    }
-
-    pub fn mir(&self) -> &'tcx Body<'tcx> {
-        self.current_fn().mir
-    }
-
-    pub fn current_bb(&self) -> BasicBlock {
-        self.current_fn().current_bb.unwrap()
-    }
-
-    pub fn find_label(&self, bb: &BasicBlock) -> String {
-        self.current_fn().labels[bb.index()].clone()
-    }
-
     pub fn set_current_fn(&mut self, instance: Instance<'tcx>) {
-        self.current_fn = Some(CurrentFnCtx::new(instance, self.tcx));
+        self.current_fn = Some(CurrentFnCtx::new(instance, self));
     }
 
     pub fn current_fn(&self) -> &CurrentFnCtx<'tcx> {
@@ -165,11 +92,6 @@ impl<'tcx> GotocCtx<'tcx> {
         format!("{}::global::{}::", self.crate_name(), c)
     }
 
-    /// the name of the current function
-    pub fn fname(&self) -> String {
-        self.symbol_name(self.instance())
-    }
-
     /// The name of the current function, if there is one.
     /// None, if there is no current function (i.e. we are compiling global state).
     ///
@@ -179,7 +101,7 @@ impl<'tcx> GotocCtx<'tcx> {
     pub fn fname_option(&self) -> Option<String> {
         // The function name is contained in the context member named instance,
         // and instance is defined only for function contexts.
-        self.current_fn.as_ref().map(|x| self.symbol_name(x.instance))
+        self.current_fn.as_ref().map(|x| self.symbol_name(x.instance()))
     }
 
     /// For the vtable field name, we need exactly the dyn trait name and the function
@@ -316,8 +238,8 @@ impl<'tcx> GotocCtx<'tcx> {
         T: TypeFoldable<'tcx>,
     {
         // Instance is Some(..) only when current codegen unit is a function.
-        if self.current_fn.is_some() {
-            self.instance().subst_mir_and_normalize_erasing_regions(
+        if let Some(current_fn) = &self.current_fn {
+            current_fn.instance().subst_mir_and_normalize_erasing_regions(
                 self.tcx,
                 ty::ParamEnv::reveal_all(),
                 value,
@@ -330,19 +252,19 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     pub fn local_ty(&self, l: Local) -> Ty<'tcx> {
-        self.monomorphize(self.mir().local_decls()[l].ty)
+        self.monomorphize(self.current_fn().mir().local_decls()[l].ty)
     }
 
     pub fn rvalue_ty(&self, rv: &Rvalue<'tcx>) -> Ty<'tcx> {
-        self.monomorphize(rv.ty(self.mir().local_decls(), self.tcx))
+        self.monomorphize(rv.ty(self.current_fn().mir().local_decls(), self.tcx))
     }
 
     pub fn operand_ty(&self, o: &Operand<'tcx>) -> Ty<'tcx> {
-        self.monomorphize(o.ty(self.mir().local_decls(), self.tcx))
+        self.monomorphize(o.ty(self.current_fn().mir().local_decls(), self.tcx))
     }
 
     pub fn place_ty(&self, p: &Place<'tcx>) -> Ty<'tcx> {
-        self.monomorphize(p.ty(self.mir().local_decls(), self.tcx).ty)
+        self.monomorphize(p.ty(self.current_fn().mir().local_decls(), self.tcx).ty)
     }
 
     pub fn closure_params(&self, substs: ty::subst::SubstsRef<'tcx>) -> Vec<Ty<'tcx>> {
@@ -400,10 +322,6 @@ impl<'tcx> GotocCtx<'tcx> {
         })
     }
 
-    pub fn fn_sig(&self) -> ty::PolyFnSig<'tcx> {
-        self.fn_sig_of_instance(self.instance())
-    }
-
     /// Given a counter `c` a function name `fname, and a prefix `prefix`, generates a new function local variable
     /// It is an error to reuse an existing `c`, `fname` `prefix` tuple.
     fn gen_stack_variable(
@@ -429,7 +347,7 @@ impl<'tcx> GotocCtx<'tcx> {
     /// Generate a new function local variable that can be used as a temporary in RMC expressions.
     pub fn gen_temp_variable(&mut self, t: Type, loc: Location) -> Symbol {
         let c = self.current_fn_mut().get_and_incr_counter();
-        self.gen_stack_variable(c, &self.fname(), "temp", t, loc)
+        self.gen_stack_variable(c, &self.current_fn().name(), "temp", t, loc)
     }
 
     pub fn find_function(&mut self, fname: &str) -> Option<Expr> {

--- a/compiler/rustc_codegen_llvm/src/gotoc/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/metadata.rs
@@ -92,18 +92,6 @@ impl<'tcx> GotocCtx<'tcx> {
         format!("{}::global::{}::", self.crate_name(), c)
     }
 
-    /// The name of the current function, if there is one.
-    /// None, if there is no current function (i.e. we are compiling global state).
-    ///
-    /// This method returns the function name for contexts describing functions
-    /// and the empty string for contexts describing static variables. It
-    /// currently returns the managled name. It should return the pretty name.
-    pub fn fname_option(&self) -> Option<String> {
-        // The function name is contained in the context member named instance,
-        // and instance is defined only for function contexts.
-        self.current_fn.as_ref().map(|x| self.symbol_name(x.instance()))
-    }
-
     /// For the vtable field name, we need exactly the dyn trait name and the function
     /// name. The table itself already is scoped by the object type.
     ///     Example: ::Shape::vol

--- a/compiler/rustc_codegen_llvm/src/gotoc/stubs/hash_map_stub.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/stubs/hash_map_stub.rs
@@ -80,7 +80,7 @@ impl<'tcx> GotocHook<'tcx> for HashMapStub<'tcx> {
                 self.translate_to_stub(tcx, instance, fargs, assign_to, target, "get")
             }
             _ if self.is_target_destructor(instance) => {
-                Stmt::goto(tcx.find_label(&target.unwrap()), Location::none())
+                Stmt::goto(tcx.current_fn().find_label(&target.unwrap()), Location::none())
             }
             _ => unreachable!(),
         }

--- a/compiler/rustc_codegen_llvm/src/gotoc/stubs/rust_stubber.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/stubs/rust_stubber.rs
@@ -123,7 +123,7 @@ pub trait RustStubber<'tcx> {
         Stmt::block(
             vec![
                 tcx.codegen_expr_to_place(&p, fn_call),
-                Stmt::goto(tcx.find_label(&target), Location::none()),
+                Stmt::goto(tcx.current_fn().find_label(&target), Location::none()),
             ],
             Location::none(),
         )

--- a/compiler/rustc_codegen_llvm/src/gotoc/stubs/vec_stub.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/stubs/vec_stub.rs
@@ -84,7 +84,7 @@ impl<'tcx> GotocHook<'tcx> for VecStub<'tcx> {
                 self.translate_to_stub(tcx, instance, fargs, assign_to, target, "new")
             }
             _ if self.is_target_destructor(instance) => {
-                Stmt::goto(tcx.find_label(&target.unwrap()), Location::none())
+                Stmt::goto(tcx.current_fn().find_label(&target.unwrap()), Location::none())
             }
             _ => unreachable!(),
         }

--- a/compiler/rustc_codegen_llvm/src/gotoc/typ.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/typ.rs
@@ -928,8 +928,8 @@ impl<'tcx> GotocCtx<'tcx> {
 
     /// the function type of the current instance
     pub fn fn_typ(&mut self) -> Type {
-        let mir = self.mir();
-        let sig = self.fn_sig();
+        let mir = self.current_fn().mir();
+        let sig = self.current_fn().sig();
         let sig = self.tcx.normalize_erasing_late_bound_regions(ty::ParamEnv::reveal_all(), sig);
         // we don't call [codegen_function_sig] because we want to get a bit more metainformation.
         let params = sig

--- a/compiler/rustc_codegen_llvm/src/gotoc/utils.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/utils.rs
@@ -18,7 +18,7 @@ pub fn dynamic_fat_ptr(typ: Type, data: Expr, vtable: Expr, symbol_table: &Symbo
 
 impl<'tcx> GotocCtx<'tcx> {
     pub fn codegen_var_name(&self, l: &Local) -> String {
-        let fname = self.fname();
+        let fname = self.current_fn().name();
         match self.find_debug_info(l) {
             Some(info) => format!("{}::1::var{:?}::{}", fname, l, info.name),
             None => format!("{}::1::var{:?}", fname, l),
@@ -26,7 +26,7 @@ impl<'tcx> GotocCtx<'tcx> {
     }
 
     pub fn find_debug_info(&self, l: &Local) -> Option<&VarDebugInfo<'tcx>> {
-        self.mir().var_debug_info.iter().find(|info| match info.value {
+        self.current_fn().mir().var_debug_info.iter().find(|info| match info.value {
             VarDebugInfoContents::Place(p) => p.local == *l && p.projection.len() == 0,
             VarDebugInfoContents::Const(_) => false,
         })

--- a/compiler/rustc_codegen_llvm/src/gotoc/utils.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/utils.rs
@@ -48,7 +48,7 @@ impl<'tcx> GotocCtx<'tcx> {
             Ok(pathbuf) => pathbuf.to_str().unwrap().to_string(),
             Err(_) => filename0,
         };
-        Location::new(filename1, self.fname_option(), line, Some(col))
+        Location::new(filename1, self.current_fn.as_ref().map(|x| x.name()), line, Some(col))
     }
 
     /// Dereference a boxed type `std::boxed::Box<T>` to get a `*T`.


### PR DESCRIPTION
### Description of changes: 

These are confusingly intermingled - this change makes them less so.
* Move `CurrentFnCtx` into its own file
* Replace `GotocCtx` forwarding functions with a direct call to the
  `CurrentFnCtx` functions
* Make all `CurrentFnCtx` fields private, with getters and setters.

### Resolved issues:

Resolves #196 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Standard regression suite - this is a pure refactor change.

* Is this a refactor change? Yes.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
