### PR TITLE
Conform with recent rustc changes (caller_location intrinsic)

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/intrinsic.rs
@@ -304,6 +304,9 @@ impl<'tcx> GotocCtx<'tcx> {
             "atomic_xsub_relaxed" => codegen_atomic_binop!(sub),
             "breakpoint" => Stmt::skip(loc),
             "bswap" => self.codegen_expr_to_place(p, fargs.remove(0).bswap()),
+            // TODO: Handle new `caller_location` intrinsic
+            // https://github.com/model-checking/rmc/issues/374
+            "caller_location" => Stmt::skip(loc),
             "ceilf32" => codegen_simple_intrinsic!(Ceilf),
             "ceilf64" => codegen_simple_intrinsic!(Ceil),
             "copy" => codegen_intrinsic_copy!(Memmove),

--- a/compiler/rustc_codegen_llvm/src/gotoc/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/intrinsic.rs
@@ -304,9 +304,9 @@ impl<'tcx> GotocCtx<'tcx> {
             "atomic_xsub_relaxed" => codegen_atomic_binop!(sub),
             "breakpoint" => Stmt::skip(loc),
             "bswap" => self.codegen_expr_to_place(p, fargs.remove(0).bswap()),
-            // TODO: Handle new `caller_location` intrinsic
-            // https://github.com/model-checking/rmc/issues/374
-            "caller_location" => Stmt::skip(loc),
+            "caller_location" => {
+                codegen_unimplemented_intrinsic!("https://github.com/model-checking/rmc/issues/374")
+            }
             "ceilf32" => codegen_simple_intrinsic!(Ceilf),
             "ceilf64" => codegen_simple_intrinsic!(Ceil),
             "copy" => codegen_intrinsic_copy!(Memmove),


### PR DESCRIPTION
### Description of changes: 

This is PR handles the new `caller_location` intrinsic for #346 to be completed. Surprisingly, the regression has not failed in CI, but it is doing so locally. This has caused two new issues to be opened, #374 (extend intrinsic) and #375 (verify CI).

### Testing:

* How is this change tested? Existing regression.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
