### PR TITLE
Add support for multiple expected failures.

### DIFF
--- a/src/test/cbmc/DynTrait/vtable_size_align_drop_fail.rs
+++ b/src/test/cbmc/DynTrait/vtable_size_align_drop_fail.rs
@@ -13,6 +13,7 @@
 #![allow(deprecated)]
 
 use std::intrinsics::size_of;
+use std::ptr::drop_in_place;
 
 include!("../Helpers/vtable_utils_ignore.rs");
 include!("../../rmc-prelude.rs");
@@ -68,7 +69,7 @@ fn main() {
 
     // Check layout/values for Sheep
     unsafe {
-        let animal_sheep = random_animal(1);
+        let animal_sheep = &*random_animal(1);
 
         // Check that the struct's data is what we expect
         let data_ptr = data!(animal_sheep);
@@ -90,15 +91,15 @@ fn main() {
     }
     // Check layout/values for Cow
     unsafe {
-        let animal_sheep = random_animal(1);
+        let animal_cow = &*random_animal(6);
 
         // Check that the struct's data is what we expect
-        let data_ptr = data!(animal_sheep);
+        let data_ptr = data!(animal_cow);
 
         // Note: i8 ptr cast
         __VERIFIER_expect_fail(*(data_ptr as *mut i8) != 9, "Wrong data"); // From Cow
 
-        let vtable_ptr = vtable!(animal_sheep);
+        let vtable_ptr = vtable!(animal_cow);
 
         // Drop pointer
         __VERIFIER_expect_fail(

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2448,8 +2448,10 @@ impl<'test> TestCx<'test> {
         let re = Regex::new(r"line [0-9]+ EXPECTED FAIL: SUCCESS").unwrap();
         let mut lines = vec![];
         for m in re.find_iter(str) {
-            lines
-                .push(m.as_str().split_ascii_whitespace().skip(1).next().unwrap().parse().unwrap());
+            let splits = m.as_str().split_ascii_whitespace();
+            let num_str = splits.skip(1).next().unwrap();
+            let num = num_str.parse().unwrap();
+            lines.push(num);
         }
         lines
     }


### PR DESCRIPTION
### Description of changes: 

This PR adds support for multiple expected failures. For each expected failure, we ensure that there is a corresponding failure in RMC's output.

### Resolved issues:

Resolves #249

### Call-outs:

The changes in this PR only ensure that assertions that are expected to fail, do indeed fail. It does not ensure that those assertions are the only ones that fail. For example, if a test contains both normal assertions AND expected failures, only expected failures are checked and that test might pass even if normal assertions fail.

### Testing:

* How is this change tested?
  * Tests that use `__VERIFIER_expect_fail` now work as expected
* Is this a refactor change?
  * No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
