### PR TITLE
Emit an error message when rmc-rustc fails

### DIFF
--- a/scripts/rmc-rustc
+++ b/scripts/rmc-rustc
@@ -11,7 +11,8 @@ shopt -s nullglob
 RMC_CANDIDATES=("$REPO_DIR"/build/*/stage1/bin/rustc)
 
 if [[ ${#RMC_CANDIDATES[@]} -ne 1 ]]; then
-    echo "ERROR: Could not find RMC binary. Looked under: $REPO_DIR"
+    echo "ERROR: Could not find RMC binary."
+    echo "Looked for: $REPO_DIR/build/*/stage1/bin/rustc"
     echo "Was RMC successfully built first?"
     exit 1
 fi

--- a/scripts/rmc-rustc
+++ b/scripts/rmc-rustc
@@ -2,10 +2,18 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-set -o errexit
-set -o pipefail
-set -o nounset
+set -eu
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-RUST_DIR=$SCRIPT_DIR/..
-RMC_RUSTC=`find $RUST_DIR/build -name "rustc" -print | grep stage1`
-$RMC_RUSTC "$@"
+REPO_DIR="$(dirname $SCRIPT_DIR)"
+
+shopt -s nullglob
+RMC_CANDIDATES=("$REPO_DIR"/build/*/stage1/bin/rustc)
+
+if [[ ${#RMC_CANDIDATES[@]} -ne 1 ]]; then
+    echo "ERROR: Could not find RMC binary. Looked under: $REPO_DIR"
+    echo "Was RMC successfully built first?"
+    exit 1
+fi
+
+"${RMC_CANDIDATES[0]}" "$@"


### PR DESCRIPTION
### Description of changes: 

`rmc` would previously emit no error messages if RMC hadn't been built yet or had failed to build.

### Resolved issues:

Resolves #173

### Call-outs:

1. Emit an error message instead of silently failing.
2. Swapped to using glob instead of `find`, potentially more efficient.
3. Any alternative suggestions for what to include in the error message to help debugging?
4. A much harder problem comes to mind: trying to detect if the binary is older than the source files, to remind people to rebuild first? But that seems out of scope for this bugfix.

### Testing:

* How is this change tested? Session below

* Is this a refactor change? No

Before (deleting the binary to simulate build failure):

```
$ rm build/x86_64-unknown-linux-gnu/stage1/bin/rustc 
$ rmc src/test/cbmc/DynTrait/vtable_duplicate_fields.rs

$ 
```

After:

```
$ rm build/x86_64-unknown-linux-gnu/stage1/bin/rustc 
$ rmc src/test/cbmc/DynTrait/vtable_duplicate_fields.rs
ERROR: Could not find RMC binary.
Looked for: /home/ubuntu/rmc/build/*/stage1/bin/rustc
Was RMC successfully built first?

$
```

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [N/A] Methods or procedures are documented
- [N/A] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
