### PR TITLE
Remove string that tripped open source alarm.

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/symtab_transformer/identity_transformer.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/symtab_transformer/identity_transformer.rs
@@ -331,9 +331,9 @@ mod tests {
     fn transmute_to_expr() {
         let mut original = empty_symtab();
         let sym = Symbol::constant(
-            "tt",
-            "tt",
-            "tt",
+            "transmuted",
+            "transmuted",
+            "transmuted",
             Expr::array_expr(Type::c_int().array_of(1), vec![Expr::int_constant(3, Type::c_int())])
                 .transmute_to(Type::c_int(), &original),
             Location::none(),


### PR DESCRIPTION
### Description of changes: 

Removes banned string from code.

### Resolved issues:


### Call-outs:


### Testing:

* How is this change tested? Existing regression suite.

* Is this a refactor change? Yes.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
