### PR TITLE
 Handle unsized dyn trait objects as source of casts

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/expr.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/expr.rs
@@ -418,16 +418,12 @@ impl Expr {
 
     /// Casts value to new_typ, only when the current type of value
     /// is equivalent to new_typ on the given machine (e.g. i32 -> c_int)
-    pub fn cast_between_machine_equivalent_types(
-        value: Expr,
-        new_typ: &Type,
-        mm: &MachineModel,
-    ) -> Expr {
-        if value.typ() == new_typ {
-            value
+    pub fn cast_to_machine_equivalent_type(self, new_typ: &Type, mm: &MachineModel) -> Expr {
+        if self.typ() == new_typ {
+            self
         } else {
-            assert!(value.typ().is_equal_on_machine(new_typ, mm));
-            value.cast_to(new_typ.clone())
+            assert!(self.typ().is_equal_on_machine(new_typ, mm));
+            self.cast_to(new_typ.clone())
         }
     }
 
@@ -443,8 +439,7 @@ impl Expr {
         let mut rval: Vec<_> = parameters
             .iter()
             .map(|parameter| {
-                let argument = arguments.remove(0);
-                Self::cast_between_machine_equivalent_types(argument, &parameter.typ(), mm)
+                arguments.remove(0).cast_to_machine_equivalent_type(&parameter.typ(), mm)
             })
             .collect();
 

--- a/compiler/rustc_codegen_llvm/src/gotoc/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/intrinsic.rs
@@ -155,7 +155,15 @@ impl<'tcx> GotocCtx<'tcx> {
                     .tcx
                     .const_eval_instance(ty::ParamEnv::reveal_all(), instance, None)
                     .unwrap();
-                let e = self.codegen_const_value(value, self.tcx.types.usize, None);
+                // We may have an implicit cast between machine equivalent
+                // types where CBMC expects a different type than Rust.
+                let place_type = self.codegen_ty(self.place_ty(p));
+                let e = self
+                    .codegen_const_value(value, self.tcx.types.usize, None)
+                    .cast_to_machine_equivalent_type(
+                        &place_type,
+                        &self.symbol_table.machine_model(),
+                    );
                 self.codegen_expr_to_place(p, e)
             }};
         }

--- a/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
@@ -101,8 +101,6 @@ impl<'tcx> GotocCtx<'tcx> {
         match self.current_fn().readable_name() {
             // https://github.com/model-checking/rmc/issues/202
             "fmt::ArgumentV1::<'a>::as_usize" => true,
-            // https://github.com/model-checking/rmc/issues/203
-            "<(dyn core::any::Any + core::marker::Send + 'static)>::downcast_ref" => true,
             // https://github.com/model-checking/rmc/issues/204
             x if x.ends_with("__getit") => true,
             // https://github.com/model-checking/rmc/issues/205

--- a/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
@@ -677,6 +677,9 @@ impl<'tcx> GotocCtx<'tcx> {
                 dst_mir_type,
             )
         } else {
+            // Assert that the source is not a pointer or is a thing pointer
+            assert!(pointee_type(src_mir_type).map_or(true, |p| self.use_thin_pointer(p)));
+
             // Sized to unsized cast
             self.cast_sized_expr_to_unsized_expr(src_goto_expr.clone(), src_mir_type, dst_mir_type)
         }

--- a/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
@@ -4,7 +4,7 @@ use super::cbmc::goto_program::{BuiltinFn, Expr, Location, Stmt, Symbol, Type};
 use super::cbmc::utils::{aggr_name, BUG_REPORT_URL};
 use super::cbmc::MachineModel;
 use super::metadata::*;
-use super::typ::{is_pointer, pointee_type};
+use super::typ::{is_dyn_trait_fat_pointer, is_pointer, pointee_type};
 use super::utils::{dynamic_fat_ptr, slice_fat_ptr};
 use crate::btree_string_map;
 use num::bigint::BigInt;
@@ -656,13 +656,29 @@ impl<'tcx> GotocCtx<'tcx> {
                 let src_goto_expr = self.codegen_operand(o);
                 let src_mir_type = self.operand_ty(o);
                 let dst_mir_type = t;
-                let dst_goto_expr = self.cast_sized_expr_to_unsized_expr(
-                    src_goto_expr.clone(),
-                    src_mir_type,
-                    dst_mir_type,
-                );
-                dst_goto_expr.unwrap_or(src_goto_expr)
+                self.cast_to_unsized_expr(src_goto_expr.clone(), src_mir_type, dst_mir_type)
+                    .unwrap_or(src_goto_expr)
             }
+        }
+    }
+
+    fn cast_to_unsized_expr(
+        &mut self,
+        src_goto_expr: Expr,
+        src_mir_type: Ty<'tcx>,
+        dst_mir_type: Ty<'tcx>,
+    ) -> Option<Expr> {
+        // Check if the cast is from a vtable fat pointer to another
+        // vtable fat pointer (which can happen with auto trait fat pointers)
+        if is_dyn_trait_fat_pointer(src_mir_type) {
+            self.cast_unsized_dyn_trait_to_unsized_dyn_trait(
+                src_goto_expr.clone(),
+                src_mir_type,
+                dst_mir_type,
+            )
+        } else {
+            // Sized to unsized cast
+            self.cast_sized_expr_to_unsized_expr(src_goto_expr.clone(), src_mir_type, dst_mir_type)
         }
     }
 
@@ -845,6 +861,47 @@ impl<'tcx> GotocCtx<'tcx> {
         )
     }
 
