### PR TITLE
Add an __VERIFIER_expected_fail() intrinsic, and use it in a test

### DIFF
--- a/src/test/cbmc/Assume/main_fail.rs
+++ b/src/test/cbmc/Assume/main_fail.rs
@@ -3,8 +3,12 @@
 
 include!("../../rmc-prelude.rs");
 
+fn __VERIFIER_expect_fail(cond: bool, msg: &str)  {
+    unimplemented!()
+}
+
 fn main() {
     let i: i32 = __nondet();
     __VERIFIER_assume(i < 10);
-    assert!(i > 20);
+    __VERIFIER_expect_fail(i > 20, "Blocked by assumption above.");
 }

--- a/src/test/cbmc/Assume/main_fail.rs
+++ b/src/test/cbmc/Assume/main_fail.rs
@@ -3,10 +3,6 @@
 
 include!("../../rmc-prelude.rs");
 
-fn __VERIFIER_expect_fail(cond: bool, msg: &str)  {
-    unimplemented!()
-}
-
 fn main() {
     let i: i32 = __nondet();
     __VERIFIER_assume(i < 10);

--- a/src/test/rmc-prelude.rs
+++ b/src/test/rmc-prelude.rs
@@ -5,6 +5,10 @@ fn __VERIFIER_assume(cond: bool) {
     unimplemented!()
 }
 
+fn __VERIFIER_expect_fail(cond: bool) {
+    unimplemented!()
+}
+
 fn __nondet<T>() -> T {
     unimplemented!()
 }


### PR DESCRIPTION
### Description of changes: 

Currently, we check for expected failing assertions by marking the whole test as `_fail`. This is not very granular.
### Resolved issues:

Resolves #228 

### Call-outs:

We have a field for custom error messages, but due to the inability of CBMC to take non-constant assertion messages, we can't yet use them.

### Testing:

* How is this change tested? Used it in a test, test still fails

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
