### PR TITLE
Initial changes required to codegen stdlib

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/current_fn.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/current_fn.rs
@@ -24,6 +24,8 @@ pub struct CurrentFnCtx<'tcx> {
     mir: &'tcx Body<'tcx>,
     /// The symbol name of the current function
     name: String,
+    /// A human readable pretty name for the current function
+    readable_name: String,
     /// The signature of the current function
     sig: PolyFnSig<'tcx>,
     /// A counter to enable creating temporary variables
@@ -40,6 +42,7 @@ impl CurrentFnCtx<'tcx> {
             labels: vec![],
             mir: gcx.tcx.instance_mir(instance.def),
             name: gcx.symbol_name(instance),
+            readable_name: gcx.readable_instance_name(instance),
             sig: gcx.fn_sig_of_instance(instance),
             temp_var_counter: 0,
         }
@@ -102,6 +105,11 @@ impl CurrentFnCtx<'tcx> {
     /// The name of the function we are currently compiling
     pub fn name(&self) -> String {
         self.name.clone()
+    }
+
+    /// The pretty name of the function we are currently compiling
+    pub fn readable_name(&self) -> String {
+        self.readable_name.clone()
     }
 
     /// The signature of the function we are currently compiling

--- a/compiler/rustc_codegen_llvm/src/gotoc/current_fn.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/current_fn.rs
@@ -3,12 +3,10 @@
 
 use crate::gotoc::GotocCtx;
 use crate::gotoc::Stmt;
-use rustc_hir::def_id::DefId;
 use rustc_middle::mir::BasicBlock;
 use rustc_middle::mir::Body;
 use rustc_middle::ty::Instance;
 use rustc_middle::ty::PolyFnSig;
-use rustc_middle::ty::TyCtxt;
 
 /// This structure represents useful data about the function we are currently compiling.
 pub struct CurrentFnCtx<'tcx> {
@@ -108,8 +106,8 @@ impl CurrentFnCtx<'tcx> {
     }
 
     /// The pretty name of the function we are currently compiling
