### PR TITLE
Regression test for codegen'ing Firecracker

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -16,7 +16,7 @@ jobs:
         id: git-diff
         run: |
           ignore='(.md|expected|ignore|gitignore)$'
-          files=$(git diff --name-only --diff-filter=A ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -v -E $ignore | xargs)
+          files=$(git diff --ignore-submodules=all --name-only --diff-filter=A ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -v -E $ignore | xargs)
           echo "::set-output name=paths::$files"
 
       - name: Execute copyright check

--- a/.gitmodules
+++ b/.gitmodules
@@ -44,3 +44,6 @@
 [submodule "library/backtrace"]
 	path = library/backtrace
 	url = https://github.com/rust-lang/backtrace-rs.git
+[submodule "firecracker"]
+	path = firecracker
+	url = https://github.com/firecracker-microvm/firecracker.git

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -42,4 +42,7 @@ ignore = [
     "src/tools/rust-analyzer",
     "src/tools/rustfmt",
     "src/tools/rust-installer",
+
+    # do not format Firecracker regression
+    "firecracker",
 ]

--- a/scripts/codegen-firecracker.sh
+++ b/scripts/codegen-firecracker.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Test for platform
+platform=`uname -sp`
+if [[ $platform != "Linux x86_64" ]]; then
+  echo "Codegen script only works on Linux x86 platform"
+  exit 0
+fi
+
+# At the moment, we only test codegen for the virtio module
+cd /tmp
+git clone https://github.com/firecracker-microvm/firecracker.git
+cd firecracker/src/devices/src/virtio/
+RUST_BACKTRACE=1 RUSTFLAGS="-Z trim-diagnostic-paths=no -Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo build --target x86_64-unknown-linux-gnu -j1

--- a/scripts/codegen-firecracker.sh
+++ b/scripts/codegen-firecracker.sh
@@ -13,4 +13,4 @@ fi
 cd /tmp
 git clone https://github.com/firecracker-microvm/firecracker.git
 cd firecracker/src/devices/src/virtio/
-RUST_BACKTRACE=1 RUSTFLAGS="-Z trim-diagnostic-paths=no -Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo build --target x86_64-unknown-linux-gnu -j1
+RUST_BACKTRACE=1 RUSTFLAGS="-Z trim-diagnostic-paths=no -Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo build --target x86_64-unknown-linux-gnu

--- a/scripts/codegen-firecracker.sh
+++ b/scripts/codegen-firecracker.sh
@@ -9,8 +9,11 @@ if [[ $platform != "Linux x86_64" ]]; then
   exit 0
 fi
 
+# Get RMC root
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+RMC_DIR=$SCRIPT_DIR/..
+
 # At the moment, we only test codegen for the virtio module
-cd /tmp
-git clone https://github.com/firecracker-microvm/firecracker.git
-cd firecracker/src/devices/src/virtio/
+git submodule update --init --recursive
+cd $(RMC_DIR)/firecracker/src/devices/src/virtio/
 RUST_BACKTRACE=1 RUSTFLAGS="-Z trim-diagnostic-paths=no -Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo build --target x86_64-unknown-linux-gnu

--- a/scripts/codegen-firecracker.sh
+++ b/scripts/codegen-firecracker.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 # Test for platform
 platform=`uname -sp`

--- a/scripts/codegen-firecracker.sh
+++ b/scripts/codegen-firecracker.sh
@@ -15,5 +15,5 @@ RMC_DIR=$SCRIPT_DIR/..
 
 # At the moment, we only test codegen for the virtio module
 git submodule update --init --recursive
-cd $(RMC_DIR)/firecracker/src/devices/src/virtio/
+cd $RMC_DIR/firecracker/src/devices/src/virtio/
 RUST_BACKTRACE=1 RUSTFLAGS="-Z trim-diagnostic-paths=no -Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo build --target x86_64-unknown-linux-gnu

--- a/scripts/rmc-regression.sh
+++ b/scripts/rmc-regression.sh
@@ -11,13 +11,14 @@ set -o nounset
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export PATH=$SCRIPT_DIR:$PATH
 EXTRA_X_PY_BUILD_ARGS="${EXTRA_X_PY_BUILD_ARGS:-}"
+RMC_DIR=$SCRIPT_DIR/..
 
 # Required dependencies
 check-cbmc-version.py --major 5 --minor 30
 check-cbmc-viewer-version.py --major 2 --minor 5
 
 # Formatting check
-./x.py fmt --check
+./x.py fmt --check --exclude firecracker
 
 # Standalone rmc tests, expected tests, and cargo tests
 ./x.py build -i --stage 1 library/std ${EXTRA_X_PY_BUILD_ARGS}

--- a/scripts/rmc-regression.sh
+++ b/scripts/rmc-regression.sh
@@ -26,3 +26,6 @@ check-cbmc-viewer-version.py --major 2 --minor 5
 
 # Check codegen for the standard library
 $SCRIPT_DIR/std-lib-regression.sh
+
+# Check codegen of firecracker
+$SCRIPT_DIR/codegen-firecracker.sh

--- a/scripts/rmc-regression.sh
+++ b/scripts/rmc-regression.sh
@@ -18,7 +18,7 @@ check-cbmc-version.py --major 5 --minor 30
 check-cbmc-viewer-version.py --major 2 --minor 5
 
 # Formatting check
-./x.py fmt --check --exclude firecracker
+./x.py fmt --check
 
 # Standalone rmc tests, expected tests, and cargo tests
 ./x.py build -i --stage 1 library/std ${EXTRA_X_PY_BUILD_ARGS}


### PR DESCRIPTION
### Description of changes: 

No changes to RMC. Add codegen test for Firecracker virtio module to regression.

### Resolved issues:

Resolves #262

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
