### PR TITLE
Fix types for codegen of intrinsic const

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/intrinsic.rs
@@ -153,17 +153,11 @@ impl<'tcx> GotocCtx<'tcx> {
             () => {{
                 let value = self
                     .tcx
-                    .const_eval_instance(ty::ParamEnv::reveal_all(), instance, None)
+                    .const_eval_instance(ty::ParamEnv::reveal_all(), instance, span)
                     .unwrap();
-                // We may have an implicit cast between machine equivalent
-                // types where CBMC expects a different type than Rust.
-                let place_type = self.codegen_ty(self.place_ty(p));
-                let e = self
-                    .codegen_const_value(value, self.tcx.types.usize, None)
-                    .cast_to_machine_equivalent_type(
-                        &place_type,
-                        &self.symbol_table.machine_model(),
-                    );
+                // We assume that the intrinsic has type checked at this point, so
+                // we can use the place type as the expression type.
+                let e = self.codegen_const_value(value, self.place_ty(p), span.as_ref());
                 self.codegen_expr_to_place(p, e)
             }};
         }

--- a/src/test/cbmc/DynTrait/dyn_fn_param_fail_fixme.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_fail_fixme.rs
@@ -15,7 +15,7 @@ include!("../../rmc-prelude.rs");
 fn takes_dyn_fun(fun: &dyn Fn() -> u32) {
     let x = fun();
     __VERIFIER_expect_fail(x != 5, "Wrong return");
-    
+
     /* The function dynamic object has no associated data */
     __VERIFIER_expect_fail(size_from_vtable(vtable!(fun)) != 0, "Wrong size");
 }

--- a/src/test/cbmc/Intrinsics/needs_drop.rs
+++ b/src/test/cbmc/Intrinsics/needs_drop.rs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that we get the expected results for needs_drop intrinsic
+
+use std::mem;
+
+pub struct Foo<T> {
+    _foo: T,
+}
+
+impl<T> Foo<T> {
+    fn call_needs_drop(&self) -> bool {
+        return mem::needs_drop::<T>();   
+    }
+}
+
+fn main() {
+    // Integers don't need to be dropped
+    let int_foo = Foo::<i32>{_foo : 0};
+    assert!(!int_foo.call_needs_drop());
+
+    // But strings do need to be dropped
+    let string_foo = Foo::<String>{_foo: "".to_string() };
+    assert!(string_foo.call_needs_drop());
+}

--- a/src/test/cbmc/Intrinsics/needs_drop.rs
+++ b/src/test/cbmc/Intrinsics/needs_drop.rs
@@ -11,16 +11,16 @@ pub struct Foo<T> {
 
 impl<T> Foo<T> {
     fn call_needs_drop(&self) -> bool {
-        return mem::needs_drop::<T>();   
+        return mem::needs_drop::<T>();
     }
 }
 
 fn main() {
     // Integers don't need to be dropped
-    let int_foo = Foo::<i32>{_foo : 0};
+    let int_foo = Foo::<i32> { _foo: 0 };
     assert!(!int_foo.call_needs_drop());
 
     // But strings do need to be dropped
-    let string_foo = Foo::<String>{_foo: "".to_string() };
+    let string_foo = Foo::<String> { _foo: "".to_string() };
     assert!(string_foo.call_needs_drop());
 }


### PR DESCRIPTION
### Description of changes: 

For generating intrinsic constants, we were using a default `size_t` type and casting to the expected type. We should just codegen the right type.

### Resolved issues:

Resolves  #265


### Call-outs:

None!

### Testing:

* How is this change tested?

New regression test.

* Is this a refactor change?

No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
