### PR TITLE
Custom panic hook for RMC including current item

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
@@ -19,6 +19,9 @@ use rustc_serialize::json::ToJson;
 use rustc_session::config::{OutputFilenames, OutputType};
 use rustc_session::Session;
 use rustc_target::abi::Endian;
+use std::cell::RefCell;
+use std::lazy::SyncLazy;
+use std::panic;
 use tracing::{debug, warn};
 
 mod assumptions;
@@ -35,6 +38,60 @@ mod statement;
 pub mod stubs;
 mod typ;
 mod utils;
+
+// Use a thread-local global variable to track the current codegen item for debugging.
+// If RMC panics during codegen, we can grab this item to include the problematic
+// codegen item in the panic trace.
+thread_local!(static CURRENT_CODEGEN_ITEM: RefCell<Option<String>> = RefCell::new(None));
+
+// Updates the tracking global variable for panic debugging.
+fn set_debug_item(s: String) {
+    CURRENT_CODEGEN_ITEM.with(|odb_cell| {
+        odb_cell.replace(Some(s));
+    });
+}
+
+// Include RMC's bug reporting URL in our panics.
+const BUG_REPORT_URL: &str =
+    "https://github.com/model-checking/rmc/issues/new?labels=bug&template=bug_report.md";
+
+// Custom panic hook.
+static DEFAULT_HOOK: SyncLazy<Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 'static>> =
+    SyncLazy::new(|| {
+        let hook = panic::take_hook();
+        panic::set_hook(Box::new(|info| {
+            // Invoke the default handler, which prints the actual panic message and
+            // optionally a backtrace. This also prints Rustc's "file a bug here" message:
+            // it seems like the only way to remove that is to use rustc_driver::report_ice;
+            // however, adding that dependency to this crate causes a circular dependency.
+            // For now, just print our message after the Rust one and explicitly point to
+            // our bug template form.
+            (*DEFAULT_HOOK)(info);
+
+            // Separate the output with an empty line
+            eprintln!();
+
+            // Print the current function if available
+            CURRENT_CODEGEN_ITEM.with(|cell| {
+                if let Some(current_item) = cell.borrow().clone() {
+                    eprintln!("[RMC] current codegen item: {}", current_item);
+                } else {
+                    eprintln!("[RMC] no current codegen item.");
+                }
+            });
+
+            // Separate the output with an empty line
+            eprintln!();
+
+            // Print the RMC message
+            eprintln!("RMC unexpectedly panicked during code generation.\n");
+            eprintln!(
+                "If you are seeing this message, please file an issue here instead of on the Rust compiler: {}",
+                BUG_REPORT_URL
+            );
+        }));
+        hook
+    });
 
 #[derive(Clone)]
 pub struct GotocCodegenBackend();
@@ -285,6 +342,9 @@ impl CodegenBackend for GotocCodegenBackend {
     ) -> Box<dyn Any> {
         use rustc_hir::def_id::LOCAL_CRATE;
 
+        // Install panic hook
+        SyncLazy::force(&DEFAULT_HOOK); // Install ice hook
+
         let codegen_units: &'tcx [CodegenUnit<'_>] = tcx.collect_and_partition_mono_items(()).1;
         let mm = machine_model_from_session(&tcx.sess);
         let mut c = GotocCtx::new(tcx, SymbolTable::new(mm));
@@ -294,8 +354,17 @@ impl CodegenBackend for GotocCodegenBackend {
             let items = cgu.items_in_deterministic_order(tcx);
             for (item, _) in items {
                 match item {
-                    MonoItem::Fn(instance) => c.declare_function(instance),
-                    MonoItem::Static(def_id) => c.declare_static(def_id, item),
+                    MonoItem::Fn(instance) => {
+                        set_debug_item(format!(
+                            "declare_function: {}",
+                            c.readable_instance_name(instance)
+                        ));
+                        c.declare_function(instance)
+                    }
+                    MonoItem::Static(def_id) => {
+                        set_debug_item(format!("declare_static: {:?}", def_id));
+                        c.declare_static(def_id, item)
+                    }
                     MonoItem::GlobalAsm(_) => {
                         warn!(
                             "Crate {} contains global ASM, which is not handled by RMC",
@@ -311,8 +380,17 @@ impl CodegenBackend for GotocCodegenBackend {
             let items = cgu.items_in_deterministic_order(tcx);
             for (item, _) in items {
                 match item {
-                    MonoItem::Fn(instance) => c.codegen_function(instance),
-                    MonoItem::Static(def_id) => c.codegen_static(def_id, item),
+                    MonoItem::Fn(instance) => {
+                        set_debug_item(format!(
+                            "codegen_function: {}",
+                            c.readable_instance_name(instance)
+                        ));
+                        c.codegen_function(instance)
+                    }
+                    MonoItem::Static(def_id) => {
+                        set_debug_item(format!("codegen_static: {:?}", def_id));
+                        c.codegen_static(def_id, item)
+                    }
                     MonoItem::GlobalAsm(_) => {} // We have already warned above
                 }
             }

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -15,6 +15,7 @@
 #![recursion_limit = "256"]
 #![feature(destructuring_assignment)]
 #![feature(box_patterns)]
+#![feature(once_cell)]
 
 use back::write::{create_informational_target_machine, create_target_machine};
 

--- a/src/test/cbmc/FatPointers/boxmuttrait.rs
+++ b/src/test/cbmc/FatPointers/boxmuttrait.rs
@@ -3,9 +3,9 @@
 #![feature(core_intrinsics)]
 #![feature(ptr_metadata)]
 
+use std::any::Any;
 use std::io::{sink, Write};
 use std::ptr::DynMetadata;
-use std::any::Any;
 
 include!("../Helpers/vtable_utils_ignore.rs");
 


### PR DESCRIPTION
### Description of changes: 

When RMC panics currently, you get the standard Rustc panic message, including a link to their bug reporting. Add a custom panic hook with our bug template link and include the current codegen item (usually function) causing the problem. 

Example panic now:

```rust
   Compiling libc v0.2.93
thread 'rustc' panicked at 'oops', compiler/rustc_codegen_llvm/src/gotoc/mod.rs:208:9
stack backtrace:
   0: std::panicking::begin_panic
             at /home/ubuntu/rmc/library/std/src/panicking.rs:541:12
…

note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

error: internal compiler error: unexpected panic

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.55.0-dev running on x86_64-unknown-linux-gnu

note: compiler flags: -Z force-unstable-if-unmarked -Z trim-diagnostic-paths=no -Z codegen-backend=gotoc -C embed-bitcode=no -C debuginfo=2 --crate-type lib

note: some of the compiler flags provided by cargo are hidden

query stack during panic:
end of query stack

[RMC] current codegen item: codegen_static: DefId(0:8806 ~ core[e967]::fmt::num::DEC_DIGITS_LUT)

RMC unexpectedly panicked during code generation.

If you are seeing this message, please file an issue here instead of on the Rust compiler: https://github.com/model-checking/rmc/issues/new?labels=bug&template=bug_report.md
error: could not compile `core`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
```

### Resolved issues:

Resolves #287


### Call-outs:

Unfortunately, we can't use the same approach Cranelift uses to remove rustc's bug report link, since that would introduce a circular dependency on `rustc_driver`. Adding a comment explaining that.

### Testing:

* How is this change tested?

Manually introducing panics. 

* Is this a refactor change?

No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
