### PR TITLE
Use new `vtable_entries` API

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/typ.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/typ.rs
@@ -11,7 +11,7 @@ use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::print::FmtPrinter;
 use rustc_middle::ty::subst::{InternalSubsts, SubstsRef};
 use rustc_middle::ty::{
-    self, AdtDef, FloatTy, Instance, IntTy, PolyFnSig, Ty, TyS, UintTy, VariantDef,
+    self, AdtDef, FloatTy, Instance, IntTy, PolyFnSig, Ty, TyS, UintTy, VariantDef, VtblEntry,
 };
 use rustc_span;
 use rustc_span::def_id::DefId;
@@ -195,13 +195,15 @@ impl<'tcx> GotocCtx<'tcx> {
                     .vtable_entries(poly)
                     .iter()
                     .cloned()
-                    .map(|entry| match entry {
-                        ty::VtblEntry::Method(def_id, substs) => {
+                    .filter_map(|entry| match entry {
+                        VtblEntry::Method(def_id, substs) => {
                             Some(self.trait_method_vtable_field_type(def_id, substs))
                         }
-                        _ => None,
+                        VtblEntry::MetadataDropInPlace
+                        | VtblEntry::MetadataSize
+                        | VtblEntry::MetadataAlign
+                        | VtblEntry::Vacant => None,
                     })
-                    .filter_map(|x| x)
                     .collect();
 
                 vtable_base.append(&mut flds);


### PR DESCRIPTION
### Description of changes: 

Mainline Rust added a new `vtable_entries` field to replace `vtable_methods`: rust-lang/rust@2336406. Move more places to use this. 

### Resolved issues:

Resolves #187

### Testing:

* How is this change tested?

Existing tests.

* Is this a refactor change?

Yes, but relatively small. 

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