-    pub fn readable_name(&self) -> String {
-        self.readable_name.clone()
+    pub fn readable_name(&self) -> &str {
+        &self.readable_name
     }
 
     /// The signature of the function we are currently compiling

--- a/compiler/rustc_codegen_llvm/src/gotoc/hooks.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/hooks.rs
@@ -224,7 +224,7 @@ impl<'tcx> GotocHook<'tcx> for Intrinsic {
         span: Option<Span>,
     ) -> Stmt {
         let loc = tcx.codegen_span_option2(span);
-        if (tcx.symbol_name(instance) == "abort") {
+        if tcx.symbol_name(instance) == "abort" {
             Stmt::assert_false("abort intrinsic reached", loc)
         } else {
             let p = assign_to.unwrap();

--- a/compiler/rustc_codegen_llvm/src/gotoc/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/intrinsic.rs
@@ -428,11 +428,7 @@ impl<'tcx> GotocCtx<'tcx> {
             "prefetch_read_instruction" => unimplemented!(),
             "prefetch_write_data" => unimplemented!(),
             "prefetch_write_instruction" => unimplemented!(),
-            "try" => unimplemented!(
-                "unsupported intrinsic: {}\n\tin function {}",
-                intrinsic,
-                self.current_fn().readable_name()
-            ),
+            "try" => unimplemented!(),
             "unaligned_volatile_store" => unimplemented!(),
             "va_arg" => unimplemented!(),
             "va_copy" => unimplemented!(),

--- a/compiler/rustc_codegen_llvm/src/gotoc/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/intrinsic.rs
@@ -428,7 +428,11 @@ impl<'tcx> GotocCtx<'tcx> {
             "prefetch_read_instruction" => unimplemented!(),
             "prefetch_write_data" => unimplemented!(),
             "prefetch_write_instruction" => unimplemented!(),
-            "try" => unimplemented!(),
+            "try" => unimplemented!(
+                "unsupported intrinsic: {}\n\tin function {}",
+                intrinsic,
+                self.current_fn().readable_name()
+            ),
             "unaligned_volatile_store" => unimplemented!(),
             "va_arg" => unimplemented!(),
             "va_copy" => unimplemented!(),

--- a/compiler/rustc_codegen_llvm/src/gotoc/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/intrinsic.rs
@@ -255,6 +255,7 @@ impl<'tcx> GotocCtx<'tcx> {
             "atomic_load" => self.codegen_atomic_load(intrinsic, fargs, p, loc),
             "atomic_load_acq" => self.codegen_atomic_load(intrinsic, fargs, p, loc),
             "atomic_load_relaxed" => self.codegen_atomic_load(intrinsic, fargs, p, loc),
+            "atomic_load_unordered" => self.codegen_atomic_load(intrinsic, fargs, p, loc),
             "atomic_or" => codegen_atomic_binop!(bitor),
             "atomic_or_acq" => codegen_atomic_binop!(bitor),
             "atomic_or_acqrel" => codegen_atomic_binop!(bitor),
@@ -263,6 +264,7 @@ impl<'tcx> GotocCtx<'tcx> {
             "atomic_store" => self.codegen_atomic_store(intrinsic, fargs, p, loc),
             "atomic_store_rel" => self.codegen_atomic_store(intrinsic, fargs, p, loc),
             "atomic_store_relaxed" => self.codegen_atomic_store(intrinsic, fargs, p, loc),
+            "atomic_store_unordered" => self.codegen_atomic_store(intrinsic, fargs, p, loc),
             "atomic_xadd" => codegen_atomic_binop!(plus),
             "atomic_xadd_acq" => codegen_atomic_binop!(plus),
             "atomic_xadd_acqrel" => codegen_atomic_binop!(plus),
@@ -434,7 +436,11 @@ impl<'tcx> GotocCtx<'tcx> {
             "va_start" => unimplemented!(),
             "volatile_set_memory" => unimplemented!(),
             "volatile_store" => unimplemented!(),
-            _ => unimplemented!("unsupported intrinsic: {}", intrinsic),
+            _ => unimplemented!(
+                "unsupported intrinsic: {}\n\tin function {}",
+                intrinsic,
+                self.current_fn().readable_name()
+            ),
         }
     }
 

--- a/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
@@ -122,7 +122,6 @@ impl<'tcx> GotocCtx<'tcx> {
     pub fn codegen_function(&mut self, instance: Instance<'tcx>) {
         self.set_current_fn(instance);
         let name = self.current_fn().name();
-        dbg!(self.current_fn().readable_name());
         let old_sym = self.symbol_table.lookup(&name).unwrap();
         assert!(old_sym.is_function());
         if old_sym.is_function_definition() {

--- a/compiler/rustc_codegen_llvm/src/gotoc/place.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/place.rs
@@ -93,7 +93,12 @@ impl<'tcx> ProjectedPlace<'tcx> {
         let mir_typ_or_variant = mir_typ_or_variant.monomorphize(ctx);
         let fat_ptr_mir_typ = fat_ptr_mir_typ.map(|t| ctx.monomorphize(t));
         if let Some(fat_ptr) = &fat_ptr_goto_expr {
-            assert!(fat_ptr.typ().is_rust_fat_ptr(&ctx.symbol_table));
+            assert!(
+                fat_ptr.typ().is_rust_fat_ptr(&ctx.symbol_table),
+                "Expected fat pointer, got {:?} in function {}",
+                fat_ptr.typ(),
+                ctx.current_fn().readable_name()
+            );
         }
         // TODO: these assertions fail on a few regressions. Figure out why.
         // I think it may have to do with boxed fat pointers.

--- a/compiler/rustc_codegen_llvm/src/gotoc/typ.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/typ.rs
@@ -578,18 +578,18 @@ impl<'tcx> GotocCtx<'tcx> {
             | ty::Uint(_) => self.codegen_ty(pointee_type).to_pointer(),
 
             // These types were blocking firecracker. Doing the default thing to unblock.
-            // TODO, determine if this is the right course of action
+            // https://github.com/model-checking/rmc/issues/215
+            // https://github.com/model-checking/rmc/issues/216
             ty::FnDef(_, _) | ty::Never => self.codegen_ty(pointee_type).to_pointer(),
 
             // These types were blocking stdlib. Doing the default thing to unblock.
-            // TODO, determine if this is the right course of action
+            // https://github.com/model-checking/rmc/issues/214
             ty::FnPtr(_) => self.codegen_ty(pointee_type).to_pointer(),
 
             // These types have no regression tests for them.
             // For soundess, hold off on generating them till we have test-cases.
             ty::Bound(_, _) => todo!("{:?} {:?}", pointee_type, pointee_type.kind()),
             ty::Error(_) => todo!("{:?} {:?}", pointee_type, pointee_type.kind()),
-            //ty::FnPtr(_) => todo!("{:?} {:?}", pointee_type, pointee_type.kind()),
             ty::Generator(_, _, _) => todo!("{:?} {:?}", pointee_type, pointee_type.kind()),
             ty::GeneratorWitness(_) => todo!("{:?} {:?}", pointee_type, pointee_type.kind()),
             ty::Infer(_) => todo!("{:?} {:?}", pointee_type, pointee_type.kind()),

--- a/compiler/rustc_codegen_llvm/src/gotoc/typ.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/typ.rs
@@ -486,7 +486,9 @@ impl<'tcx> GotocCtx<'tcx> {
 
                 final_fields
             }
-            _ => unreachable!(),
+            // Primitives, such as NEVER, have no fields
+            FieldsShape::Primitive => vec![],
+            _ => unreachable!("{}\n{:?}", self.current_fn().readable_name(), layout.fields),
         }
     }
 
@@ -579,11 +581,15 @@ impl<'tcx> GotocCtx<'tcx> {
             // TODO, determine if this is the right course of action
             ty::FnDef(_, _) | ty::Never => self.codegen_ty(pointee_type).to_pointer(),
 
+            // These types were blocking stdlib. Doing the default thing to unblock.
+            // TODO, determine if this is the right course of action
+            ty::FnPtr(_) => self.codegen_ty(pointee_type).to_pointer(),
+
             // These types have no regression tests for them.
             // For soundess, hold off on generating them till we have test-cases.
             ty::Bound(_, _) => todo!("{:?} {:?}", pointee_type, pointee_type.kind()),
             ty::Error(_) => todo!("{:?} {:?}", pointee_type, pointee_type.kind()),
-            ty::FnPtr(_) => todo!("{:?} {:?}", pointee_type, pointee_type.kind()),
+            //ty::FnPtr(_) => todo!("{:?} {:?}", pointee_type, pointee_type.kind()),
             ty::Generator(_, _, _) => todo!("{:?} {:?}", pointee_type, pointee_type.kind()),
             ty::GeneratorWitness(_) => todo!("{:?} {:?}", pointee_type, pointee_type.kind()),
             ty::Infer(_) => todo!("{:?} {:?}", pointee_type, pointee_type.kind()),

--- a/compiler/rustc_codegen_llvm/src/gotoc/utils.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/utils.rs
@@ -88,7 +88,12 @@ impl<'tcx> GotocCtx<'tcx> {
         assert!(e.typ().is_rust_box(), "expected rust box {:?}", e);
         let unique_ptr_typ =
             self.symbol_table.lookup_field_type_in_type(e.typ(), "0").unwrap().clone();
-        assert!(unique_ptr_typ.is_rust_unique_pointer());
+        assert!(
+            unique_ptr_typ.is_rust_unique_pointer(),
+            "{:?}\n\t{}",
+            unique_ptr_typ,
+            self.current_fn().readable_name()
+        );
         e.member("0", &self.symbol_table).member("pointer", &self.symbol_table)
     }
 
@@ -133,7 +138,9 @@ impl Type {
     /// Checks if the struct represents a Rust "Unique"
     pub fn is_rust_unique_pointer(&self) -> bool {
         self.type_name().map_or(false, |name| {
-            name.starts_with("tag-std::ptr::Unique") || name.starts_with("tag-core::ptr::Unique")
+            name.starts_with("tag-std::ptr::Unique")
+                || name.starts_with("tag-core::ptr::Unique")
+                || name.starts_with("tag-rustc_std_workspace_core::ptr::Unique")
         })
     }
 


### PR DESCRIPTION
### Description of changes: 

Partially resolves issues from #109, and adds a mechanism to handle more such issues as I dig deeper into that issue.  Although the command from #109 fails, it now compiles many more modules than before.

### Resolved issues:

None,  we make progress on #109 but do not resolve it.

### Call-outs:

This makes four related changes to get standard library code to codegen:

1. Unsupported intrinsics
1. Unsupported struct fields type (Primitive)
1. Avoid aborting if ASM code is found
1. Mechanism to avoid codegen of functions

### Testing:

* How is this change tested? Existing regression suite, ran the command in #109.  Although it still fails, it now gets through many more modules than before. 

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
