### PR TITLE
Update dyn trait tests from raw to ptr Rust APIs

### DIFF
--- a/src/test/cbmc/DynTrait/dyn_fn_param.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param.rs
@@ -4,8 +4,7 @@
 // Check that we can pass a dyn function pointer to a stand alone
 // function definition
 
-#![feature(raw)]
-#![allow(deprecated)]
+#![feature(ptr_metadata)]
 
 include!("../Helpers/vtable_utils_ignore.rs");
 

--- a/src/test/cbmc/DynTrait/dyn_fn_param_closure.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_closure.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 // Check that we can pass a dyn function pointer to a simple closure
-#![feature(raw)]
-#![allow(deprecated)]
+#![feature(ptr_metadata)]
 
 include!("../Helpers/vtable_utils_ignore.rs");
 

--- a/src/test/cbmc/DynTrait/dyn_fn_param_closure_capture.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_closure_capture.rs
@@ -3,8 +3,7 @@
 
 // Check that we can pass a dyn function pointer to a closure that captures
 // some data
-#![feature(raw)]
-#![allow(deprecated)]
+#![feature(ptr_metadata)]
 
 include!("../Helpers/vtable_utils_ignore.rs");
 

--- a/src/test/cbmc/DynTrait/dyn_fn_param_closure_capture_fail.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_closure_capture_fail.rs
@@ -3,8 +3,7 @@
 
 // Check that we can pass a dyn function pointer to a closure that captures
 // some data
-#![feature(raw)]
-#![allow(deprecated)]
+#![feature(ptr_metadata)]
 
 include!("../Helpers/vtable_utils_ignore.rs");
 include!("../../rmc-prelude.rs");

--- a/src/test/cbmc/DynTrait/dyn_fn_param_closure_fail.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_closure_fail.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 // Check that we can pass a dyn function pointer to a simple closure
-#![feature(raw)]
-#![allow(deprecated)]
+#![feature(ptr_metadata)]
 
 include!("../Helpers/vtable_utils_ignore.rs");
 include!("../../rmc-prelude.rs");

--- a/src/test/cbmc/DynTrait/dyn_fn_param_fail_fixme.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_fail_fixme.rs
@@ -5,9 +5,7 @@
 // function definition. Inverted negative test.
 
 // FIXME https://github.com/model-checking/rmc/issues/240
-
-#![feature(raw)]
-#![allow(deprecated)]
+#![feature(ptr_metadata)]
 
 include!("../Helpers/vtable_utils_ignore.rs");
 include!("../../rmc-prelude.rs");

--- a/src/test/cbmc/DynTrait/nested_boxes_fail.rs
+++ b/src/test/cbmc/DynTrait/nested_boxes_fail.rs
@@ -6,8 +6,7 @@
 // In this failing tests, assertions are inverted to use !=.
 
 #![feature(core_intrinsics)]
-#![feature(raw)]
-#![allow(deprecated)]
+#![feature(ptr_metadata)]
 
 use std::intrinsics::size_of;
 

--- a/src/test/cbmc/DynTrait/vtable_size_align_drop.rs
+++ b/src/test/cbmc/DynTrait/vtable_size_align_drop.rs
@@ -3,12 +3,11 @@
 
 // This test checks the `size` and `align` fields of vtables, for a
 // dynamic trait where two implementing structs have different sizes.
-// The strategy is to cast the dyn trait object to a raw::TraitObject
-// then do some unsafe pointer math.
+// The strategy is to use the new pointer metadata API:
+// https://github.com/rust-lang/rust/issues/81513
 
 #![feature(core_intrinsics)]
-#![feature(raw)]
-#![allow(deprecated)]
+#![feature(ptr_metadata)]
 
 use std::intrinsics::size_of;
 use std::ptr::drop_in_place;

--- a/src/test/cbmc/DynTrait/vtable_size_align_drop_fail.rs
+++ b/src/test/cbmc/DynTrait/vtable_size_align_drop_fail.rs
@@ -3,14 +3,13 @@
 
 // This test checks the `size` and `align` fields of vtables, for a
 // dynamic trait where two implementing structs have different sizes.
