### PR TITLE
Added --function flag to cargo-rmc

### DIFF
--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -29,15 +29,11 @@ def main():
     parser.add_argument("--target-dir", default="target",
                         help="Directory for all generated artifacts")
     parser.add_argument("--wkdir", default=".")
+    parser.add_argument("--function", default="main")
     parser.add_argument("crate", help="crate to verify")
     parser.add_argument("cbmc_args", nargs=argparse.REMAINDER,
                         default=[], help="Pass through directly to CBMC")
     args = parser.parse_args()
-
-    # In the future we hope to make this configurable in the command line.
-    # For now, however, changing this from "main" breaks rmc.
-    # Issue: https://github.com/model-checking/rmc/issues/169
-    args.function = "main"
 
     if args.quiet:
         args.verbose = False

--- a/scripts/rmc.py
+++ b/scripts/rmc.py
@@ -117,7 +117,7 @@ def run_visualize(cbmc_filename, cbmc_args, verbose=False, quiet=False, keep_tem
     # 4) cbmc --xml-ui --show-properties ~/rmc/library/rmc/rmc_lib.c temp.goto > property.xml
     # 5) cbmc-viewer --result results.xml --coverage coverage.xml --property property.xml --srcdir . --goto temp.goto --reportdir report
 
-    run_goto_cc(cbmc_filename, temp_goto_filename, verbose, quiet)
+    run_goto_cc(cbmc_filename, temp_goto_filename, verbose, quiet, function=function)
     
     def run_cbmc_local(cbmc_args, output_to):
         cbmc_cmd = ["cbmc"] + cbmc_args + [temp_goto_filename]

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2430,11 +2430,10 @@ impl<'test> TestCx<'test> {
         let function_name = self.testpaths.file.file_stem().unwrap().to_str().unwrap();
         cargo
             .arg("rmc")
+            .args(["--function", function_name])
             .arg("--target")
             .arg(self.output_base_dir().join("target"))
-            .arg(&parent_dir)
-            .arg("--")
-            .args(["--function", function_name]);
+            .arg(&parent_dir);
         self.add_rmc_dir_to_path(&mut cargo);
         let proc_res = self.compose_and_run_compiler(cargo, None);
         let expected = fs::read_to_string(self.testpaths.file.clone()).unwrap();


### PR DESCRIPTION
### Description of changes: 

Currently, we hard-code the entry point for both `rmc` and `cargo-rmc` to be `main` (see #169). However, this issue only applies to `rmc`, not `cargo-rmc`, so we can add the `--function` flag in for `cargo-rmc`.

### Resolved issues:

### Call-outs:

### Testing:

* How is this change tested? Existing regression suite.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
