### PR TITLE
Fix dry-run to print to stdout when output_to is not stdout.

### DIFF
--- a/scripts/rmc.py
+++ b/scripts/rmc.py
@@ -100,9 +100,12 @@ def run_cmd(cmd, label=None, cwd=None, env=None, output_to=None, quiet=False, ve
     # If this a dry run, we emulate running a successful process whose output is the command itself
     # We set `output_to` to `stdout` so that the output is not omitted below
     if dry_run:
-        if output_to == None:
-            output_to = "stdout"
         cmd_line = ' '.join(cmd)
+        if output_to != "stdout" and output_to is not None:
+            cmd_line += f" > \"{output_to}\""
+
+        output_to = "stdout"
+
         process = subprocess.CompletedProcess(None, EXIT_CODE_SUCCESS, stdout=cmd_line)
     else:
         process = subprocess.run(


### PR DESCRIPTION
### Description of changes: 

Currently, when running `rmc` with the `--dry-run` flag, any command which sets `output_to` to anything but `"stdout"` writes the command to the file instead of stdout.

With this change, the output now includes those commands with a trailing ` > "{output_to}"`, e.g.:

```
>>> rmc --visualize main.rs
rmc-rustc -Z codegen-backend=gotoc -Z symbol-mangling-version=v0 -Z symbol_table_passes= --cfg=rmc -o main.json main.rs
symtab2gb main.json --out main.goto
goto-cc --function main main.goto /Users/vecchiot/Documents/rmclibrary/rmc/rmc_lib.c -o main.goto
cbmc --bounds-check --pointer-check --pointer-primitive-check --conversion-check --div-by-zero-check --float-overflow-check --nan-check --pointer-overflow-check --signed-overflow-check --undefined-shift-check --unsigned-overflow-check --unwinding-assertions --function main --xml-ui --trace main.goto > "./results.xml"
cbmc --xml-ui --cover location main.goto > "./coverage.xml"
cbmc --bounds-check --pointer-check --pointer-primitive-check --conversion-check --div-by-zero-check --float-overflow-check --nan-check --pointer-overflow-check --signed-overflow-check --undefined-shift-check --unsigned-overflow-check --unwinding-assertions --function main --xml-ui --show-properties main.goto > "./property.xml"
cbmc-viewer --result ./results.xml --coverage ./coverage.xml --property ./property.xml --srcdir /Users/vecchiot/Documents/rmc/src/test/cbmc/Closure --wkdir /Users/vecchiot/Documents/rmc/src/test/cbmc/Closure --goto main.goto --reportdir ./report
```

### Resolved issues:

### Call-outs:

### Testing:

* How is this change tested? Existing regression suite.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x]  My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
