### PR TITLE
Add rmc-prelude.rs, and use it in tests

### DIFF
--- a/src/test/cbmc/Assume/main.rs
+++ b/src/test/cbmc/Assume/main.rs
@@ -1,13 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-fn __VERIFIER_assume(cond: bool) {
-    unimplemented!()
-}
-
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let i: i32 = __nondet();

--- a/src/test/cbmc/Assume/main_fail.rs
+++ b/src/test/cbmc/Assume/main_fail.rs
@@ -1,13 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-fn __VERIFIER_assume(cond: bool) {
-    unimplemented!()
-}
-
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let i: i32 = __nondet();

--- a/src/test/cbmc/Enum/result3.rs
+++ b/src/test/cbmc/Enum/result3.rs
@@ -1,12 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+
+include!("../../rmc-prelude.rs");
+
 #[derive(Debug, PartialEq)]
 pub enum Unit {
     Unit,
-}
-
-fn __nondet<T>() -> T {
-    unimplemented!()
 }
 
 fn foo(input: &Result<u32, Unit>) -> u32 {

--- a/src/test/rmc-prelude.rs
+++ b/src/test/rmc-prelude.rs
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+fn __VERIFIER_assume(cond: bool) {
+    unimplemented!()
+}
+
+fn __nondet<T>() -> T {
+    unimplemented!()
+}


### PR DESCRIPTION
### Description of changes: 

Currently, each test that uses `__nondet()` or `__VERIFIER_assume` needs to declare them inline.
After this PR, they can `include!("rmc_prelude")` instead

### Resolved issues:

Resolves #227 

### Call-outs:

Ideally, we would have a seperate crate for this. For now, just `include!` the file works

### Testing:

* How is this change tested? Regressions still work after the change

* Is this a refactor change? yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
