### PR TITLE
Use RMC prelude in all tests

### DIFF
--- a/src/test/cbmc/ArithEqualOperators/main.rs
+++ b/src/test/cbmc/ArithEqualOperators/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let mut a: u32 = __nondet();

--- a/src/test/cbmc/ArithOperators/main.rs
+++ b/src/test/cbmc/ArithOperators/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let a: u32 = __nondet();

--- a/src/test/cbmc/BinOp_Offset/main_fail.rs
+++ b/src/test/cbmc/BinOp_Offset/main_fail.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unreachable!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn test_offset_in_double_array() {
     //let table: Vec<Vec<u64>> = Vec::with_capacity(1);

--- a/src/test/cbmc/BitwiseArithOperators/main.rs
+++ b/src/test/cbmc/BitwiseArithOperators/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     assert!(3 | 5 == 7);

--- a/src/test/cbmc/BitwiseEqualOperators/main.rs
+++ b/src/test/cbmc/BitwiseEqualOperators/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let mut x = 0;

--- a/src/test/cbmc/Bool-BoolOperators/main.rs
+++ b/src/test/cbmc/Bool-BoolOperators/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     assert!(true);

--- a/src/test/cbmc/Cast/from_be_bytes.rs
+++ b/src/test/cbmc/Cast/from_be_bytes.rs
@@ -1,9 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::convert::TryInto;
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 fn main() {
     let input: &[u8] = &vec![
         __nondet(),

--- a/src/test/cbmc/EQ-NE/main.rs
+++ b/src/test/cbmc/EQ-NE/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let x: u32 = __nondet();

--- a/src/test/cbmc/FloatingPoint/main.rs
+++ b/src/test/cbmc/FloatingPoint/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 macro_rules! test_floats {
     ($ty:ty) => {

--- a/src/test/cbmc/FunctionCall_Ret-NoParam/main.rs
+++ b/src/test/cbmc/FunctionCall_Ret-NoParam/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let a = return_u32();

--- a/src/test/cbmc/FunctionCall_Ret-Param/main.rs
+++ b/src/test/cbmc/FunctionCall_Ret-Param/main.rs
@@ -3,9 +3,7 @@
 
 // cbmc-flags: --unwind 10
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let x: u32 = __nondet();

--- a/src/test/cbmc/IfElseifElse_NonReturning/main.rs
+++ b/src/test/cbmc/IfElseifElse_NonReturning/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let a: u32 = __nondet();

--- a/src/test/cbmc/IfElseifElse_Returning/main.rs
+++ b/src/test/cbmc/IfElseifElse_Returning/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let a: u32 = __nondet();

--- a/src/test/cbmc/LT-GT-LE-GE/main.rs
+++ b/src/test/cbmc/LT-GT-LE-GE/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let a: u32 = __nondet();

--- a/src/test/cbmc/LoopLoop_NonReturning/main.rs
+++ b/src/test/cbmc/LoopLoop_NonReturning/main.rs
@@ -3,9 +3,7 @@
 
 // cbmc-flags: --unwind 10 --unwinding-assertions
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let mut a: u32 = __nondet();

--- a/src/test/cbmc/LoopWhile_NonReturning/main.rs
+++ b/src/test/cbmc/LoopWhile_NonReturning/main.rs
@@ -3,9 +3,7 @@
 
 // cbmc-flags: --unwind 11 --unwinding-assertions
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let mut a: u32 = __nondet();

--- a/src/test/cbmc/NondetVectors/bytes.rs
+++ b/src/test/cbmc/NondetVectors/bytes.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::convert::TryInto;
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let input: &[u8] = &vec![

--- a/src/test/cbmc/NondetVectors/fixme_main.rs
+++ b/src/test/cbmc/NondetVectors/fixme_main.rs
@@ -1,9 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 const FIFO_SIZE: usize = 2;
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let len: usize = __nondet();

--- a/src/test/cbmc/Pointers_OtherTypes/main.rs
+++ b/src/test/cbmc/Pointers_OtherTypes/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let mut x = 1;

--- a/src/test/cbmc/SaturatingIntrinsics/fixme_128.rs
+++ b/src/test/cbmc/SaturatingIntrinsics/fixme_128.rs
@@ -5,9 +5,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics;
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let v: u128 = __nondet();

--- a/src/test/cbmc/SaturatingIntrinsics/main.rs
+++ b/src/test/cbmc/SaturatingIntrinsics/main.rs
@@ -3,9 +3,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics;
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 macro_rules! test_saturating_intrinsics {
     ($ty:ty) => {

--- a/src/test/cbmc/Scopes_NonReturning/main.rs
+++ b/src/test/cbmc/Scopes_NonReturning/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let a: u32 = __nondet();

--- a/src/test/cbmc/Scopes_Returning/main.rs
+++ b/src/test/cbmc/Scopes_Returning/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let x = { 5 };

--- a/src/test/cbmc/Slice/slice_from_raw_fail.rs
+++ b/src/test/cbmc/Slice/slice_from_raw_fail.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::slice;
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 // From Listing 19-7: Creating a slice from an arbitrary memory location. https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html
 fn main() {

--- a/src/test/cbmc/i32-Unary-/main.rs
+++ b/src/test/cbmc/i32-Unary-/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let a: i32 = __nondet();

--- a/src/test/expected/closure/expected
+++ b/src/test/expected/closure/expected
@@ -1,7 +1,7 @@
 resume instruction: SUCCESS
-line 22 attempt to compute `move _8 + move _9`, which would overflow: SUCCESS
-line 22 attempt to compute `move _5 + move _6`, which would overflow: SUCCESS
-line 22 attempt to compute `(*((*_1).0: &mut i32)) + move _4`, which would overflow: SUCCESS
-line 27 attempt to compute `move _18 + const 12_i32`, which would overflow: SUCCESS
-line 27 assertion failed: original_num + 12 == num: SUCCESS
-line 27 arithmetic overflow on signed + in var_18 + 12: SUCCESS
+line 20 attempt to compute `move _8 + move _9`, which would overflow: SUCCESS
+line 20 attempt to compute `move _5 + move _6`, which would overflow: SUCCESS
+line 20 attempt to compute `(*((*_1).0: &mut i32)) + move _4`, which would overflow: SUCCESS
+line 25 attempt to compute `move _18 + const 12_i32`, which would overflow: SUCCESS
+line 25 assertion failed: original_num + 12 == num: SUCCESS
+line 25 arithmetic overflow on signed + in var_18 + 12: SUCCESS

--- a/src/test/expected/closure/main.rs
+++ b/src/test/expected/closure/main.rs
@@ -8,9 +8,7 @@ fn call_with_one<F>(mut some_closure: F) -> ()
     some_closure(1, 1);
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let mut num: i32 = __nondet();

--- a/src/test/expected/closure3/expected
+++ b/src/test/expected/closure3/expected
@@ -1,3 +1,3 @@
-line 18 attempt to compute `move _3 + move _4`, which would overflow: SUCCESS
-line 19 attempt to compute `move _11 + const 10_i64`, which would overflow: SUCCESS
-line 19 assertion failed: num + 10 == y: SUCCESS
+line 16 attempt to compute `move _3 + move _4`, which would overflow: SUCCESS
+line 17 attempt to compute `move _11 + const 10_i64`, which would overflow: SUCCESS
+line 17 assertion failed: num + 10 == y: SUCCESS

--- a/src/test/expected/closure3/main.rs
+++ b/src/test/expected/closure3/main.rs
@@ -7,9 +7,7 @@ fn call_with_one<F, T>(f: F) -> T
     f(10)
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let num: i64 = __nondet();

--- a/src/test/expected/comp/main.rs
+++ b/src/test/expected/comp/main.rs
@@ -12,9 +12,7 @@ fn eq2(a: i32, b: i32) {
     assert!(a - b < a);
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let a = __nondet();

--- a/src/test/expected/dynamic-error-trait/main.rs
+++ b/src/test/expected/dynamic-error-trait/main.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::io::{self, Read, Write};
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 type Result<T> = std::result::Result<T, io::Error>;
 

--- a/src/test/expected/nondet/expected
+++ b/src/test/expected/nondet/expected
@@ -1,5 +1,5 @@
-line 11 attempt to compute `move _12 * move _13`, which would overflow: SUCCESS
-line 11 attempt to compute `const 2_i32 * move _16`, which would overflow: SUCCESS
-line 11 attempt to compute `move _11 - move _15`, which would overflow: SUCCESS
-line 11 attempt to compute `move _10 + const 1_i32`, which would overflow: SUCCESS
-line 11 assertion failed: x * x - 2 * x + 1 != 4 || (x == -1 || x == 3): SUCCESS
+line 9 attempt to compute `move _12 * move _13`, which would overflow: SUCCESS
+line 9 attempt to compute `const 2_i32 * move _16`, which would overflow: SUCCESS
+line 9 attempt to compute `move _11 - move _15`, which would overflow: SUCCESS
+line 9 attempt to compute `move _10 + const 1_i32`, which would overflow: SUCCESS
+line 9 assertion failed: x * x - 2 * x + 1 != 4 || (x == -1 || x == 3): SUCCESS

--- a/src/test/expected/nondet/main.rs
+++ b/src/test/expected/nondet/main.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let x: i32 = __nondet();

--- a/src/test/expected/replace-hashmap/expected
+++ b/src/test/expected/replace-hashmap/expected
@@ -1,6 +1,6 @@
-line 28 attempt to compute `((*_1).0: usize) + const 1_usize`, which would overflow: SUCCESS
-line 28 arithmetic overflow on unsigned + in self->len + 1: SUCCESS
-line 58 assertion failed: a.is_some(): FAILURE
-line 59 assertion failed: a.is_none(): FAILURE
-line 61 assertion failed: b.is_some(): SUCCESS
-line 62 assertion failed: b.is_none(): FAILURE
+line 26 attempt to compute `((*_1).0: usize) + const 1_usize`, which would overflow: SUCCESS
+line 26 arithmetic overflow on unsigned + in self->len + 1: SUCCESS
+line 56 assertion failed: a.is_some(): FAILURE
+line 57 assertion failed: a.is_none(): FAILURE
+line 59 assertion failed: b.is_some(): SUCCESS
+line 60 assertion failed: b.is_none(): FAILURE

--- a/src/test/expected/replace-hashmap/main.rs
+++ b/src/test/expected/replace-hashmap/main.rs
@@ -5,9 +5,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::collections::hash_map::RandomState;
 use std::borrow::Borrow;
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 use std::marker::PhantomData;
 struct CbmcHashMap<K,V, S=RandomState> {len: usize, _k : PhantomData<K>, _s : PhantomData<S>, last : Option<V>}

--- a/src/test/expected/replace-vec/expected
+++ b/src/test/expected/replace-vec/expected
@@ -1,8 +1,8 @@
-line 24 attempt to compute `((*_1).0: usize) + const 1_usize`, which would overflow: SUCCESS
-line 34 attempt to compute `((*_1).0: usize) - const 1_usize`, which would overflow: SUCCESS
-line 53 assertion failed: v.len() == 1: SUCCESS
-line 54 assertion failed: v.len() == 11: FAILURE
-line 56 assertion failed: p != None: SUCCESS
-line 57 assertion failed: p == None: FAILURE
-line 58 assertion failed: p == Some(to_push): SUCCESS
-line 59 assertion failed: p == Some(not_pushed): FAILURE
+line 22 attempt to compute `((*_1).0: usize) + const 1_usize`, which would overflow: SUCCESS
+line 32 attempt to compute `((*_1).0: usize) - const 1_usize`, which would overflow: SUCCESS
+line 51 assertion failed: v.len() == 1: SUCCESS
+line 52 assertion failed: v.len() == 11: FAILURE
+line 54 assertion failed: p != None: SUCCESS
+line 55 assertion failed: p == None: FAILURE
+line 56 assertion failed: p == Some(to_push): SUCCESS
+line 57 assertion failed: p == Some(not_pushed): FAILURE

--- a/src/test/expected/replace-vec/main.rs
+++ b/src/test/expected/replace-vec/main.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![feature(allocator_api)]
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 use std::marker::PhantomData;
 use std::alloc::Allocator;

--- a/src/test/expected/vecdq/main.rs
+++ b/src/test/expected/vecdq/main.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::collections::VecDeque;
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let x = __nondet();

--- a/src/test/firecracker/micro-http-parsed-request/ignore-main.rs
+++ b/src/test/firecracker/micro-http-parsed-request/ignore-main.rs
@@ -3,9 +3,7 @@
 // Example from Firecracker micro_http request handling
 // https://github.com/firecracker-microvm/firecracker/commit/22908c9fb0cd5fb20febc5d18ff1284caa5f3a53
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 // Should return a nondet string of up to n characters
 // Currently RMC does not support strings

--- a/src/test/firecracker/virtio-balloon-compact/ignore-main.rs
+++ b/src/test/firecracker/virtio-balloon-compact/ignore-main.rs
@@ -53,9 +53,7 @@ fn expand(ranges: Vec<(u32, u32)>) -> Vec<u32> {
     return v;
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     let mut input = vec![0; 2];

--- a/src/test/firecracker/virtio-block-parse/main.rs
+++ b/src/test/firecracker/virtio-block-parse/main.rs
@@ -25,9 +25,7 @@ static mut TRACK_READ_OBJ: Option<GuestAddress> = None;
 
 pub struct GuestMemoryMmap {}
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 impl GuestMemoryMmap {
     fn checked_offset(&self, base: GuestAddress, offset: usize) -> Option<GuestAddress> {

--- a/src/test/prusti/Binary_search_fail.rs
+++ b/src/test/prusti/Binary_search_fail.rs
@@ -43,9 +43,7 @@ fn binary_search<T: Ord>(arr: &[T], elem: &T) -> Option<usize> {
     None
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn get() -> [i32; 11] {
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]

--- a/src/test/serial/serial.rs
+++ b/src/test/serial/serial.rs
@@ -322,9 +322,7 @@ impl Serial {
     }
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     {

--- a/src/test/serial/serial2.rs
+++ b/src/test/serial/serial2.rs
@@ -322,9 +322,7 @@ impl Serial {
     }
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     {

--- a/src/test/serial/serial_spec.rs
+++ b/src/test/serial/serial_spec.rs
@@ -464,9 +464,7 @@ impl Serial {
     }
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 fn main() {
     {

--- a/src/test/smack/basic/arith_assume.rs
+++ b/src/test/smack/basic/arith_assume.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // @expect verified
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let a = __nondet();

--- a/src/test/smack/basic/arith_assume2.rs
+++ b/src/test/smack/basic/arith_assume2.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // @expect verified
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let a = __nondet();

--- a/src/test/smack/basic/arith_assume_fail.rs
+++ b/src/test/smack/basic/arith_assume_fail.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // @expect error
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let a = __nondet();

--- a/src/test/smack/functions/closure.rs
+++ b/src/test/smack/functions/closure.rs
@@ -10,9 +10,7 @@ where
     some_closure(1);
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let mut num: i32 = __nondet();

--- a/src/test/smack/functions/closure_fail.rs
+++ b/src/test/smack/functions/closure_fail.rs
@@ -10,9 +10,7 @@ where
     some_closure(1);
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let mut num: i32 = __nondet();

--- a/src/test/smack/functions/double.rs
+++ b/src/test/smack/functions/double.rs
@@ -6,9 +6,7 @@ fn double(a: u32) -> u32 {
     a * 2
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let a = __nondet();

--- a/src/test/smack/functions/double_fail.rs
+++ b/src/test/smack/functions/double_fail.rs
@@ -6,9 +6,7 @@ fn double(a: u32) -> u32 {
     a * 2
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let a = __nondet();

--- a/src/test/smack/generics/generic_function.rs
+++ b/src/test/smack/generics/generic_function.rs
@@ -33,9 +33,7 @@ fn swapem<T, U: S<T>>(s: U) -> U {
     s.swap_items()
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let x2 = __nondet();

--- a/src/test/smack/generics/generic_function_fail1.rs
+++ b/src/test/smack/generics/generic_function_fail1.rs
@@ -33,9 +33,7 @@ fn swapem<T, U: S<T>>(s: U) -> U {
     s.swap_items()
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let x2 = __nondet();

--- a/src/test/smack/generics/generic_function_fail2.rs
+++ b/src/test/smack/generics/generic_function_fail2.rs
@@ -33,9 +33,7 @@ fn swapem<T, U: S<T>>(s: U) -> U {
     s.swap_items()
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let x2 = __nondet();

--- a/src/test/smack/generics/generic_function_fail3.rs
+++ b/src/test/smack/generics/generic_function_fail3.rs
@@ -33,9 +33,7 @@ fn swapem<T, U: S<T>>(s: U) -> U {
     s.swap_items()
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let x2 = __nondet();

--- a/src/test/smack/generics/generic_function_fail4.rs
+++ b/src/test/smack/generics/generic_function_fail4.rs
@@ -33,9 +33,7 @@ fn swapem<T, U: S<T>>(s: U) -> U {
     s.swap_items()
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let x2 = __nondet();

--- a/src/test/smack/generics/generic_function_fail5.rs
+++ b/src/test/smack/generics/generic_function_fail5.rs
@@ -33,9 +33,7 @@ fn swapem<T, U: S<T>>(s: U) -> U {
     s.swap_items()
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let x2 = __nondet();

--- a/src/test/smack/loops/gauss_sum_nondet.rs
+++ b/src/test/smack/loops/gauss_sum_nondet.rs
@@ -5,9 +5,7 @@
 
 // cbmc-flags: --unwind 5 --unwinding-assertions
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let mut sum = 0;

--- a/src/test/smack/loops/gauss_sum_nondet_fail.rs
+++ b/src/test/smack/loops/gauss_sum_nondet_fail.rs
@@ -5,9 +5,7 @@
 
 // cbmc-flags: --unwind 5 --unwinding-assertions
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let mut sum = 0;

--- a/src/test/smack/loops/iterator.rs
+++ b/src/test/smack/loops/iterator.rs
@@ -13,9 +13,7 @@ fn fac(n: u64) -> u64 {
     }
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let mut a = 1;

--- a/src/test/smack/loops/iterator_fail.rs
+++ b/src/test/smack/loops/iterator_fail.rs
@@ -13,9 +13,7 @@ fn fac(n: u64) -> u64 {
     }
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let mut a = 1;

--- a/src/test/smack/structures/option.rs
+++ b/src/test/smack/structures/option.rs
@@ -6,9 +6,7 @@ fn safe_div(x: u32, y: u32) -> Option<u32> {
     if y != 0 { Some(x / y) } else { None }
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let x = __nondet();

--- a/src/test/smack/structures/option_fail.rs
+++ b/src/test/smack/structures/option_fail.rs
@@ -6,9 +6,7 @@ fn safe_div(x: u32, y: u32) -> Option<u32> {
     if y != 0 { Some(x / y) } else { None }
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let x = __nondet();

--- a/src/test/smack/structures/point.rs
+++ b/src/test/smack/structures/point.rs
@@ -36,9 +36,7 @@ impl AddAssign for Point {
     }
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let w = __nondet();

--- a/src/test/smack/structures/point_fail.rs
+++ b/src/test/smack/structures/point_fail.rs
@@ -36,9 +36,7 @@ impl AddAssign for Point {
     }
 }
 
-fn __nondet<T>() -> T {
-    unimplemented!()
-}
+include!("../../rmc-prelude.rs");
 
 pub fn main() {
     let w = __nondet();


### PR DESCRIPTION
### Description of changes: 

Use RMC prelude in all tests that declared the `__nondet()` function.

### Resolved issues:

Resolves #230 


### Call-outs:

There is one remaining file that still includes a declaration of `__nondet()` in `src/test/cargo-rmc/simple-lib/src/lib.rs` because I believe `cargo-rmc` tests must be self-contained and not include external code.

### Testing:

* How is this change tested? Tests have been modified and executed.

* Is this a refactor change? Yes.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
