### PR TITLE
Support passing options to cargo-rmc.

### DIFF
--- a/src/test/cargo-rmc/simple-lib/test_one_plus_two.config
+++ b/src/test/cargo-rmc/simple-lib/test_one_plus_two.config
@@ -1,0 +1,2 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT

--- a/src/test/cargo-rmc/simple-lib/test_sum.config
+++ b/src/test/cargo-rmc/simple-lib/test_sum.config
@@ -1,0 +1,2 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT

--- a/src/test/cargo-rmc/simple-main/main.config
+++ b/src/test/cargo-rmc/simple-main/main.config
@@ -1,0 +1,3 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+cbmc-flags: --unwind 11 --unwinding-assertions

--- a/src/test/cargo-rmc/simple-main/main.expected
+++ b/src/test/cargo-rmc/simple-main/main.expected
@@ -1,2 +1,3 @@
-[main.assertion.1] line 4 assertion failed: 1 == 2: FAILURE
+[memcmp.precondition.1] line 19 memcmp region 1 readable: FAILURE
+[memcmp.precondition.2] line 21 memcpy region 2 readable: FAILURE
 VERIFICATION FAILED

--- a/src/test/cargo-rmc/simple-main/src/main.rs
+++ b/src/test/cargo-rmc/simple-main/src/main.rs
@@ -1,5 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+
+include!("../../../rmc-prelude.rs");
+
 fn main() {
-    assert!(1 == 2);
+    assert!("stationary" == "stationary", "the two words are different");
 }

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -699,7 +699,13 @@ fn iter_header<R: Read>(testfile: &Path, cfg: Option<&str>, rdr: R, it: &mut dyn
         return;
     }
 
-    let comment = if testfile.to_string_lossy().ends_with(".rs") { "//" } else { "#" };
+    let comment = if testfile.to_string_lossy().ends_with(".rs") {
+        "//"
+    } else if testfile.to_string_lossy().ends_with(".config") {
+        ""
+    } else {
+        "#"
+    };
 
     let mut rdr = BufReader::new(rdr);
     let mut ln = String::new();

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -585,14 +585,14 @@ fn collect_tests_from_dir(
     fs::create_dir_all(&build_dir).unwrap();
 
     // If we find a `Cargo.toml` file in the current directory and we're in
-    // Cargo-rmc mode, we should look for `*.expected` files and create an
-    // output directory corresponding to each to avoid race conditions during
-    // the testing phase. We immediately return after adding the tests to avoid
+    // Cargo-rmc mode, we should look for `*.config` files and create an output
+    // directory corresponding to each to avoid race conditions during the
+    // testing phase. We immediately return after adding the tests to avoid
     // treating `*.rs` files as tests.
     if config.mode == Mode::CargoRMC && dir.join("Cargo.toml").exists() {
         for file in fs::read_dir(dir)? {
             let file_path = file?.path();
-            if file_path.to_str().unwrap().ends_with(".expected") {
+            if file_path.to_str().unwrap().ends_with(".config") {
                 fs::create_dir_all(&build_dir.join(file_path.file_stem().unwrap())).unwrap();
                 let paths =
                     TestPaths { file: file_path, relative_dir: relative_dir_path.to_path_buf() };


### PR DESCRIPTION
### Description of changes: 

This PR supports passing options to `cargo-rmc` in `src/test/cargo-rmc` testing suite. It does so by requireing each tested function to have a `<fun-name>.config` file along with `<fun-name>.expected`. Just like for `cbmc` tests, this is a temporary solution until RMC supports a proper API with macros to pass options.

### Resolved issues:

None. However, this PR should help @vecchiot-aws test the behavior of `cargo-rmc` with external C files in #260.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?
  * `src/simple-main` was slightly modified to test the feature
* Is this a refactor change?
  * No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