+    /// Fat pointers to dynamic auto trait objects can be the src of casts.
+    /// For example, this cast is legal, because Send is an auto trait with
+    /// no associated function:
+    ///
+    ///     &(dyn Any + Send) as &dyn Any
+    ///
+    /// This cast is legal because without any changes to the set of virtual
+    /// functions, the underlying vtable does not need to change.
+    ///
+    /// Cast a pointer from one usized dynamic trait object to another. The
+    /// result  of the cast will be a fat pointer with the same data and
+    /// vtable, but the new type. Returns None if no cast is needed.
+    fn cast_unsized_dyn_trait_to_unsized_dyn_trait(
+        &mut self,
+        src_goto_expr: Expr,
+        src_mir_type: Ty<'tcx>,
+        dst_mir_type: Ty<'tcx>,
+    ) -> Option<Expr> {
+        if src_mir_type.kind() == dst_mir_type.kind() {
+            return None; // no cast required, nothing to do
+        }
+
+        // The source destination must be a fat pointers to a dyn trait object
+        assert!(is_dyn_trait_fat_pointer(src_mir_type));
+        assert!(is_dyn_trait_fat_pointer(dst_mir_type));
+
+        let dst_mir_dyn_ty = pointee_type(dst_mir_type).unwrap();
+
+        // Get the fat pointer data and vtable fields, and cast the type of
+        // the vtable.
+        let dst_goto_type = self.codegen_ty(dst_mir_type);
+        let data = src_goto_expr.to_owned().member("data", &self.symbol_table);
+        let vtable_name = self.vtable_name(dst_mir_dyn_ty);
+        let vtable_ty = Type::struct_tag(&vtable_name).to_pointer();
+
+        let vtable = src_goto_expr.member("vtable", &self.symbol_table).cast_to(vtable_ty);
+
+        // Construct a fat pointer with the same (casted) fields and new type
+        Some(dynamic_fat_ptr(dst_goto_type, data, vtable, &self.symbol_table))
+    }
+
     /// Cast a sized object to an unsized object: the result of the cast will be
     /// a fat pointer or an ADT with a nested fat pointer.  Return the result of
     /// the cast as Some(expr) and return None if no cast was required.
