### PR TITLE
Fix closure untupling/retupling

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/metadata.rs
@@ -255,13 +255,37 @@ impl<'tcx> GotocCtx<'tcx> {
         self.monomorphize(p.ty(self.current_fn().mir().local_decls(), self.tcx).ty)
     }
 
-    pub fn closure_params(&self, substs: ty::subst::SubstsRef<'tcx>) -> Vec<Ty<'tcx>> {
-        let sig = self.monomorphize(substs.as_closure().sig());
-        let args = match sig.skip_binder().inputs()[0].kind() {
-            ty::Tuple(substs) => substs.iter().map(|s| s.expect_ty()),
-            _ => unreachable!("this argument of a closure must be a tuple"),
-        };
-        args.collect()
+    /// Closures expect their last arg untupled at call site, see comment at
+    /// ty_needs_closure_untupled.
+    fn sig_with_closure_untupled(&self, sig: ty::PolyFnSig<'tcx>) -> ty::PolyFnSig<'tcx> {
+        debug!("sig_with_closure_untupled sig: {:?}", sig);
+        let fn_sig = sig.skip_binder();
+        if let Some((tupe, prev_args)) = fn_sig.inputs().split_last() {
+            let args: Vec<Ty<'tcx>> = match tupe.kind() {
+                ty::Tuple(substs) => substs.iter().map(|s| s.expect_ty()),
+                _ => unreachable!("the final argument of a closure must be a tuple"),
+            }
+            .collect();
+
+            // The leading argument should be exactly the environment
+            assert!(prev_args.len() == 1);
+            let env = prev_args[0].clone();
+
+            // Recombine arguments: environment first, then the flattened tuple elements
+            let recombined_args = iter::once(env).chain(args);
+
+            return ty::Binder::bind_with_vars(
+                self.tcx.mk_fn_sig(
+                    recombined_args,
+                    fn_sig.output(),
+                    fn_sig.c_variadic,
+                    fn_sig.unsafety,
+                    fn_sig.abi,
+                ),
+                sig.bound_vars(),
+            );
+        }
+        sig
     }
 
     fn closure_sig(
@@ -283,30 +307,41 @@ impl<'tcx> GotocCtx<'tcx> {
         let env_region = ty::ReLateBound(ty::INNERMOST, br);
         let env_ty = self.tcx.closure_env_ty(def_id, substs, env_region).unwrap();
 
-        // The parameter types are tupled, but we want to have them in a vector
-        let params = self.closure_params(substs);
         let sig = sig.skip_binder();
 
         // We build a binder from `sig` where:
         //  * `inputs` contains a sequence with the closure and parameter types
         //  * the rest of attributes are obtained from `sig`
-        ty::Binder::bind_with_vars(
+        let sig = ty::Binder::bind_with_vars(
             self.tcx.mk_fn_sig(
-                iter::once(env_ty).chain(params.iter().cloned()),
+                iter::once(env_ty).chain(iter::once(sig.inputs()[0])),
                 sig.output(),
                 sig.c_variadic,
                 sig.unsafety,
                 sig.abi,
             ),
             bound_vars,
-        )
+        );
+
+        // The parameter types are tupled, but we want to have them in a vector
+        self.sig_with_closure_untupled(sig)
     }
 
     pub fn fn_sig_of_instance(&self, instance: Instance<'tcx>) -> ty::PolyFnSig<'tcx> {
         let fntyp = instance.ty(self.tcx, ty::ParamEnv::reveal_all());
         self.monomorphize(match fntyp.kind() {
             ty::Closure(def_id, subst) => self.closure_sig(*def_id, subst),
-            _ => fntyp.fn_sig(self.tcx),
+            ty::FnPtr(..) | ty::FnDef(..) => {
+                let sig = fntyp.fn_sig(self.tcx);
+                // Some virtual calls through a vtable may actually be closures
+                // or shims that also need the arguments untupled, even though
+                // the kind of the trait type is not a ty::Closure.
+                if self.ty_needs_closure_untupled(fntyp) {
+                    return self.sig_with_closure_untupled(sig);
+                }
+                sig
+            }
+            _ => unreachable!("Can't get function signature of type: {:?}", fntyp),
         })
     }
 

--- a/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
@@ -136,7 +136,7 @@ impl<'tcx> GotocCtx<'tcx> {
         let ldecls = mir.local_decls();
         ldecls.indices().for_each(|lc| {
             if Some(lc) == mir.spread_arg {
-                // We have already added this local in the functin prelude, so
+                // We have already added this local in the function prelude, so
                 // skip adding it again here.
                 return;
             }

--- a/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use bitflags::_core::any::Any;
 use cbmc::goto_program::symtab_transformer;
-use cbmc::goto_program::{Stmt, Symbol, SymbolTable};
+use cbmc::goto_program::{Expr, Stmt, Symbol, SymbolTable};
 use cbmc::{MachineModel, RoundingMode};
 use metadata::*;
 use rustc_codegen_ssa::traits::CodegenBackend;
@@ -12,10 +12,10 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_middle::middle::cstore::{EncodedMetadata, MetadataLoaderDyn};
 use rustc_middle::mir::mono::{CodegenUnit, MonoItem};
-use rustc_middle::mir::{BasicBlock, BasicBlockData, Body, HasLocalDecls};
+use rustc_middle::mir::{BasicBlock, BasicBlockData, Body, HasLocalDecls, Local};
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::query::Providers;
-use rustc_middle::ty::{self, Instance, TyCtxt};
+use rustc_middle::ty::{self, Instance, TyCtxt, TyS};
 use rustc_serialize::json::ToJson;
 use rustc_session::config::{OutputFilenames, OutputType};
 use rustc_session::Session;
@@ -135,10 +135,12 @@ impl<'tcx> GotocCtx<'tcx> {
         let mir = self.current_fn().mir();
         let ldecls = mir.local_decls();
         ldecls.indices().for_each(|lc| {
-            let base_name = match self.find_debug_info(&lc) {
-                None => format!("var_{}", lc.index()),
-                Some(info) => format!("{}", info.name),
-            };
+            if Some(lc) == mir.spread_arg {
+                // We have already added this local in the functin prelude, so
+                // skip adding it again here. 
+                return
+            }
+            let base_name = self.codegen_var_base_name(&lc);
             let name = self.codegen_var_name(&lc);
             let ldata = &ldecls[lc];
             let t = self.monomorphize(ldata.ty);
@@ -149,11 +151,94 @@ impl<'tcx> GotocCtx<'tcx> {
             let sym_e = sym.to_expr();
             self.symbol_table.insert(sym);
 
-            // declare local variables. 0 represents return value
+            // Index 0 represents the return value, which does not need to be
+            // declared in the first block
             if lc.index() < 1 || lc.index() > mir.arg_count {
                 self.current_fn_mut().push_onto_block(Stmt::decl(sym_e, None, loc));
             }
         });
+    }
+
+    /// MIR functions have a `spread_arg` field that specifies whether the
+    /// final argument to the function is "spread" at the LLVM/codegen level
+    /// from a tuple into its individual components. (Used for the "rust-
+    /// call" ABI, necessary because dynamic trait closure cannot have an
+    /// argument list in MIR that is both generic and variadic, so Rust
+    /// allows a generic tuple).
+    ///
+    /// If `spread_arg` is Some, then the wrapped value is the local that is
+    /// to be "spread"/untupled. However, the MIR function body itself expects
+    /// the tuple instead of the individual components, so we need to generate
+    /// a function prelude that _retuples_, that is, writes the components
+    /// back to the tuple local for use in the body.
+    ///
+    /// See:
+    /// https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Determine.20untupled.20closure.20args.20from.20Instance.3F
+    fn codegen_function_prelude(&mut self) {
+        let mir = self.current_fn().mir();
+        if mir.spread_arg.is_none() {
+            // No special tuple argument, no work to be done.
+            return;
+        }
+        let spread_arg = mir.spread_arg.unwrap();
+        let spread_data = &mir.local_decls()[spread_arg];
+        let loc = self.codegen_span2(&spread_data.source_info.span);
+
+        // When we codegen the function signature elsewhere, we will codegen the
+        // untupled version. So, the tuple argument itself needs to have a
+        // symbol declared for it outside of the function signature, we do that
+        // here.
+        let tup_typ = self.codegen_ty(self.monomorphize(spread_data.ty));
+        let tup_sym = Symbol::variable(
+            self.codegen_var_name(&spread_arg),
+            self.codegen_var_base_name(&spread_arg),
+            tup_typ.clone(),
+            loc.clone(),
+        );
+        self.symbol_table.insert(tup_sym.clone());
+
+        // Get the function signature from MIR, _before_ we untuple
+        let fntyp = self.current_fn().instance().ty(self.tcx, ty::ParamEnv::reveal_all());
+        let sig = match fntyp.kind() {
+            ty::FnPtr(..) | ty::FnDef(..) => fntyp.fn_sig(self.tcx).skip_binder(),
+            // Closures themselves will have their arguments already untupled,
+            // see Zulip link above.
+            ty::Closure(..) => unreachable!(
+                "Unexpected `spread arg` set for closure, got: {:?}, {:?}",
+                fntyp,
+                self.current_fn().readable_name()
+            ),
+            _ => unreachable!(
+                "Expected function type for `spread arg` prelude, got: {:?}, {:?}",
+                fntyp,
+                self.current_fn().readable_name()
+            ),
+        };
+
+        // Now that we have the tuple, write the individual component locals
+        // back to it as a GotoC struct.
+        let tupe = sig.inputs().last().unwrap();
+        let args: Vec<&TyS<'tcx>> = match tupe.kind() {
+            ty::Tuple(substs) => substs.iter().map(|s| s.expect_ty()).collect(),
+            _ => unreachable!("a function's spread argument must be a tuple"),
+        };
+
+        // Convert each arg to a GotoC expression.
+        let mut arg_exprs = Vec::new();
+        let starting_idx = sig.inputs().len();
+        for (arg_i, arg_t) in args.iter().enumerate() {
+            // The components come at the end, so offset by the untupled length.
+            let lc = Local::from_usize(arg_i + starting_idx);
+            let (name, base_name) = self.codegen_spread_arg_name(&lc);
+            let sym = Symbol::variable(name, base_name, self.codegen_ty(arg_t), loc.clone());
+            self.symbol_table.insert(sym.clone());
+            arg_exprs.push(sym.to_expr());
+        }
+
+        // Finally, combine the expression into a struct.
+        let tuple_expr = Expr::struct_expr_from_values(tup_typ, arg_exprs, &self.symbol_table)
+            .with_location(loc.clone());
+        self.current_fn_mut().push_onto_block(Stmt::decl(tup_sym.to_expr(), Some(tuple_expr), loc));
     }
 
     /// collect all labels for goto
@@ -202,6 +287,7 @@ impl<'tcx> GotocCtx<'tcx> {
             self.print_instance(instance, mir);
             let labels = self.codegen_prepare_blocks();
             self.current_fn_mut().set_labels(labels);
+            self.codegen_function_prelude();
             self.codegen_declare_variables();
 
             mir.basic_blocks().iter_enumerated().for_each(|(bb, bbd)| self.codegen_block(bb, bbd));

--- a/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
@@ -137,8 +137,8 @@ impl<'tcx> GotocCtx<'tcx> {
         ldecls.indices().for_each(|lc| {
             if Some(lc) == mir.spread_arg {
                 // We have already added this local in the functin prelude, so
-                // skip adding it again here. 
-                return
+                // skip adding it again here.
+                return;
             }
             let base_name = self.codegen_var_base_name(&lc);
             let name = self.codegen_var_name(&lc);

--- a/src/test/cbmc/DynTrait/boxed_closure.rs
+++ b/src/test/cbmc/DynTrait/boxed_closure.rs
@@ -5,8 +5,11 @@
 
 fn main() {
     // Create a boxed once-callable closure
-    let f: Box<dyn FnOnce(i32)> = Box::new(|x| assert!(x == 1));
+    let f: Box<dyn FnOnce(f32, i32)> = Box::new(|x, y| {
+        assert!(x == 1.0);
+        assert!(y == 2);
+    });
 
     // Call it
-    f(1);
+    f(1.0, 2);
 }

--- a/src/test/cbmc/DynTrait/dyn_fn_param.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param.rs
@@ -1,13 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//rmc-flags: --no-memory-safety-checks
-
-// We use `--no-memory-safety-checks` in this test to avoid getting
-// a verification failure:
-// [pointer_dereference.14] invalid function pointer: FAILURE
-// Tracking issue: https://github.com/model-checking/rmc/issues/307
-
 // Check that we can pass a dyn function pointer to a stand alone
 // function definition
 

--- a/src/test/cbmc/DynTrait/nested_closures.rs
+++ b/src/test/cbmc/DynTrait/nested_closures.rs
@@ -4,26 +4,30 @@
 // Check that we can codegen various nesting structures of boxes and
 // pointer to closures.
 
-// FIXME: several cases fail because we need to "retuple" closures,
-// see: https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Determine.20untupled.20closure.20args.20from.20Instance.3F
-
 fn main() {
     // Create a nested boxed once-callable closure
     let f: Box<Box<dyn FnOnce(i32)>> = Box::new(Box::new(|x| assert!(x == 1)));
     f(1);
 
     // Create a pointer to a closure
-    let g = |y| assert!(y == 2);
-    let p: &dyn Fn(i32) = &g;
-    p(2);
+    let g = |x: f32, y: i32| {
+        assert!(x == 1.0);
+        assert!(y == 2)
+    };
+    let p: &dyn Fn(f32, i32) = &g;
+    p(1.0, 2);
 
     // Additional level of pointer nesting
-    let q: &dyn Fn(i32) = &p;
-    q(2);
+    let q: &dyn Fn(f32, i32) = &p;
+    q(1.0, 2);
 
     // Create a boxed pointer to a closure
-    let r: Box<&dyn Fn(i32)> = Box::new(&g);
-    r(2);
+    let r: Box<&dyn Fn(f32, i32, bool)> = Box::new(&|x: f32, y: i32, z: bool| {
+        assert!(x == 1.0);
+        assert!(y == 2);
+        assert!(z);
+    });
+    r(1.0, 2, true);
 
     // Another boxed box
     let s: Box<Box<dyn Fn(i32)>> = Box::new(Box::new(|x| assert!(x == 3)));

--- a/src/test/cbmc/DynTrait/nested_closures_fail.rs
+++ b/src/test/cbmc/DynTrait/nested_closures_fail.rs
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Check that we can codegen various nesting structures of boxes and
+// pointer to closures. Conditions negated for negative test.
+
+// rmc-verify-fail
+
+include!("../../rmc-prelude.rs");
+
+fn main() {
+    // Create a nested boxed once-callable closure
+    let f: Box<Box<dyn FnOnce(i32)>> =
+        Box::new(Box::new(|x| __VERIFIER_expect_fail(x != 1, "wrong int")));
+    f(1);
+
+    // Create a pointer to a closure
+    let g = |x: f32, y: i32| {
+        __VERIFIER_expect_fail(x != 1.0, "wrong float");
+        __VERIFIER_expect_fail(y != 2, "wrong int")
+    };
+    let p: &dyn Fn(f32, i32) = &g;
+    p(1.0, 2);
+
+    // Additional level of pointer nesting
+    let q: &dyn Fn(f32, i32) = &p;
+    q(1.0, 2);
+
+    // Create a boxed pointer to a closure
+    let r: Box<&dyn Fn(f32, i32, bool)> = Box::new(&|x: f32, y: i32, z: bool| {
+        __VERIFIER_expect_fail(x != 1.0, "wrong float");
+        __VERIFIER_expect_fail(y != 2, "wrong int");
+        __VERIFIER_expect_fail(!z, "wrong bool");
+    });
+    r(1.0, 2, true);
+
+    // Another boxed box
+    let s: Box<Box<dyn Fn(i32)>> =
+        Box::new(Box::new(|x| __VERIFIER_expect_fail(x != 3, "wrong int")));
+    s(3);
+
+    // A pointer to the boxed box
+    let t: &Box<Box<dyn Fn(i32)>> = &s;
+    t(3);
+}


### PR DESCRIPTION
### Description of changes: 

RMC currently fails to verify some nested boxed closures, such as this:
```rust
    let f: Box<Box<dyn FnOnce(f32, i32)>> = Box::new(Box::new(|x, y| { assert!(x == 1.0); assert!(y == 2) }));
    f(1.0, 2);
```

Here is an example of the code we now generate (with renaming for clarity):
```
struct Unit call_once_vtable_shim(struct [boxed_closure.rs:8:49: 11:6] *var_1, float spread_2, int spread_3)
{
  struct (f32, i32) var_2={ .0=spread_2, .1=spread_3 }; // new: retuple since the body requires it
  struct Unit var_0;

bb0:
  ;
  boxed_closure_main(*var_1, var_2.0, var_2.1);

bb1:
  ;
  return var_0;
}
```


The problem is that we were checking whether to untuple closure arguments based on whether the function's type kind was a `Closure`, but this misses some cases (where the trait points to a defined function, or with vtable shims) where the type is a `FnDef`. The right way to check for untupling is via a check to the function's ABI. However, in that case, we also need to _retuple_ arguments based on the MIR's `spread_arg` flag. See [this Zulip](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Determine.20untupled.20closure.20args.20from.20Instance.3F) for more discussion.

The trickiness here is that we need to insert both the tuple and its individual components into the symbol table, and then write the components out to the tuple at the start of a function. To do this, I added a new naming convention for the untupled args, avoiding naming conflicts based on the local index. Local index math determines what gets retupled when necessary.

### Resolved issues:

Resolves #240


### Call-outs:

`ignore_var_ty` is mystifying, and there are some intrinsic cases where skipping `FnDef` there elides the environment argument of a call through a tuple. I don't like this, and we should probably eventually remove `ignore_var_ty` in favor of elides arguments only for specific, documented reasons (like the being Zero Sized Types that rust elides). 

### Testing:

* How is this change tested?

Existing tests, including a `fixme` added in my last PR.

* Is this a refactor change?

Somewhat.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
