### PR TITLE
Separate RMC sanity check function

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
@@ -187,15 +187,12 @@ impl Stmt {
         Stmt::assert(Expr::bool_false(), msg, loc)
     }
 
-    /// RMC-specific function to sanity check expected components of in code
-    /// generation. If users see these assertions fail, something in our
+    /// A __CPROVER_assert to sanity check expected components of code
+    /// generation. If users see these assertions fail, something in the
     /// translation to Gotoc has gone wrong, and we want them to file an issue.
-    pub fn assert_sanity_check(expect_true: Expr, message: &str, loc: Location) -> Stmt {
-        let url = "https://github.com/model-checking/rmc/issues/new?template=bug_report.md";
-        let assert_msg = format!(
-            "RMC code generation sanity check: {}. Please report failures:\n{}",
-            message, url
-        );
+    pub fn assert_sanity_check(expect_true: Expr, message: &str, url: &str, loc: Location) -> Stmt {
+        let assert_msg =
+            format!("Code generation sanity check: {}. Please report failures:\n{}", message, url);
 
         Stmt::block(
             vec![

--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
@@ -187,6 +187,28 @@ impl Stmt {
         Stmt::assert(Expr::bool_false(), msg, loc)
     }
 
+    /// RMC-specific function to sanity check expected components of in code
+    /// generation. If users see these assertions fail, something in our
+    /// translation to Gotoc has gone wrong, and we want them to file an issue.
+    pub fn assert_sanity_check(expect_true: Expr, message: &str, loc: Location) -> Stmt {
+        let url = "https://github.com/model-checking/rmc/issues/new?template=bug_report.md";
+        let assert_msg = format!(
+            "RMC code generation sanity check: {}. Please report failures:\n{}",
+            message, url
+        );
+
+        Stmt::block(
+            vec![
+                // Assert our expected true expression.
+                Stmt::assert(expect_true.clone(), &assert_msg, loc.clone()),
+                // If expect_true is false, assume false to block any further
+                // exploration of this path.
+                Stmt::assume(expect_true, loc.clone()),
+            ],
+            loc,
+        )
+    }
+
     /// `__CPROVER_assume(cond);`
     pub fn assume(cond: Expr, loc: Location) -> Self {
         assert!(cond.typ().is_bool(), "Assume expected bool, got {:?}", cond);

--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/utils.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/utils.rs
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Useful utilities for CBMC
 
+/// RMC bug report URL, for asserts/errors
+pub const BUG_REPORT_URL: &str =
+    "https://github.com/model-checking/rmc/issues/new?template=bug_report.md";
+
 /// The aggregate name used in CBMC for aggregates of type `n`.
 pub fn aggr_name(n: &str) -> String {
     format!("tag-{}", n)

--- a/compiler/rustc_codegen_llvm/src/gotoc/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/metadata.rs
@@ -394,37 +394,6 @@ impl<'tcx> GotocCtx<'tcx> {
 
         Expr::statement_expression(body, t).with_location(loc)
     }
-
-    /// RMC-specific function to sanity check expected components of in code
-    /// generation. If users see these assertions fail, something in our
-    /// translation to Gotoc has gone wrong, and we want them to file an issue.
-    pub fn codegen_sanity_check(
-        &mut self,
-        expect_true: Expr,
-        message: &str,
-        loc: Location,
-    ) -> Stmt {
-        let url = "https://github.com/model-checking/rmc/issues/new?template=bug_report.md";
-        let assert_msg = format!(
-            "RMC code generation sanity check: {}. Please report failures:\n{}",
-            message, url
-        );
-
-        Stmt::block(
-            vec![
-                // Assert our expected true expression.
-                Stmt::assert(expect_true.clone(), &assert_msg, loc.clone()),
-                // If it fails, assume false to block any further exploration of this path.
-                Stmt::if_then_else(
-                    expect_true.not(),
-                    Stmt::assume(Expr::bool_false(), loc.clone()),
-                    None,
-                    loc.clone(),
-                ),
-            ],
-            loc,
-        )
-    }
 }
 
 impl<'tcx> LayoutOf for GotocCtx<'tcx> {

--- a/compiler/rustc_codegen_llvm/src/gotoc/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/metadata.rs
@@ -394,6 +394,37 @@ impl<'tcx> GotocCtx<'tcx> {
 
         Expr::statement_expression(body, t).with_location(loc)
     }
+
+    /// RMC-specific function to sanity check expected components of in code
+    /// generation. If users see these assertions fail, something in our
+    /// translation to Gotoc has gone wrong, and we want them to file an issue.
+    pub fn codegen_sanity_check(
+        &mut self,
+        expect_true: Expr,
+        message: &str,
+        loc: Location,
+    ) -> Stmt {
+        let url = "https://github.com/model-checking/rmc/issues/new?template=bug_report.md";
+        let assert_msg = format!(
+            "RMC code generation sanity check: {}. Please report failures:\n{}",
+            message, url
+        );
+
+        Stmt::block(
+            vec![
+                // Assert our expected true expression.
+                Stmt::assert(expect_true.clone(), &assert_msg, loc.clone()),
+                // If it fails, assume false to block any further exploration of this path.
+                Stmt::if_then_else(
+                    expect_true.not(),
+                    Stmt::assume(Expr::bool_false(), loc.clone()),
+                    None,
+                    loc.clone(),
+                ),
+            ],
+            loc,
+        )
+    }
 }
 
 impl<'tcx> LayoutOf for GotocCtx<'tcx> {

--- a/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
@@ -789,7 +789,7 @@ impl<'tcx> GotocCtx<'tcx> {
         let decl = Stmt::decl(temp_var.clone(), None, Location::none());
         let check = Expr::eq(Expr::object_size(temp_var.address_of()), vt_size.clone());
         let assert_msg = format!("Correct CBMC vtable size for {:?}", operand_type.kind());
-        let size_assert = self.codegen_sanity_check(check, &assert_msg, Location::none());
+        let size_assert = Stmt::assert_sanity_check(check, &assert_msg, Location::none());
         Stmt::block(vec![decl, size_assert], Location::none())
     }
 

--- a/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
@@ -788,10 +788,8 @@ impl<'tcx> GotocCtx<'tcx> {
         let temp_var = self.gen_temp_variable(ty, Location::none()).to_expr();
         let decl = Stmt::decl(temp_var.clone(), None, Location::none());
         let check = Expr::eq(Expr::object_size(temp_var.address_of()), vt_size.clone());
-
-        // TODO: Add an rmc_sanity_check function https://github.com/model-checking/rmc/issues/200
         let assert_msg = format!("Correct CBMC vtable size for {:?}", operand_type.kind());
-        let size_assert = Stmt::assert(check, &assert_msg, Location::none());
+        let size_assert = self.codegen_sanity_check(check, &assert_msg, Location::none());
         Stmt::block(vec![decl, size_assert], Location::none())
     }
 

--- a/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use super::cbmc::goto_program::{BuiltinFn, Expr, Location, Stmt, Symbol, Type};
-use super::cbmc::utils::aggr_name;
+use super::cbmc::utils::{aggr_name, BUG_REPORT_URL};
 use super::cbmc::MachineModel;
 use super::metadata::*;
 use super::typ::{is_pointer, pointee_type};
@@ -789,7 +789,8 @@ impl<'tcx> GotocCtx<'tcx> {
         let decl = Stmt::decl(temp_var.clone(), None, Location::none());
         let check = Expr::eq(Expr::object_size(temp_var.address_of()), vt_size.clone());
         let assert_msg = format!("Correct CBMC vtable size for {:?}", operand_type.kind());
-        let size_assert = Stmt::assert_sanity_check(check, &assert_msg, Location::none());
+        let size_assert =
+            Stmt::assert_sanity_check(check, &assert_msg, BUG_REPORT_URL, Location::none());
         Stmt::block(vec![decl, size_assert], Location::none())
     }
 


### PR DESCRIPTION
### Description of changes: 

Add a clearly-named function for CBMC-time assertions that indicate codegen failures that can only be detected then. Similar to `codegen_unimplemented`, refer users to file an issue when they see these assertions fail.

### Resolved issues:

Resolves #200

### Call-outs:

Right now, the vtable size check seems to be the only place we use this, but @danielsn and I agreed we might want to add more in the future.

### Testing:

* How is this change tested?

Existing tests.

* Is this a refactor change?

A very small one, yes.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