@@ -866,6 +923,10 @@ impl<'tcx> GotocCtx<'tcx> {
         assert!(
             src_mir_type.is_sized(self.tcx.at(rustc_span::DUMMY_SP), ty::ParamEnv::reveal_all())
         );
+
+        // The src type cannot be a pointer to a dynamic trait object, otherwise
+        // we should have called cast_unsized_dyn_trait_to_unsized_dyn_trait
+        assert!(!is_dyn_trait_fat_pointer(src_mir_type));
 
         match (src_mir_type.kind(), dst_mir_type.kind()) {
             (ty::Ref(..), ty::Ref(..)) => {
@@ -1009,7 +1070,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // Cast each field and collect the fields for which a cast was required
         let mut cast_required: Vec<(String, Expr)> = vec![];
         for field in src_goto_field_values.keys() {
-            if let Some(expr) = self.cast_sized_expr_to_unsized_expr(
+            if let Some(expr) = self.cast_to_unsized_expr(
                 src_goto_field_values.get(field).unwrap().clone(),
                 src_mir_field_types.get(field).unwrap(),
                 dst_mir_field_types.get(field).unwrap(),

--- a/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
@@ -677,7 +677,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 dst_mir_type,
             )
         } else {
-            // Assert that the source is not a pointer or is a thing pointer
+            // Assert that the source is not a pointer or is a thin pointer
             assert!(pointee_type(src_mir_type).map_or(true, |p| self.use_thin_pointer(p)));
 
             // Sized to unsized cast

--- a/compiler/rustc_codegen_llvm/src/gotoc/typ.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/typ.rs
@@ -1016,6 +1016,11 @@ pub fn pointee_type(pointer_type: Ty<'tcx>) -> Option<Ty<'tcx>> {
     }
 }
 
+/// Check if the mir type already is a vtable fat pointer.
+pub fn is_dyn_trait_fat_pointer(mir_type: Ty<'tcx>) -> bool {
+    if let Some(p) = pointee_type(mir_type) { p.is_trait() } else { false }
+}
+
 impl<'tcx> GotocCtx<'tcx> {
     /// A pointer to the mir type should be a thin pointer.
     pub fn use_thin_pointer(&self, mir_type: Ty<'tcx>) -> bool {

--- a/src/test/cbmc/DynTrait/any_cast_int.rs
+++ b/src/test/cbmc/DynTrait/any_cast_int.rs
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::any::Any;
+
+// Cast one dynamic trait object type to another, which is legal because Send
+// is an auto trait with no associated function (so the underlying vtable is
+// the same before and after the cast).
+
+// We can also downcast Any to a backing concrete type.
+
+fn downcast_to_concrete(a: &dyn Any) {
+    match a.downcast_ref::<i32>() {
+        Some(i) => {
+            assert!(*i == 7);
+        }
+        None => {
+            assert!(false);
+        }
+    }
+}
+
+fn downcast_to_fewer_traits(s: &(dyn Any + Send)) {
+    let c = s as &dyn Any;
+    downcast_to_concrete(c);
+}
+
+fn main() {
+    let i: i32 = 7;
+    downcast_to_fewer_traits(&i);
+}

--- a/src/test/cbmc/DynTrait/any_cast_int_fail.rs
+++ b/src/test/cbmc/DynTrait/any_cast_int_fail.rs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::any::Any;
+
+include!("../../rmc-prelude.rs");
+
+// Cast one dynamic trait object type to another, which is legal because Send
+// is an auto trait with no associated function (so the underlying vtable is
+// the same before and after the cast).
+
+// We can also downcast Any to a backing concrete type.
+// Inverted assert for _fail test.
+
+fn downcast_to_concrete(a: &dyn Any) {
+    match a.downcast_ref::<i32>() {
+        Some(i) => {
+            __VERIFIER_expect_fail(*i == 8, "Wrong underlying concrete value");
+        }
+        None => {
+            assert!(false);
+        }
+    }
+}
+
+fn downcast_to_fewer_traits(s: &(dyn Any + Send)) {
+    let c = s as &dyn Any;
+    downcast_to_concrete(c);
+}
+
+fn main() {
+    let i: i32 = 7;
+    downcast_to_fewer_traits(&i);
+}

--- a/src/test/cbmc/DynTrait/boxed_debug_cast.rs
+++ b/src/test/cbmc/DynTrait/boxed_debug_cast.rs
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that we can cast &&Box<dyn Error + Send + Sync> to &dyn Debug
+// without panicing
+
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter, Result};
+
+#[derive(Debug)]
+struct Concrete;
+impl Error for Concrete {}
+
+impl Display for Concrete {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        Ok(())
+    }
+}
+
+fn f<'a>(x: &'a &Box<dyn Error + Send + Sync>) -> Box<&'a dyn Debug> {
+    let d = x as &dyn Debug;
+    Box::new(d)
+}
+
+fn main() {
+    let c = Concrete {};
+    let x = Box::new(c) as Box<dyn Error + Send + Sync>;
+    let d = f(&&x);
+}

--- a/src/test/cbmc/DynTrait/main.rs
+++ b/src/test/cbmc/DynTrait/main.rs
@@ -1,5 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+
+include!("../../rmc-prelude.rs");
+
 struct Sheep {}
 struct Cow {}
 
@@ -24,12 +27,20 @@ impl Animal for Cow {
 
 // Returns some struct that implements Animal, but we don't know which one at compile time.
 fn random_animal(random_number: i64) -> Box<dyn Animal> {
-    if random_number < 5 { Box::new(Sheep {}) } else { Box::new(Cow {}) }
+    if random_number < 5 {
+        Box::new(Sheep {})
+    } else {
+        Box::new(Cow {})
+    }
 }
 
 fn main() {
-    let random_number = 1;
+    let random_number = __nondet();
     let animal = random_animal(random_number);
     let s = animal.noise();
-    assert!(s == 1);
+    if (random_number < 5) {
+        assert!(s == 1);
+    } else {
+        assert!(s == 2);
+    }
 }

--- a/src/test/cbmc/DynTrait/main.rs
+++ b/src/test/cbmc/DynTrait/main.rs
@@ -27,11 +27,7 @@ impl Animal for Cow {
 
 // Returns some struct that implements Animal, but we don't know which one at compile time.
 fn random_animal(random_number: i64) -> Box<dyn Animal> {
-    if random_number < 5 {
-        Box::new(Sheep {})
-    } else {
-        Box::new(Cow {})
-    }
+    if random_number < 5 { Box::new(Sheep {}) } else { Box::new(Cow {}) }
 }
 
 fn main() {

--- a/src/test/cbmc/DynTrait/main_fail.rs
+++ b/src/test/cbmc/DynTrait/main_fail.rs
@@ -1,5 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+
+include!("../../rmc-prelude.rs");
+
 struct Sheep {}
 struct Cow {}
 
@@ -28,8 +31,12 @@ fn random_animal(random_number: i64) -> Box<dyn Animal> {
 }
 
 fn main() {
-    let random_number = 1;
+    let random_number = __nondet();
     let animal = random_animal(random_number);
     let s = animal.noise();
-    assert!(s == 3); // Should be == 1
+    if (random_number < 5) {
+        _VERIFIER_expect_fail(s == 2, "Wrong noise");
+    } else {
+        _VERIFIER_expect_fail(s == 1, "Wrong noise");
+    }
 }


### PR DESCRIPTION
### Description of changes: 

We previously assumed that any `PointerCast::Unsize` is from a sized pointer to either a sized or unsized pointer. However, when auto traits (like `Send`) are in play, pointer casts can be _from_ an unsized pointer as well. This is because auto traits have no associated functions, so the underlying vtable does not need to change in a cast from some dynamic trait object reference with an auto trait to another without that trait. For example, this is legal:
```rust
&(dyn Any + Send) -> &dyn Any
```

This change adds a new cast case that essentially copies the source fat pointer to a destination fat pointer where the vtable is casted to the new type.

### Resolved issues:

Resolves #203. 

### Call-outs:

I have a TODO to see if we can actually assert that the difference between the source and destination of the cast differ only by auto traits, I suspect core Rust has a utility for this somewhere.

### Testing:

* How is this change tested?
Existing regression tests, 2 new tests that previously panicked RMC and now passes (pass and fail versions).

* Is this a refactor change?
No. 

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
