### PR TITLE
use codegen_unimplemented() for the try intrinsic

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
@@ -628,7 +628,15 @@ impl<'tcx> GotocCtx<'tcx> {
         match k {
             PointerCast::ReifyFnPointer => self.codegen_operand(o).address_of(),
             PointerCast::UnsafeFnPointer => self.codegen_operand(o),
-            PointerCast::ClosureFnPointer(_) => unimplemented!(),
+            PointerCast::ClosureFnPointer(_) => {
+                let dest_typ = self.codegen_ty(t);
+                self.codegen_unimplemented(
+                    "PointerCast::ClosureFnPointer",
+                    dest_typ,
+                    Location::none(),
+                    "https://github.com/model-checking/rmc/issues/274",
+                )
+            }
             PointerCast::MutToConstPointer => self.codegen_operand(o),
             PointerCast::ArrayToPointer => {
                 // TODO: I am not sure whether it is correct or not.

--- a/src/test/cbmc/Intrinsics/fixme_catch_unwind.rs
+++ b/src/test/cbmc/Intrinsics/fixme_catch_unwind.rs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// https://doc.rust-lang.org/std/panic/fn.catch_unwind.html
+// Stable way of calling the `try` intrinsic.
+use std::panic;
+
+fn main() {
+    let result = panic::catch_unwind(|| {
+        println!("hello!");
+    });
+    assert!(result.is_ok());
+
+    let result = panic::catch_unwind(|| {
+        panic!("oh no!");
+    });
+    assert!(result.is_err());
+}

--- a/src/test/cbmc/Intrinsics/fixme_try.rs
+++ b/src/test/cbmc/Intrinsics/fixme_try.rs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// See discussion on https://github.com/model-checking/rmc/issues/267
+#![feature(core_intrinsics)]
+use std::intrinsics::r#try;
+
+fn main() {
+    unsafe {
+        // Rust will make a best-effort to swallow the panic, and then execute the cleanup function.
+        // However, my understanding is that failure is still possible, since its just a best-effort
+        r#try(
+            |_a: *mut u8| panic!("foo"),
+            std::ptr::null_mut(),
+            |_a: *mut u8, _b: *mut u8| println!("bar"),
+        );
+    }
+}


### PR DESCRIPTION
- Refactor: Use borrowed types for arguments
- use codegen_unimplemented() for the try intrinsic


### Description of changes: 

Use `codegen_unimplemented` to avoid problems that are blocking firecracker compilation.
Along the way, discovered that we also require the `PointerCast::ClosureFnPointer` operation.
Used `codegen_unimplemtned` for that too and raised an issue.

### Resolved issues:

Partial fix for #267 and #274 via `codegen_unimplemented()`

### Call-outs:

The actual semantics of try are complicated, discussed in the linked issues. But this unblocks that part of codegenning firecracker. 

For now, marked the new test `fixme` .

### Testing:

* How is this change tested? Additional regression test2, one for the raw intrinsic, one for the stabilized version. Both are currently marked `fixme`

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