-// The strategy is to cast the dyn trait object to a raw::TraitObject
-// then do some unsafe pointer math.
+// The strategy is to use the new pointer metadata API:
+// https://github.com/rust-lang/rust/issues/81513
 
 // In this _fail version, all asserts should fail.
 
 #![feature(core_intrinsics)]
-#![feature(raw)]
-#![allow(deprecated)]
+#![feature(ptr_metadata)]
 
 use std::intrinsics::size_of;
 use std::ptr::drop_in_place;

--- a/src/test/cbmc/FatPointers/boxmuttrait.rs
+++ b/src/test/cbmc/FatPointers/boxmuttrait.rs
@@ -1,10 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![feature(core_intrinsics)]
-#![feature(raw)]
-#![allow(deprecated)]
+#![feature(ptr_metadata)]
 
 use std::io::{sink, Write};
+use std::ptr::DynMetadata;
+use std::any::Any;
 
 include!("../Helpers/vtable_utils_ignore.rs");
 
@@ -31,7 +32,7 @@ fn main() {
         let dest_data_ptr = data!(dest_ptr) as *mut usize;
 
         // // The second half of this fat pointer is another vtable, for log
-        let second_vtable_ptr = dest_data_ptr.offset(1) as *mut *mut usize;
+        let second_vtable_ptr = dest_data_ptr.offset(1) as *mut DynMetadata<dyn Any>;
         let second_vtable = *second_vtable_ptr;
 
         // The sink itself has no size, weirdly enough

--- a/src/test/cbmc/Helpers/vtable_utils_ignore.rs
+++ b/src/test/cbmc/Helpers/vtable_utils_ignore.rs
@@ -5,35 +5,39 @@
 // an import! to share this code across test directories.
 
 // Macro rules because we can't cast between incompatible dyn trait fat pointer types
-macro_rules! vtable {
-    ($f:ident) => {{
-        unsafe {
-            let trait_object: std::raw::TraitObject = std::mem::transmute($f);
-            trait_object.vtable as *mut usize
-        }
-    }};
-}
-
 macro_rules! data {
     ($f:ident) => {{
         unsafe {
-            let trait_object: std::raw::TraitObject = std::mem::transmute($f);
-            trait_object.data as *mut ()
+            let ptr: *mut dyn std::any::Any = std::mem::transmute($f);
+            let data: *mut () = ptr.cast();
+            data
         }
     }};
 }
 
-fn drop_from_vtable(vtable_ptr: *mut usize) -> *mut () {
+macro_rules! vtable {
+    ($f:ident) => {{
+        unsafe {
+            let ptr: *mut dyn std::any::Any = std::mem::transmute($f);
+            std::ptr::metadata(ptr)
+        }
+    }};
+}
+
+fn drop_from_vtable(vtable_ptr: std::ptr::DynMetadata<dyn std::any::Any>) -> *mut () {
     // 1st pointer-sized position
-    unsafe { *vtable_ptr as *mut () }
+    unsafe {
+        let ptr: *mut usize = std::mem::transmute(vtable_ptr);
+        *ptr as *mut ()
+    }
 }
 
-fn size_from_vtable(vtable_ptr: *mut usize) -> usize {
+fn size_from_vtable(vtable_ptr: std::ptr::DynMetadata<dyn std::any::Any>) -> usize {
     // 2nd usize-sized position
-    unsafe { *(vtable_ptr.offset(1)) }
+    vtable_ptr.size_of()
 }
 
-fn align_from_vtable(vtable_ptr: *mut usize) -> usize {
+fn align_from_vtable(vtable_ptr: std::ptr::DynMetadata<dyn std::any::Any>) -> usize {
     // 3rd usize-sized position
-    unsafe { *(vtable_ptr.offset(2)) }
+    vtable_ptr.align_of()
 }


### PR DESCRIPTION
### Description of changes: 

Rustc fully removed the deprecated raw API, we need to update our trait object tests to use the new pointer API:

rust-lang/rust@0d1919c

### Resolved issues:

Resolves #305


### Call-outs:

We should land this before attempting the next rebase.

### Testing:

* How is this change tested?

Updates to tests.

* Is this a refactor change?
* 
No.

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
