### PR TITLE
Implement `sizeof` for `Code` for vtable generation (fix crash)

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
@@ -809,6 +809,7 @@ impl<'tcx> GotocCtx<'tcx> {
     fn codegen_vtable_size_and_align(&self, operand_type: Ty<'tcx>) -> (Expr, Expr) {
         debug!("vtable_size_and_align {:?}", operand_type.kind());
         let vtable_layout = self.layout_of(operand_type);
+        assert!(!vtable_layout.is_unsized(), "Can't create a vtable for an unsized type");
         let vt_size = Expr::int_constant(vtable_layout.size.bytes(), Type::size_t());
         let vt_align = Expr::int_constant(vtable_layout.align.abi.bytes(), Type::size_t());
 

--- a/src/test/cbmc/DynTrait/dyn_fn_param.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param.rs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that we can pass a dyn function pointer to a stand alone
+// function definition
+
+#![feature(raw)]
+#![allow(deprecated)]
+
+include!("../Helpers/vtable_utils_ignore.rs");
+
+fn takes_dyn_fun(fun: &dyn Fn() -> u32) {
+    let x = fun();
+    assert!(x == 5);
+
+    /* The function dynamic object has no associated data */
+    assert!(size_from_vtable(vtable!(fun)) == 0);
+}
+
+pub fn unit_to_u32() -> u32 {
+    5 as u32
+}
+
+fn main() {
+    takes_dyn_fun(&unit_to_u32)
+}

--- a/src/test/cbmc/DynTrait/dyn_fn_param_closure.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_closure.rs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that we can pass a dyn function pointer to a simple closure
+#![feature(raw)]
+#![allow(deprecated)]
+
+include!("../Helpers/vtable_utils_ignore.rs");
+
+fn takes_dyn_fun(fun: &dyn Fn() -> i32) {
+    let x = fun();
+    assert!(x == 5);
+    /* The closure does not capture anything and thus has zero size */
+    assert!(size_from_vtable(vtable!(fun)) == 0);
+}
+fn main() {
+    let closure = || 5;
+    takes_dyn_fun(&closure)
+}

--- a/src/test/cbmc/DynTrait/dyn_fn_param_closure_capture.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_closure_capture.rs
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that we can pass a dyn function pointer to a closure that captures
+// some data
+#![feature(raw)]
+#![allow(deprecated)]
+
+include!("../Helpers/vtable_utils_ignore.rs");
+
+fn takes_dyn_fun(fun: &dyn Fn() -> i32) {
+    let x = fun();
+    assert!(x == 5);
+    /* The closure captures `a` and thus has nonzero size */
+    assert!(size_from_vtable(vtable!(fun)) == 8);
+}
+
+fn main() {
+    let a = vec![3];
+    let closure = || a[0] + 2;
+    takes_dyn_fun(&closure)
+}

--- a/src/test/cbmc/DynTrait/dyn_fn_param_closure_capture_fail.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_closure_capture_fail.rs
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that we can pass a dyn function pointer to a closure that captures
+// some data
+#![feature(raw)]
+#![allow(deprecated)]
+
+include!("../Helpers/vtable_utils_ignore.rs");
+include!("../../rmc-prelude.rs");
+
+fn takes_dyn_fun(fun: &dyn Fn() -> i32) {
+    let x = fun();
+    __VERIFIER_expect_fail(x != 5, "Wrong return");
+    /* The closure captures `a` and thus is sized */
+    __VERIFIER_expect_fail(size_from_vtable(vtable!(fun)) == 8, "Wrong size");
+}
+
+fn main() {
+    let a = vec![3];
+    let closure = || a[0] + 2;
+    takes_dyn_fun(&closure)
+}

--- a/src/test/cbmc/DynTrait/dyn_fn_param_closure_fail.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_closure_fail.rs
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that we can pass a dyn function pointer to a simple closure
+#![feature(raw)]
+#![allow(deprecated)]
+
+include!("../Helpers/vtable_utils_ignore.rs");
+include!("../../rmc-prelude.rs");
+
+fn takes_dyn_fun(fun: &dyn Fn() -> i32) {
+    let x = fun();
+    __VERIFIER_expect_fail(x != 5, "Wrong return");
+    /* The closure does not capture anything and thus has zero size */
+    __VERIFIER_expect_fail(size_from_vtable(vtable!(fun)) != 0, "Wrong size");
+}
+fn main() {
+    let closure = || 5;
+    takes_dyn_fun(&closure)
+}

--- a/src/test/cbmc/DynTrait/dyn_fn_param_fail_fixme.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_fail_fixme.rs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that we can pass a dyn function pointer to a stand alone
+// function definition. Inverted negative test.
+
+// FIXME https://github.com/model-checking/rmc/issues/240
+
+#![feature(raw)]
+#![allow(deprecated)]
+
+include!("../Helpers/vtable_utils_ignore.rs");
+include!("../../rmc-prelude.rs");
+
+fn takes_dyn_fun(fun: &dyn Fn() -> u32) {
+    let x = fun();
+    __VERIFIER_expect_fail(x != 5, "Wrong return");
+    
+    /* The function dynamic object has no associated data */
+    __VERIFIER_expect_fail(size_from_vtable(vtable!(fun)) != 0, "Wrong size");
+}
+
+pub fn unit_to_u32() -> u32 {
+    assert!(false);
+    5 as u32
+}
+
+fn main() {
+    takes_dyn_fun(&unit_to_u32)
+}

--- a/src/test/cbmc/DynTrait/nested_boxes.rs
+++ b/src/test/cbmc/DynTrait/nested_boxes.rs
@@ -9,8 +9,6 @@
 #![allow(deprecated)]
 
 use std::intrinsics::size_of;
-use std::mem::transmute;
-use std::raw::TraitObject;
 
 include!("../Helpers/vtable_utils_ignore.rs");
 
@@ -26,16 +24,15 @@ fn main() {
 
     // Do some unsafe magic to check that we generate the right three vtables
     unsafe {
-        let trait_object3: TraitObject = transmute(dyn_trait3);
-
         // Outermost trait object
         // The size is 16, because the data is another fat pointer
-        let vtable3: *mut usize = trait_object3.vtable as *mut usize;
+        let dyn_3 = &*dyn_trait3 as &dyn Send;
+        let vtable3: *mut usize = vtable!(dyn_3);
         assert!(size_from_vtable(vtable3) == 16);
         assert!(align_from_vtable(vtable3) == 8);
 
         // Inspect the data pointer from dyn_trait3
-        let data_ptr3 = trait_object3.data as *mut usize;
+        let data_ptr3 = data!(dyn_3) as *mut usize;
 
         // The second half of this fat pointer is another vtable, for dyn_trait2
         let vtable2 = *(data_ptr3.offset(1) as *mut *mut usize);

--- a/src/test/cbmc/DynTrait/nested_boxes_fail.rs
+++ b/src/test/cbmc/DynTrait/nested_boxes_fail.rs
@@ -9,10 +9,7 @@
 #![feature(raw)]
 #![allow(deprecated)]
 
-use std::fs::File;
 use std::intrinsics::size_of;
-use std::mem::transmute;
-use std::raw::TraitObject;
 
 include!("../Helpers/vtable_utils_ignore.rs");
 
@@ -28,16 +25,14 @@ fn main() {
 
     // Do some unsafe magic to check that we generate the right three vtables
     unsafe {
-        let trait_object3: TraitObject = transmute(dyn_trait3);
-
         // Outermost trait object
         // The size is 16, because the data is another fat pointer
-        let vtable3: *mut usize = trait_object3.vtable as *mut usize;
+        let vtable3: *mut usize = vtable!(dyn_trait3);
         assert!(size_from_vtable(vtable3) != 16);
         assert!(align_from_vtable(vtable3) != 8);
 
         // Inspect the data pointer from dyn_trait3
-        let data_ptr3 = trait_object3.data as *mut usize;
+        let data_ptr3 = data!(dyn_trait3) as *mut usize;
 
         // The second half of this fat pointer is another vtable, for dyn_trait2
         let vtable2 = *(data_ptr3.offset(1) as *mut *mut usize);

--- a/src/test/cbmc/DynTrait/vtable_size_align_drop.rs
+++ b/src/test/cbmc/DynTrait/vtable_size_align_drop.rs
@@ -11,11 +11,10 @@
 #![allow(deprecated)]
 
 use std::intrinsics::size_of;
-use std::mem::transmute;
 use std::ptr::drop_in_place;
-use std::raw::TraitObject;
 
 include!("../Helpers/vtable_utils_ignore.rs");
+include!("../../rmc-prelude.rs");
 
 // Different sized data fields on each struct
 struct Sheep {
@@ -66,21 +65,18 @@ fn main() {
 
     // Check layout/values for Sheep
     unsafe {
-        let animal_sheep = random_animal(1);
-
-        // Unsafe cast to dynamic trait object fat pointer
-        let trait_object: TraitObject = transmute(animal_sheep);
+        let animal_sheep = &*random_animal(1);
 
         // Check that the struct's data is what we expect
-        let data_ptr = trait_object.data;
+        let data_ptr = data!(animal_sheep);
 
         // Note: i32 ptr cast
         assert!(*(data_ptr as *mut i32) == 7); // From Sheep
 
-        let vtable_ptr = trait_object.vtable as *mut usize;
+        let vtable_ptr = vtable!(animal_sheep);
 
         // Drop pointer
-        assert!(drop_from_vtrable(vtable_ptr) == drop_in_place::<Sheep> as *mut ());
+        assert!(drop_from_vtable(vtable_ptr) == drop_in_place::<Sheep> as *mut ());
 
         // Size and align as usizes
         assert!(size_from_vtable(vtable_ptr) == size_of::<i32>());
@@ -88,21 +84,18 @@ fn main() {
     }
     // Check layout/values for Cow
     unsafe {
-        let animal_cow = random_animal(6);
-
-        // Unsafe cast to dynamic trait object fat pointer
-        let trait_object: TraitObject = transmute(animal_cow);
+        let animal_cow = &*random_animal(6);
 
         // Check that the struct's data is what we expect
-        let data_ptr = trait_object.data;
+        let data_ptr = data!(animal_cow);
 
         // Note: i8 ptr cast
         assert!(*(data_ptr as *mut i8) == 9); // From Cow
 
-        let vtable_ptr = trait_object.vtable as *mut usize;
+        let vtable_ptr = vtable!(animal_cow);
 
         // Drop pointer
-        assert!(drop_from_vtrable(vtable_ptr) == drop_in_place::<Cow> as *mut ());
+        assert!(drop_from_vtable(vtable_ptr) == drop_in_place::<Cow> as *mut ());
 
         // Size and align as usizes
         assert!(size_from_vtable(vtable_ptr) == size_of::<i8>());

--- a/src/test/cbmc/DynTrait/vtable_size_align_drop_fail.rs
+++ b/src/test/cbmc/DynTrait/vtable_size_align_drop_fail.rs
@@ -13,9 +13,6 @@
 #![allow(deprecated)]
 
 use std::intrinsics::size_of;
-use std::mem::transmute;
-use std::ptr::drop_in_place;
-use std::raw::TraitObject;
 
 include!("../Helpers/vtable_utils_ignore.rs");
 include!("../../rmc-prelude.rs");
@@ -73,20 +70,17 @@ fn main() {
     unsafe {
         let animal_sheep = random_animal(1);
 
-        // Unsafe cast to dynamic trait object fat pointer
-        let trait_object: TraitObject = transmute(animal_sheep);
-
         // Check that the struct's data is what we expect
-        let data_ptr = trait_object.data;
+        let data_ptr = data!(animal_sheep);
 
         // Note: i32 ptr cast
         __VERIFIER_expect_fail(*(data_ptr as *mut i32) != 7, "Wrong data"); // From Sheep
 
-        let vtable_ptr = trait_object.vtable as *mut usize;
+        let vtable_ptr = vtable!(animal_sheep);
 
         // Drop pointer
         __VERIFIER_expect_fail(
-            drop_from_vtrable(vtable_ptr) != drop_in_place::<Sheep> as *mut (),
+            drop_from_vtable(vtable_ptr) != drop_in_place::<Sheep> as *mut (),
             "Wrong drop",
         );
 
@@ -96,22 +90,19 @@ fn main() {
     }
     // Check layout/values for Cow
     unsafe {
-        let animal_cow = random_animal(6);
-
-        // Unsafe cast to dynamic trait object fat pointer
-        let trait_object: TraitObject = transmute(animal_cow);
+        let animal_sheep = random_animal(1);
 
         // Check that the struct's data is what we expect
-        let data_ptr = trait_object.data;
+        let data_ptr = data!(animal_sheep);
 
         // Note: i8 ptr cast
         __VERIFIER_expect_fail(*(data_ptr as *mut i8) != 9, "Wrong data"); // From Cow
 
-        let vtable_ptr = trait_object.vtable as *mut usize;
+        let vtable_ptr = vtable!(animal_sheep);
 
         // Drop pointer
         __VERIFIER_expect_fail(
-            drop_from_vtrable(vtable_ptr) != drop_in_place::<Cow> as *mut (),
+            drop_from_vtable(vtable_ptr) != drop_in_place::<Cow> as *mut (),
             "Wrong drop",
         );
 

--- a/src/test/cbmc/FatPointers/boxmuttrait.rs
+++ b/src/test/cbmc/FatPointers/boxmuttrait.rs
@@ -5,8 +5,6 @@
 #![allow(deprecated)]
 
 use std::io::{sink, Write};
-use std::mem::transmute;
-use std::raw::TraitObject;
 
 include!("../Helpers/vtable_utils_ignore.rs");
 
@@ -21,17 +19,16 @@ fn main() {
 
     // Do some unsafe magic to check that we generate the right two vtables
     unsafe {
-        let dest_trait_object: TraitObject = transmute(&*dest);
-
         // The vtable has [&drop, size, align, ....]
-        let dest_vtable_ptr = dest_trait_object.vtable as *mut usize;
+        let dest_ptr = &*dest;
+        let dest_vtable_ptr = vtable!(dest_ptr);
 
         // The size is 16, because the data is another fat pointer
         assert!(size_from_vtable(dest_vtable_ptr) == 16);
         assert!(align_from_vtable(dest_vtable_ptr) == 8);
 
         // Inspect the data pointer from dest
-        let dest_data_ptr = dest_trait_object.data as *mut usize;
+        let dest_data_ptr = data!(dest_ptr) as *mut usize;
 
         // // The second half of this fat pointer is another vtable, for log
         let second_vtable_ptr = dest_data_ptr.offset(1) as *mut *mut usize;

--- a/src/test/cbmc/Helpers/vtable_utils_ignore.rs
+++ b/src/test/cbmc/Helpers/vtable_utils_ignore.rs
@@ -3,7 +3,27 @@
 
 // Because each regression test does not share a crate, we just use
 // an import! to share this code across test directories.
-fn drop_from_vtrable(vtable_ptr: *mut usize) -> *mut () {
+
+// Macro rules because we can't cast between incompatible dyn trait fat pointer types
+macro_rules! vtable {
+    ($f:ident) => {{
+        unsafe {
+            let trait_object: std::raw::TraitObject = std::mem::transmute($f);
+            trait_object.vtable as *mut usize
+        }
+    }};
+}
+
+macro_rules! data {
+    ($f:ident) => {{
+        unsafe {
+            let trait_object: std::raw::TraitObject = std::mem::transmute($f);
+            trait_object.data as *mut ()
+        }
+    }};
+}
+
+fn drop_from_vtable(vtable_ptr: *mut usize) -> *mut () {
     // 1st pointer-sized position
     unsafe { *vtable_ptr as *mut () }
 }


### PR DESCRIPTION
### Description of changes: 

When passing a standalone function name as a dyn trait object parameter, we correctly generate a vtable with `size = 0`. The `sizeof_in_bits` should match this behavior for `Code`, consistent with how rustc handles the layout of the `ty::FnDef` type.


### Resolved issues:

Resolves https://github.com/model-checking/rmc/issues/259

### Call-outs:

- Found more cases of unsoundness for passing functions as dyn objects: https://github.com/model-checking/rmc/issues/240
- Some cleanup edits to other `DynTrait` tests.

### Testing:

* How is this change tested?

3 new tests + 2 _fail tests + 1 _fail _fixme test. 

* Is this a refactor change?

No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
