### PR TITLE
Fix dyn trait _fail tests compilation errors

### DIFF
--- a/src/test/cbmc/DynTrait/main_fail.rs
+++ b/src/test/cbmc/DynTrait/main_fail.rs
@@ -35,8 +35,8 @@ fn main() {
     let animal = random_animal(random_number);
     let s = animal.noise();
     if (random_number < 5) {
-        _VERIFIER_expect_fail(s == 2, "Wrong noise");
+        __VERIFIER_expect_fail(s == 2, "Wrong noise");
     } else {
-        _VERIFIER_expect_fail(s == 1, "Wrong noise");
+        __VERIFIER_expect_fail(s == 1, "Wrong noise");
     }
 }

--- a/src/test/cbmc/DynTrait/nested_boxes_fail.rs
+++ b/src/test/cbmc/DynTrait/nested_boxes_fail.rs
@@ -8,7 +8,9 @@
 #![feature(core_intrinsics)]
 #![feature(ptr_metadata)]
 
+use std::any::Any;
 use std::intrinsics::size_of;
+use std::ptr::DynMetadata;
 
 include!("../Helpers/vtable_utils_ignore.rs");
 
@@ -26,15 +28,16 @@ fn main() {
     unsafe {
         // Outermost trait object
         // The size is 16, because the data is another fat pointer
-        let vtable3: *mut usize = vtable!(dyn_trait3);
+        let dyn_3 = &*dyn_trait3 as &dyn Send;
+        let vtable3: DynMetadata<dyn Any> = vtable!(dyn_3);
         assert!(size_from_vtable(vtable3) != 16);
         assert!(align_from_vtable(vtable3) != 8);
 
         // Inspect the data pointer from dyn_trait3
-        let data_ptr3 = data!(dyn_trait3) as *mut usize;
+        let data_ptr3 = data!(dyn_3) as *mut usize;
 
         // The second half of this fat pointer is another vtable, for dyn_trait2
-        let vtable2 = *(data_ptr3.offset(1) as *mut *mut usize);
+        let vtable2 = *(data_ptr3.offset(1) as *mut DynMetadata<dyn Any>);
 
         // The size is 16, because the data is another fat pointer
         assert!(size_from_vtable(vtable2) != 16);
@@ -44,7 +47,7 @@ fn main() {
         let data_ptr2 = *(data_ptr3 as *mut *mut usize);
 
         // The second half of this fat pointer is another vtable, for dyn_trait1
-        let vtable1 = *(data_ptr2.offset(1) as *mut *mut usize);
+        let vtable1 = *(data_ptr2.offset(1) as *mut DynMetadata<dyn Any>);
 
         // The size is 8, because the data is the Foo itself
         assert!(size_from_vtable(vtable1) != size_of::<Foo>());


### PR DESCRIPTION
### Description of changes: 

Two `_fail` tests have compiler errors.

### Resolved issues:

Resolves #389


### Call-outs:

We should have `_fail` regression tests succeed only on verification failure, not compilation failure. Let's track that with https://github.com/model-checking/rmc/issues/338?

### Testing:

* How is this change tested?

Existing, manually compile.

* Is this a refactor change?

No. 

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
