### PR TITLE
C lib flag

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Get paths for files added
         id: git-diff
         run: |
-          files=$(git diff --name-only --diff-filter=A ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -v -E '(expected|gitignore)$' | xargs)
+          files=$(git diff --name-only --diff-filter=A ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -v -E '(expected|ignore|gitignore)$' | xargs)
           echo "::set-output name=paths::$files"
 
       - name: Execute copyright check

--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -8,6 +8,7 @@ import sys
 import rmc
 import os
 import pathlib
+
 MY_PATH = pathlib.Path(__file__).parent.parent.absolute()
 RMC_C_LIB = MY_PATH / "library" / "rmc" / "rmc_lib.c"
 EXIT_CODE_SUCCESS = 0
@@ -44,9 +45,9 @@ def main():
     args = parser.parse_args()
 
     if args.crate:
-        assert args.crate_flag is None, "Please only provide one crate."
+        assert args.crate_flag is None, "Please provide a single crate to verify."
     else:
-        assert args.crate_flag is not None, "Please provide a crate."
+        assert args.crate_flag is not None, "Please provide a crate to verify."
         args.crate = args.crate_flag
 
     if args.quiet:
@@ -72,6 +73,8 @@ def main():
     if EXIT_CODE_SUCCESS != rmc.symbol_table_to_gotoc(jsons[0], cbmc_filename, args.verbose, args.keep_temps, args.dry_run):
         return 1
 
+    args.c_lib.append(str(RMC_C_LIB))
+
     if EXIT_CODE_SUCCESS != rmc.link_c_lib(cbmc_filename, cbmc_filename, args.c_lib, args.verbose, args.quiet, args.function, args.dry_run):
         return 1
 
@@ -81,8 +84,6 @@ def main():
 
     if "--function" not in args.cbmc_args:
         args.cbmc_args.extend(["--function", args.function])
-        
-    args.cbmc_args.append(str(RMC_C_LIB))
 
     if args.visualize:
         # Use a separate set of flags for coverage checking (empty for now)

--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -72,7 +72,7 @@ def main():
     if EXIT_CODE_SUCCESS != rmc.symbol_table_to_gotoc(jsons[0], cbmc_filename, args.verbose, args.keep_temps, args.dry_run):
         return 1
 
-    if EXIT_CODE_SUCCESS != rmc.run_goto_cc(cbmc_filename, cbmc_filename, args.c_lib, args.verbose, args.quiet, args.function, args.dry_run):
+    if EXIT_CODE_SUCCESS != rmc.link_c_lib(cbmc_filename, cbmc_filename, args.c_lib, args.verbose, args.quiet, args.function, args.dry_run):
         return 1
 
     if args.gen_c:

--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -85,7 +85,9 @@ def main():
     args.cbmc_args.append(str(RMC_C_LIB))
 
     if args.visualize:
