### PR TITLE
Improve setup scripts for development

### DIFF
--- a/scripts/setup/install_viewer.sh
+++ b/scripts/setup/install_viewer.sh
@@ -16,5 +16,5 @@ URL="https://github.com/awslabs/aws-viewer-for-cbmc/releases/download/viewer-$1/
 
 set -x
 
-curl --fail --silent --location "$URL" -o "$FILE"
+wget -O "$FILE" "$URL"
 sudo python3 -m pip install --upgrade "$FILE"

--- a/scripts/setup/install_viewer.sh
+++ b/scripts/setup/install_viewer.sh
@@ -2,13 +2,19 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-set -eux
+set -eu
 
 # Install cbmc-viewer
-if [[ $# -eq 1 ]] ; then
-wget https://github.com/awslabs/aws-viewer-for-cbmc/releases/download/viewer-$1/cbmc_viewer-$1-py3-none-any.whl \
-  && sudo python3 -m pip install --upgrade cbmc_viewer-$1-py3-none-any.whl
-else
-  echo "Error: Specify the version to install"
+
+if [[ $# -ne 1 ]]; then
+  echo "$0: Error: Specify the version to install"
   exit 1
 fi
+
+FILE="cbmc_viewer-$1-py3-none-any.whl"
+URL="https://github.com/awslabs/aws-viewer-for-cbmc/releases/download/viewer-$1/$FILE"
+
+set -x
+
+curl --fail --silent --location "$URL" -o "$FILE"
+sudo python3 -m pip install --upgrade "$FILE"

--- a/scripts/setup/ubuntu-20.04/install_cbmc.sh
+++ b/scripts/setup/ubuntu-20.04/install_cbmc.sh
@@ -2,9 +2,16 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-set -eux
+set -eu
 
 # Install CBMC 5.30.1 for Ubuntu 20.04
-wget https://github.com/diffblue/cbmc/releases/download/cbmc-5.30.1/ubuntu-20.04-cbmc-5.30.1-Linux.deb \
-  && sudo dpkg -i ubuntu-20.04-cbmc-5.30.1-Linux.deb \
-  && cbmc --version
+
+FILE="ubuntu-20.04-cbmc-5.30.1-Linux.deb"
+URL="https://github.com/diffblue/cbmc/releases/download/cbmc-5.30.1/$FILE"
+
+set -x
+
+curl --fail --silent --location "$URL" -o "$FILE"
+sudo dpkg -i "$FILE"
+
+cbmc --version

--- a/scripts/setup/ubuntu-20.04/install_cbmc.sh
+++ b/scripts/setup/ubuntu-20.04/install_cbmc.sh
@@ -11,7 +11,7 @@ URL="https://github.com/diffblue/cbmc/releases/download/cbmc-5.30.1/$FILE"
 
 set -x
 
-curl --fail --silent --location "$URL" -o "$FILE"
+wget -O "$FILE" "$URL"
 sudo dpkg -i "$FILE"
 
 cbmc --version

--- a/scripts/setup/ubuntu-20.04/install_deps.sh
+++ b/scripts/setup/ubuntu-20.04/install_deps.sh
@@ -25,6 +25,8 @@ DEPS=(
   wget
   zlib1g
   zlib1g-dev
+  # Default in CI, but not present on AWS AMI:
+  python3-pip
 )
 
 set -x

--- a/scripts/setup/ubuntu-20.04/install_deps.sh
+++ b/scripts/setup/ubuntu-20.04/install_deps.sh
@@ -2,28 +2,32 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-set -eux
+set -eu
 
-# Install tools in Ubuntu 20.04 via `apt-get`
-sudo apt-get --yes update \
-  && sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
-  bison \
-  cmake \
-  ctags \
-  curl \
-  flex \
-  g++ \
-  gcc \
-  git \
-  gpg-agent \
-  libssl-dev \
-  lsb-release \
-  make \
-  ninja-build \
-  patch \
-  pkg-config \
-  python-is-python3 \
-  software-properties-common \
-  wget \
-  zlib1g \
+DEPS=(
+  bison
+  cmake
+  ctags
+  curl
+  flex
+  g++
+  gcc
+  git
+  gpg-agent
+  libssl-dev
+  lsb-release
+  make
+  ninja-build
+  patch
+  pkg-config
+  python-is-python3
+  software-properties-common
+  wget
+  zlib1g
   zlib1g-dev
+)
+
+set -x
+
+sudo apt-get --yes update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes "${DEPS[@]}"

--- a/scripts/setup/ubuntu-20.04/install_deps.sh
+++ b/scripts/setup/ubuntu-20.04/install_deps.sh
@@ -21,12 +21,11 @@ DEPS=(
   patch
   pkg-config
   python-is-python3
+  python3-pip # Default in CI, but missing in AWS AMI
   software-properties-common
   wget
   zlib1g
   zlib1g-dev
-  # Default in CI, but not present on AWS AMI:
-  python3-pip
 )
 
 set -x


### PR DESCRIPTION
### Description of changes: 

Hello, world.

Adrian suggested I set up my development environment using the same scripts the CI was using. I ran into two minor issues:

1. With the Ubuntu AMI, Python's `pip` was missing. Presumably this is installed by default in CI. I think adding it is harmless to CI and improves the usability of these scripts to set up development environments.
2. `wget` has this default behavior that downloads new copies if the file already exists (e.g. `cbmc_viewer-2.5-py3-none-any.whl.1` Note the new `.1`.) I'm used to `curl` so I fixed this by switching. If there's a preference the other way, I could go figure it out.

In addition:

3. Cleaned up some things I thought could be done better: using an array for dependencies (comments!), and doing error checking up front in one script.

### Call-outs:

1. It might be nice to comment on the origins of some of our dependencies now that we *can* comment on them.
2. Do we really need a "version" parameter to `install_viewer.sh`? Seems we could just bake that in.
3. If we'll be using these as the recommended path for dev environment setup, should we add to `.gitignore` for the `.deb` and `.whl` that we download?

### Testing:

I've run all these scripts again on my Ubuntu development box. They seem nicely idempotent, too.

We'll see how it runs in CI? I'm not sure if there's any better method here but to pull request and check? I haven't used Github Actions before.

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [N/A] Methods or procedures are documented
- [N/A] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
