### PR TITLE
Switch functions to use readable name in visualization. [Merge after CBMC-Viewer version update]

### DIFF
--- a/.github/workflows/rmc.yml
+++ b/.github/workflows/rmc.yml
@@ -22,7 +22,7 @@ jobs:
         run: ./scripts/setup/${{ matrix.os }}/install_cbmc.sh
       
       - name: Install cbmc-viewer
-        run: ./scripts/setup/install_viewer.sh 2.5
+        run: ./scripts/setup/install_viewer.sh 2.6
 
       - name: Install Rust toolchain
         run: ./scripts/setup/install_rustup.sh

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/span.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/span.rs
@@ -19,7 +19,12 @@ impl<'tcx> GotocCtx<'tcx> {
             Ok(pathbuf) => pathbuf.to_str().unwrap().to_string(),
             Err(_) => filename0,
         };
-        Location::new(filename1, self.current_fn.as_ref().map(|x| x.name()), line, Some(col))
+        Location::new(
+            filename1,
+            self.current_fn.as_ref().map(|x| x.readable_name().to_string()),
+            line,
+            Some(col),
+        )
     }
 
     pub fn codegen_span_option(&self, sp: Option<Span>) -> Location {

--- a/src/test/cargo-rmc/simple-config-toml/test_one_plus_two.expected
+++ b/src/test/cargo-rmc/simple-config-toml/test_one_plus_two.expected
@@ -1,1 +1,1 @@
-[test_one_plus_two.assertion.1] line 31 assertion failed: p.sum() == 3: SUCCESS
+[pair::rmc_tests::test_one_plus_two.assertion.1] line 31 assertion failed: p.sum() == 3: SUCCESS

--- a/src/test/cargo-rmc/simple-config-toml/test_sum.expected
+++ b/src/test/cargo-rmc/simple-config-toml/test_sum.expected
@@ -1,1 +1,1 @@
-[test_sum.assertion.1] line 27 assertion failed: p.sum() == a.wrapping_add(b): SUCCESS
+[rmc_tests::test_sum.assertion.1] line 27 assertion failed: p.sum() == a.wrapping_add(b): SUCCESS

--- a/src/test/cargo-rmc/simple-lib/test_one_plus_two.expected
+++ b/src/test/cargo-rmc/simple-lib/test_one_plus_two.expected
@@ -1,1 +1,1 @@
-[test_one_plus_two.assertion.1] line 31 assertion failed: p.sum() == 3: SUCCESS
+[pair::rmc_tests::test_one_plus_two.assertion.1] line 31 assertion failed: p.sum() == 3: SUCCESS

--- a/src/test/cargo-rmc/simple-lib/test_sum.expected
+++ b/src/test/cargo-rmc/simple-lib/test_sum.expected
@@ -1,1 +1,1 @@
-[test_sum.assertion.1] line 27 assertion failed: p.sum() == a.wrapping_add(b): SUCCESS
+[rmc_tests::test_sum.assertion.1] line 27 assertion failed: p.sum() == a.wrapping_add(b): SUCCESS


### PR DESCRIPTION
### Description of changes: 

Currently, the visualization of RMC failure traces use mangled function names for both source locations of steps and for the code coverage report. This PR switches over to using the readable name of the function, making both traces and coverage reports much easier to read.

An example coverage report now looks like:
<img width="436" alt="image" src="https://user-images.githubusercontent.com/84409848/122469447-f81cb700-cf8a-11eb-93fa-47c1ee14603a.png">

An example trace step now looks like:
<img width="674" alt="image" src="https://user-images.githubusercontent.com/84409848/122469771-534ea980-cf8b-11eb-860e-a0d977e6423c.png">


### Resolved issues:


### Call-outs:

This PR depends on a change to CMBC-viewer that is [on the master branch](https://github.com/awslabs/aws-viewer-for-cbmc/commit/aff75c57673da2dd092f98f9491a37a7f07250e7) but not yet in a numbered version. Until CMBC-viewer updates, we will need to install from master.

Even with this CBMC-viewer patch, the href attached to the function names in locations are broken due to a C-specific feature of CMBC-viewer, which I am currently working on a fix for.

Lastly, there is another similar issue which I have not been able to find the source of that causes the function names to display incorrectly, likely due to C-specific name expectations again:
<img width="568" alt="image" src="https://user-images.githubusercontent.com/84409848/122470673-55fdce80-cf8c-11eb-87f7-4b03836417b3.png">


### Testing:

* How is this change tested? Existing regression tests.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
