### PR TITLE
Correct check for vtable pointer type (fix Firecracker regression)

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
@@ -686,7 +686,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 dst_mir_type,
             )
         } else {
-            // Check that the source is either not a pointer or some other known case
+            // Check that the source is either not a pointer, or a thin or a slice pointer
             assert!(
                 pointee_type(src_mir_type)
                     .map_or(true, |p| self.use_thin_pointer(p) || self.use_slice_fat_pointer(p))

--- a/compiler/rustc_codegen_llvm/src/gotoc/typ.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/typ.rs
@@ -1016,11 +1016,6 @@ pub fn pointee_type(pointer_type: Ty<'tcx>) -> Option<Ty<'tcx>> {
     }
 }
 
-/// Check if the mir type already is a vtable fat pointer.
-pub fn is_dyn_trait_fat_pointer(mir_type: Ty<'tcx>) -> bool {
-    if let Some(p) = pointee_type(mir_type) { p.is_trait() } else { false }
-}
-
 impl<'tcx> GotocCtx<'tcx> {
     /// A pointer to the mir type should be a thin pointer.
     pub fn use_thin_pointer(&self, mir_type: Ty<'tcx>) -> bool {
@@ -1036,5 +1031,10 @@ impl<'tcx> GotocCtx<'tcx> {
     pub fn use_vtable_fat_pointer(&self, mir_type: Ty<'tcx>) -> bool {
         let metadata = mir_type.ptr_metadata_ty(self.tcx);
         return metadata != self.tcx.types.unit && metadata != self.tcx.types.usize;
+    }
+
+    /// Check if the mir type already is a vtable fat pointer.
+    pub fn is_vtable_fat_pointer(&self, mir_type: Ty<'tcx>) -> bool {
+        pointee_type(mir_type).map_or(false, |p| self.use_vtable_fat_pointer(p))
     }
 }


### PR DESCRIPTION
### Description of changes: 

Using `is_trait()` on a pointee type is an not always a reliable way of checking if a pointer is to a vtable, since it returns false for types with more indirection, such as: `&std::sync::Mutex<dyn bus::BusDevice>`.

### Resolved issues:

Resolves https://github.com/model-checking/rmc/issues/272

### Call-outs:

Same commit on https://github.com/model-checking/rmc/pull/264, will merge.

### Testing:

* How is this change tested?

Tested on https://github.com/model-checking/rmc/pull/264.

* Is this a refactor change?

No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