-        return rmc.run_visualize(cbmc_filename, args.cbmc_args, \
+        # Use a separate set of flags for coverage checking (empty for now)
+        cover_args = []
+        return rmc.run_visualize(cbmc_filename, args.cbmc_args, cover_args, \
                                  args.verbose, args.quiet, args.keep_temps, \
                                  args.function, args.srcdir, args.wkdir, args.target_dir, args.dry_run)
     else:

--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -82,10 +82,10 @@ def main():
     if "--function" not in args.cbmc_args:
         args.cbmc_args.extend(["--function", args.function])
         
-    args.cbmc_args.extend(args.c_lib)
+    args.cbmc_args.append(str(RMC_C_LIB))
 
     if args.visualize:
-        return rmc.run_visualize(cbmc_filename, args.c_lib, args.cbmc_args, \
+        return rmc.run_visualize(cbmc_filename, args.cbmc_args, \
                                  args.verbose, args.quiet, args.keep_temps, \
                                  args.function, args.srcdir, args.wkdir, args.target_dir, args.dry_run)
     else:

--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -7,8 +7,9 @@ import glob
 import sys
 import rmc
 import os
-
-
+import pathlib
+MY_PATH = pathlib.Path(__file__).parent.parent.absolute()
+RMC_C_LIB = MY_PATH / "library" / "rmc" / "rmc_lib.c"
 EXIT_CODE_SUCCESS = 0
 
 
@@ -18,6 +19,8 @@ def main():
         del sys.argv[1]
 
     parser = argparse.ArgumentParser(description="Verify a Rust crate")
+    parser.add_argument("crate", help="crate to verify", nargs="?")
+    parser.add_argument("--crate", help="crate to verify", dest="crate_flag")
     parser.add_argument("--verbose", "-v", action="store_true")
     parser.add_argument("--quiet", "-q", action="store_true")
     parser.add_argument("--debug", action="store_true")
@@ -25,20 +28,26 @@ def main():
     parser.add_argument("--gen-c", action="store_true")
     parser.add_argument("--mangler", default="v0")
     parser.add_argument("--visualize", action="store_true")
+    parser.add_argument("--c-lib", nargs="*", default=[], action="extend")
     parser.add_argument("--srcdir", default=".")
     parser.add_argument("--target-dir", default="target",
                         help="Directory for all generated artifacts")
     parser.add_argument("--wkdir", default=".")
     parser.add_argument("--function", default="main")
-    parser.add_argument("crate", help="crate to verify")
     parser.add_argument("--no-default-checks", action="store_true", help="Disable all default checks")
     parser.add_argument("--no-memory-safety-checks", action="store_true", help="Disable default memory safety checks")
     parser.add_argument("--no-overflow-checks", action="store_true", help="Disable default overflow checks")
     parser.add_argument("--no-unwinding-checks", action="store_true", help="Disable default unwinding checks")
     parser.add_argument("--dry-run", action="store_true", help="Print commands instead of running them")
-    parser.add_argument("cbmc_args", nargs=argparse.REMAINDER,
+    parser.add_argument("--cbmc-args", nargs=argparse.REMAINDER,
                         default=[], help="Pass through directly to CBMC")
     args = parser.parse_args()
+
+    if args.crate:
+        assert args.crate_flag is None, "Please only provide one crate."
+    else:
+        assert args.crate_flag is not None, "Please provide a crate."
+        args.crate = args.crate_flag
 
     if args.quiet:
         args.verbose = False
@@ -63,15 +72,20 @@ def main():
     if EXIT_CODE_SUCCESS != rmc.symbol_table_to_gotoc(jsons[0], cbmc_filename, args.verbose, args.keep_temps, args.dry_run):
         return 1
 
+    if EXIT_CODE_SUCCESS != rmc.run_goto_cc(cbmc_filename, cbmc_filename, args.c_lib, args.verbose, args.quiet, args.function, args.dry_run):
+        return 1
+
     if args.gen_c:
         if EXIT_CODE_SUCCESS != rmc.goto_to_c(cbmc_filename, c_filename, args.verbose, args.dry_run):
             return 1
 
     if "--function" not in args.cbmc_args:
         args.cbmc_args.extend(["--function", args.function])
+        
+    args.cbmc_args.extend(args.c_lib)
 
     if args.visualize:
-        return rmc.run_visualize(cbmc_filename, args.cbmc_args, \
+        return rmc.run_visualize(cbmc_filename, args.c_lib, args.cbmc_args, \
                                  args.verbose, args.quiet, args.keep_temps, \
                                  args.function, args.srcdir, args.wkdir, args.target_dir, args.dry_run)
     else:

--- a/scripts/rmc
+++ b/scripts/rmc
@@ -90,8 +90,7 @@ def main():
     if "--function" not in args.cbmc_args:
         args.cbmc_args.extend(["--function", args.function])
     
-    args.c_lib.append(str(RMC_C_LIB))
-    args.cbmc_args.extend(args.c_lib)
+    args.cbmc_args.append(str(RMC_C_LIB))
     
     if args.visualize:
         # Use a separate set of flags for coverage checking (empty for now)

--- a/scripts/rmc
+++ b/scripts/rmc
@@ -28,6 +28,8 @@ def main():
     parser.add_argument("--visualize", action="store_true")
     parser.add_argument("--c-lib", nargs="*", default=[], action="extend")
     parser.add_argument("--srcdir", default=".")
+    parser.add_argument("--target-dir", default=".",
+                        help="Directory for all generated artifacts")
     parser.add_argument("--wkdir", default=".")
     parser.add_argument("--no-default-checks", action="store_true", help="Disable all default checks")
     parser.add_argument("--no-memory-safety-checks", action="store_true", help="Disable default memory safety checks")
@@ -97,7 +99,7 @@ def main():
         cover_args = []
         retcode = rmc.run_visualize(goto_filename, args.cbmc_args, cover_args, \
                                     args.verbose, args.quiet, args.keep_temps, \
-                                    args.function, args.srcdir, args.wkdir, args.dry_run)
+                                    args.function, args.srcdir, args.wkdir, args.target_dir, args.dry_run)
     else:
         retcode = rmc.run_cbmc(goto_filename, args.cbmc_args, args.verbose, args.quiet, args.dry_run)
     if retcode == CBMC_VERIFICATION_FAILURE_EXIT_CODE and args.allow_cbmc_verification_failure:

--- a/scripts/rmc
+++ b/scripts/rmc
@@ -7,6 +7,7 @@ import os
 import sys
 import rmc
 import pathlib
+
 MY_PATH = pathlib.Path(__file__).parent.parent.absolute()
 RMC_C_LIB = MY_PATH / "library" / "rmc" / "rmc_lib.c"
 EXIT_CODE_SUCCESS = 0
@@ -46,7 +47,7 @@ def main():
     args.function = "main"
 
     if args.input:
-        assert args.input_flag is None, "Please only provide one file to verify."
+        assert args.input_flag is None, "Please provide a single file to verify."
     else:
         assert args.input_flag is not None, "Please provide a file to verify."
         args.input = args.input_flag
@@ -91,8 +92,6 @@ def main():
 
     if "--function" not in args.cbmc_args:
         args.cbmc_args.extend(["--function", args.function])
-    
-    args.cbmc_args.append(str(RMC_C_LIB))
     
     if args.visualize:
         # Use a separate set of flags for coverage checking (empty for now)

--- a/scripts/rmc
+++ b/scripts/rmc
@@ -15,7 +15,8 @@ CBMC_VERIFICATION_FAILURE_EXIT_CODE = 10
 
 def main():
     parser = argparse.ArgumentParser(description="Verify a single Rust file")
-    parser.add_argument("input", help="Rust file to verify")
+    parser.add_argument("input", help="Rust file to verify", nargs="?")
+    parser.add_argument("--input", help="Rust file to verify", dest="input_flag")
     parser.add_argument("--verbose", "-v", action="store_true")
     parser.add_argument("--quiet", "-q", action="store_true")
     parser.add_argument("--debug", action="store_true")
@@ -25,6 +26,7 @@ def main():
     parser.add_argument("--allow-cbmc-verification-failure", action="store_true")
     parser.add_argument("--mangler", default="v0")
     parser.add_argument("--visualize", action="store_true")
+    parser.add_argument("--c-lib", nargs="*", default=[], action="extend")
     parser.add_argument("--srcdir", default=".")
     parser.add_argument("--wkdir", default=".")
     parser.add_argument("--no-default-checks", action="store_true", help="Disable all default checks")
@@ -32,7 +34,7 @@ def main():
     parser.add_argument("--no-overflow-checks", action="store_true", help="Disable default overflow checks")
     parser.add_argument("--no-unwinding-checks", action="store_true", help="Disable default unwinding checks")
     parser.add_argument("--dry-run", action="store_true", help="Print commands instead of running them")
-    parser.add_argument("cbmc_args", nargs=argparse.REMAINDER,
+    parser.add_argument("--cbmc-args", nargs=argparse.REMAINDER,
                         default=[], help="Pass through directly to CBMC")
     args = parser.parse_args()
 
@@ -40,6 +42,12 @@ def main():
     # For now, however, changing this from "main" breaks rmc.
     # Issue: https://github.com/model-checking/rmc/issues/169
     args.function = "main"
+
+    if args.input:
+        assert args.input_flag is None, "Please only provide one file to verify."
+    else:
+        assert args.input_flag is not None, "Please provide a file to verify."
+        args.input = args.input_flag
     
     if args.quiet:
         args.verbose = False
@@ -66,6 +74,11 @@ def main():
     if EXIT_CODE_SUCCESS != rmc.symbol_table_to_gotoc(json_filename, goto_filename, args.verbose, args.keep_temps, args.dry_run):
         return 1
 
+    args.c_lib.append(str(RMC_C_LIB))
+
+    if EXIT_CODE_SUCCESS != rmc.run_goto_cc(goto_filename, goto_filename, args.c_lib, args.verbose, args.quiet, args.function, args.dry_run):
+        return 1
+
     if args.gen_c:
         if EXIT_CODE_SUCCESS != rmc.goto_to_c(goto_filename, c_filename, args.verbose, args.dry_run):
             return 1
@@ -77,7 +90,9 @@ def main():
     if "--function" not in args.cbmc_args:
         args.cbmc_args.extend(["--function", args.function])
     
-    args.cbmc_args.append(str(RMC_C_LIB))
+    args.c_lib.append(str(RMC_C_LIB))
+    args.cbmc_args.extend(args.c_lib)
+    
     if args.visualize:
         # Use a separate set of flags for coverage checking (empty for now)
         cover_args = []

--- a/scripts/rmc
+++ b/scripts/rmc
@@ -76,7 +76,7 @@ def main():
 
     args.c_lib.append(str(RMC_C_LIB))
 
-    if EXIT_CODE_SUCCESS != rmc.run_goto_cc(goto_filename, goto_filename, args.c_lib, args.verbose, args.quiet, args.function, args.dry_run):
+    if EXIT_CODE_SUCCESS != rmc.link_c_lib(goto_filename, goto_filename, args.c_lib, args.verbose, args.quiet, args.function, args.dry_run):
         return 1
 
     if args.gen_c:

--- a/scripts/rmc.py
+++ b/scripts/rmc.py
@@ -161,6 +161,10 @@ def symbol_table_to_gotoc(json_filename, cbmc_filename, verbose=False, keep_temp
     cmd = ["symtab2gb", json_filename, "--out", cbmc_filename]
     return run_cmd(cmd, label="to-gotoc", verbose=verbose, dry_run=dry_run)
 
+def run_goto_cc(src, dst, c_lib, verbose=False, quiet=False, function="main", dry_run=False):
+    cmd = ["goto-cc"] + ["--function", function] + [src] + c_lib + ["-o", dst]
+    return run_cmd(cmd, label="goto-cc", verbose=verbose, quiet=quiet, dry_run=dry_run)
+
 def run_cbmc(cbmc_filename, cbmc_args, verbose=False, quiet=False, dry_run=False):
     cbmc_cmd = ["cbmc"] + cbmc_args + [cbmc_filename]
     scanners = []
@@ -186,8 +190,6 @@ def run_visualize(cbmc_filename, prop_args, cover_args, verbose=False, quiet=Fal
     # 4) cbmc --xml-ui --show-properties ~/rmc/library/rmc/rmc_lib.c temp.goto > property.xml
     # 5) cbmc-viewer --result results.xml --coverage coverage.xml --property property.xml --srcdir . --goto temp.goto --reportdir report
 
-    run_goto_cc(cbmc_filename, temp_goto_filename, verbose, quiet, function=function, dry_run=dry_run)
-    
     def run_cbmc_local(cbmc_args, output_to, dry_run=False):
         cbmc_cmd = ["cbmc"] + cbmc_args + [temp_goto_filename]
         return run_cmd(cbmc_cmd, label="cbmc", output_to=output_to, verbose=verbose, quiet=quiet, dry_run=dry_run)
@@ -203,10 +205,6 @@ def run_visualize(cbmc_filename, prop_args, cover_args, verbose=False, quiet=Fal
                     property_filename, verbose, quiet, srcdir, wkdir, os.path.join(outdir, "report"), dry_run=dry_run)
 
     return retcode
-
-def run_goto_cc(src, dst, verbose=False, quiet=False, function="main", dry_run=False):
-    cmd = ["goto-cc"] + ["--function", function] + [src] + ["-o", dst]
-    return run_cmd(cmd, label="goto-cc", verbose=verbose, quiet=quiet, dry_run=dry_run)
 
 def run_cbmc_viewer(goto_filename, results_filename, coverage_filename, property_filename, verbose=False, quiet=False, srcdir=".", wkdir=".", reportdir="report", dry_run=False):
     cmd = ["cbmc-viewer"] + \

--- a/scripts/rmc.py
+++ b/scripts/rmc.py
@@ -161,7 +161,7 @@ def symbol_table_to_gotoc(json_filename, cbmc_filename, verbose=False, keep_temp
     cmd = ["symtab2gb", json_filename, "--out", cbmc_filename]
     return run_cmd(cmd, label="to-gotoc", verbose=verbose, dry_run=dry_run)
 
-def run_goto_cc(src, dst, c_lib, verbose=False, quiet=False, function="main", dry_run=False):
+def link_c_lib(src, dst, c_lib, verbose=False, quiet=False, function="main", dry_run=False):
     cmd = ["goto-cc"] + ["--function", function] + [src] + c_lib + ["-o", dst]
     return run_cmd(cmd, label="goto-cc", verbose=verbose, quiet=quiet, dry_run=dry_run)
 

--- a/scripts/rmc.py
+++ b/scripts/rmc.py
@@ -179,19 +179,17 @@ def run_visualize(cbmc_filename, prop_args, cover_args, verbose=False, quiet=Fal
     results_filename = os.path.join(outdir, "results.xml")
     coverage_filename = os.path.join(outdir, "coverage.xml")
     property_filename = os.path.join(outdir, "property.xml")
-    temp_goto_filename = os.path.join(outdir, "temp.goto")
     if not keep_temps:
-        for filename in [results_filename, coverage_filename, property_filename, temp_goto_filename]:
+        for filename in [results_filename, coverage_filename, property_filename]:
             atexit.register(delete_file, filename)
 
-    # 1) goto-cc --function main <cbmc_filename> -o temp.goto
-    # 2) cbmc --xml-ui --trace ~/rmc/library/rmc/rmc_lib.c temp.goto > results.xml
-    # 3) cbmc --xml-ui --cover location ~/rmc/library/rmc/rmc_lib.c temp.goto > coverage.xml
-    # 4) cbmc --xml-ui --show-properties ~/rmc/library/rmc/rmc_lib.c temp.goto > property.xml
-    # 5) cbmc-viewer --result results.xml --coverage coverage.xml --property property.xml --srcdir . --goto temp.goto --reportdir report
-
+    # 1) cbmc --xml-ui --trace ~/rmc/library/rmc/rmc_lib.c <cbmc_filename> > results.xml
+    # 2) cbmc --xml-ui --cover location ~/rmc/library/rmc/rmc_lib.c <cbmc_filename> > coverage.xml
+    # 3) cbmc --xml-ui --show-properties ~/rmc/library/rmc/rmc_lib.c <cbmc_filename> > property.xml
+    # 4) cbmc-viewer --result results.xml --coverage coverage.xml --property property.xml --srcdir . --goto <cbmc_filename> --reportdir report
+    
     def run_cbmc_local(cbmc_args, output_to, dry_run=False):
-        cbmc_cmd = ["cbmc"] + cbmc_args + [temp_goto_filename]
+        cbmc_cmd = ["cbmc"] + cbmc_args + [cbmc_filename]
         return run_cmd(cbmc_cmd, label="cbmc", output_to=output_to, verbose=verbose, quiet=quiet, dry_run=dry_run)
 
     cbmc_prop_args = prop_args + ["--xml-ui"]
@@ -201,7 +199,7 @@ def run_visualize(cbmc_filename, prop_args, cover_args, verbose=False, quiet=Fal
     run_cbmc_local(cbmc_cover_args + ["--cover", "location"], coverage_filename, dry_run=dry_run)
     run_cbmc_local(cbmc_prop_args + ["--show-properties"], property_filename, dry_run=dry_run)
 
-    run_cbmc_viewer(temp_goto_filename, results_filename, coverage_filename,
+    run_cbmc_viewer(cbmc_filename, results_filename, coverage_filename,
                     property_filename, verbose, quiet, srcdir, wkdir, os.path.join(outdir, "report"), dry_run=dry_run)
 
     return retcode

--- a/src/test/cargo-rmc/simple-extern/Cargo.toml
+++ b/src/test/cargo-rmc/simple-extern/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "simple-lib"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+
+[workspace]

--- a/src/test/cargo-rmc/simple-extern/Cargo.toml
+++ b/src/test/cargo-rmc/simple-extern/Cargo.toml
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 [package]
 name = "simple-lib"
 version = "0.1.0"

--- a/src/test/cargo-rmc/simple-extern/src/externs.rs
+++ b/src/test/cargo-rmc/simple-extern/src/externs.rs
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+extern "C" {
+    pub fn external_c_assertion(i: u32) -> u32;
+}
+
+#[no_mangle]
+pub extern "C" fn rust_add1(i: u32) -> u32 {
+    i + 1
+}

--- a/src/test/cargo-rmc/simple-extern/src/helper.c
+++ b/src/test/cargo-rmc/simple-extern/src/helper.c
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#include <stdint.h>
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+uint32_t rust_add1(uint32_t i);
+
+uint32_t external_c_assertion(uint32_t x) {
+    assert(rust_add1(x) == x + 1);
+    return 0;
+}

--- a/src/test/cargo-rmc/simple-extern/src/lib.rs
+++ b/src/test/cargo-rmc/simple-extern/src/lib.rs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pub mod externs;
+pub use externs::external_c_assertion;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        unsafe {
+            external_c_assertion(12);
+        }
+    }
+}
+
+#[cfg(rmc)]
+mod rmc_tests {
+    use super::*;
+
+    fn __nondet<T>() -> T {
+        unimplemented!()
+    }
+    #[allow(dead_code)]
+    #[no_mangle]
+    fn test_sum() {
+        let a: u32 = __nondet();
+
+        if a < 100 {
+            unsafe {
+                external_c_assertion(a);
+            }
+        }
+    }
+}

--- a/src/test/cargo-rmc/simple-extern/test_sum.ignore
+++ b/src/test/cargo-rmc/simple-extern/test_sum.ignore
@@ -1,0 +1,1 @@
+[call_into_rust.assertion.1] line 13 assertion takes_int(x) == x + 1: SUCCESS

--- a/src/test/cbmc/ForeignItems/lib.c
+++ b/src/test/cbmc/ForeignItems/lib.c
@@ -84,7 +84,7 @@ uint32_t takes_struct_ptr(struct Foo* f) {
 
 uint32_t takes_struct2(struct Foo2 f) {
     assert(sizeof(unsigned int) == sizeof(uint32_t));
-    return f.i + f.c;
+    return f.i + f.i2;
 }
 
 uint32_t takes_struct_ptr2(struct Foo2* f) {

--- a/src/test/cbmc/ForeignItems/main.rs
+++ b/src/test/cbmc/ForeignItems/main.rs
@@ -5,16 +5,12 @@
 
 // rmc-flags: --c-lib src/test/cbmc/ForeignItems/lib.c
 
-// TODO, we should also test packed and transparent representations
-// https://doc.rust-lang.org/reference/type-layout.html
 #[repr(C)]
 pub struct Foo {
     i: u32,
     c: u8,
 }
 
-// TODO:
-//#[repr(packed)]
 #[repr(C)]
 pub struct Foo2 {
     i: u32,
@@ -25,19 +21,11 @@ pub struct Foo2 {
 // https://doc.rust-lang.org/reference/items/external-blocks.html
 // https://doc.rust-lang.org/nomicon/ffi.html
 extern "C" {
-    // NOTE: this currently works even if I don't make S static, but is UB.
-    // We should have a check for that.
     static mut S: u32;
 
     fn update_static();
     fn takes_int(i: u32) -> u32;
     fn takes_ptr(p: &u32) -> u32;
-    // In rust, you say nullable pointer by using option of reference.
-    // Rust guarantees that this has the bitwise represntation
-    // Some(&x) => &x;
-    // None => NULL;
-    // FIXME: we need to notice when this happens and do a bitcast, or C is unhappy
-    // https://github.com/model-checking/rmc/issues/3
     fn takes_ptr_option(p: Option<&u32>) -> u32;
     fn mutates_ptr(p: &mut u32);
     #[link_name = "name_in_c"]

--- a/src/test/cbmc/ForeignItems/main.rs
+++ b/src/test/cbmc/ForeignItems/main.rs
@@ -3,7 +3,7 @@
 //! To run this test, do
 //! rmc fixme_main.rs -- lib.c
 
-// rmc-flags: --c-lib lib.c
+// rmc-flags: --c-lib src/test/cbmc/ForeignItems/lib.c
 
 // TODO, we should also test packed and transparent representations
 // https://doc.rust-lang.org/reference/type-layout.html
@@ -56,8 +56,7 @@ fn main() {
 
         assert!(takes_int(1) == 3);
         assert!(takes_ptr(&5) == 7);
-        //assert!(takes_ptr_option(Some(&5)) == 4);
-        //assert!(takes_ptr_option(None) == 0);
+
         let mut p = 17;
         mutates_ptr(&mut p);
         assert!(p == 16);

--- a/src/test/cbmc/ForeignItems/main.rs
+++ b/src/test/cbmc/ForeignItems/main.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! To run this test, do
-//! rmc fixme_main.rs -- lib.c
+//! rmc main.rs -- lib.c
 
 // rmc-flags: --c-lib src/test/cbmc/ForeignItems/lib.c
 

--- a/src/test/cbmc/ForeignItems/main.rs
+++ b/src/test/cbmc/ForeignItems/main.rs
@@ -69,6 +69,6 @@ fn main() {
 
         let f2 = Foo2 { i: 12, c: 7, i2: 8 };
         assert!(takes_struct_ptr2(&f2) == 19);
-        assert!(takes_struct2(f2) == 19);
+        assert!(takes_struct2(f2) == 20);
     }
 }

--- a/src/test/cbmc/VolatileIntrinsics/main.rs
+++ b/src/test/cbmc/VolatileIntrinsics/main.rs
@@ -1,9 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![feature(core_intrinsics)]
-/// rmc main.rs --cbmc-args --unwind 20 --unwinding-assertions
-// rmc-flags:
-// cbmc-flags: --unwind 20 --unwinding-assertions
+
 use std::mem;
 use std::ptr;
 // https://doc.rust-lang.org/std/ptr/fn.write_volatile.html

--- a/src/test/cbmc/VolatileIntrinsics/main.rs
+++ b/src/test/cbmc/VolatileIntrinsics/main.rs
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![feature(core_intrinsics)]
-/// rmc main.rs -- --unwind 20 --unwinding-assertions
+/// rmc main.rs --cbmc-args --unwind 20 --unwinding-assertions
+// rmc-flags:
+// cbmc-flags: --unwind 20 --unwinding-assertions
 use std::mem;
 use std::ptr;
 // https://doc.rust-lang.org/std/ptr/fn.write_volatile.html

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2413,8 +2413,9 @@ impl<'test> TestCx<'test> {
         let mut rmc = Command::new("rmc");
         // Pass the test path along with RMC and CBMC flags parsed from comments at the top of the test file.
         rmc.args(&self.props.rmc_flags)
+            .arg("--input")
             .arg(&self.testpaths.file)
-            .arg("--")
+            .arg("--cbmc-args")
             .args(&self.props.cbmc_flags);
         self.add_rmc_dir_to_path(&mut rmc);
         let proc_res = self.compose_and_run_compiler(rmc, None);
@@ -2486,6 +2487,7 @@ impl<'test> TestCx<'test> {
             .args(["--function", function_name])
             .arg("--target")
             .arg(self.output_base_dir().join("target"))
+            .arg("--crate")
             .arg(&parent_dir);
         self.add_rmc_dir_to_path(&mut cargo);
         let proc_res = self.compose_and_run_compiler(cargo, None);
@@ -2501,8 +2503,9 @@ impl<'test> TestCx<'test> {
         let mut rmc = Command::new("rmc");
         // Pass the test path along with RMC and CBMC flags parsed from comments at the top of the test file.
         rmc.args(&self.props.rmc_flags)
+            .arg("--input")
             .arg(&self.testpaths.file)
-            .arg("--")
+            .arg("--cbmc-args")
             .args(&self.props.cbmc_flags);
         self.add_rmc_dir_to_path(&mut rmc);
         let proc_res = self.compose_and_run_compiler(rmc, None);


### PR DESCRIPTION
### Description of changes: 

Currently, to pass external C files to RMC, you have to pass them as CBMC flags. Additionally, this caused them to not be added to the symbol table, and so linking did not work properly in visualizer reports.

This patch adds a `--c-lib` flag to both `rmc` and `cargo-rmc`, additionally fixing the missing links to external C files in the visualizer.

Example usage:

```
rmc --c-lib helper.c -- main.rs
rmc --c-lib helper.c --end-rmc-flags main.rs
rmc --c-lib helper.c --visualize main.rs
rmc --c-lib helper.c --end-rmc-flags main.rs -- --show-symbol-table
rmc --c-lib helper.c --visualize main.rs -- --show-symbol-table

cargo-rmc --function test_sum --c-lib src/helper.c -- .
cargo-rmc --function test_sum --c-lib src/helper.c --end-rmc-flags .
cargo-rmc --function test_sum --c-lib src/helper.c --visualize .
cargo-rmc --function test_sum --c-lib src/helper.c --end-rmc-flags . -- --show-symbol-table
cargo-rmc --function test_sum --c-lib src/helper.c --visualize . -- --show-symbol-table
```

### Resolved issues:

Resolves #246 

### Call-outs:

There is not test for the `--c-lib` flag for `cargo-rmc` since there is no way of writing such a test.

### Testing:

* How is this change tested? Existing regression suite with new `rmc` test.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
