### PR TITLE
Fix extern statics to be codegenned as extern

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/env.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/env.rs
@@ -69,14 +69,12 @@ pub fn additional_env_symbols() -> Vec<Symbol> {
         int_constant("__CPROVER_malloc_failure_mode_assert_then_assume", 2),
         int_constant("__CPROVER_malloc_failure_mode_return_null", 1),
         Symbol::typedef("__CPROVER_size_t", "__CPROVER_size_t", Type::size_t(), Location::none()),
-        Symbol::variable(
+        Symbol::static_variable(
             "__CPROVER_memory".to_string(),
             "__CPROVER_memory".to_string(),
             Type::unsigned_int(8).infinite_array_of(),
             Location::none(),
         )
-        .with_is_extern(true)
-        .with_is_static_lifetime(true)
-        .with_is_thread_local(false),
+        .with_is_extern(true),
     ]
 }

--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/symbol.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/symbol.rs
@@ -175,6 +175,12 @@ impl Symbol {
             .with_is_state_var(true)
     }
 
+    pub fn static_variable(name: String, base_name: String, t: Type, l: Location) -> Symbol {
+        Symbol::variable(name, base_name, t, l)
+            .with_is_thread_local(false)
+            .with_is_static_lifetime(true)
+    }
+
     pub fn struct_type(name: &str, components: Vec<DatatypeComponent>) -> Symbol {
         Symbol::aggr_ty(Type::struct_type(name, components))
     }

--- a/compiler/rustc_codegen_llvm/src/gotoc/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/metadata.rs
@@ -194,10 +194,8 @@ impl<'tcx> GotocCtx<'tcx> {
         init_fn: F,
     ) -> Expr {
         if !self.symbol_table.contains(name) {
-            let sym = Symbol::variable(name.to_string(), name.to_string(), t.clone(), loc)
-                .with_is_file_local(is_file_local)
-                .with_is_thread_local(false)
-                .with_is_static_lifetime(true);
+            let sym = Symbol::static_variable(name.to_string(), name.to_string(), t.clone(), loc)
+                .with_is_file_local(is_file_local);
             let var = sym.to_expr();
             self.symbol_table.insert(sym);
             if let Some(body) = init_fn(self, var) {

--- a/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mod.rs
@@ -334,9 +334,7 @@ impl<'tcx> GotocCtx<'tcx> {
         let typ = self.codegen_ty(self.tcx.type_of(def_id));
         let span = self.tcx.def_span(def_id);
         let location = self.codegen_span2(&span);
-        let symbol = Symbol::variable(symbol_name.to_string(), symbol_name, typ, location)
-            .with_is_thread_local(false)
-            .with_is_static_lifetime(true);
+        let symbol = Symbol::static_variable(symbol_name.to_string(), symbol_name, typ, location);
         self.symbol_table.insert(symbol);
     }
 

--- a/compiler/rustc_codegen_llvm/src/gotoc/operand.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/operand.rs
@@ -329,11 +329,11 @@ impl<'tcx> GotocCtx<'tcx> {
 
                 let sym = self.ensure(&self.symbol_name(instance), |ctx, name| {
                     // check if this static is extern
-                    // TODO: copying what cranelift did here
                     let rlinkage = ctx.tcx.codegen_fn_attrs(def_id).linkage;
 
-                    // we believe rlinkage some => not extern
-                    assert!(rlinkage.is_none()); // leave assert, add comment to make ticket
+                    // we believe rlinkage being `Some` means the static not extern
+                    // see https://github.com/model-checking/rmc/issues/388
+                    assert!(rlinkage.is_none());
 
                     let span = ctx.tcx.def_span(def_id);
                     Symbol::static_variable(

--- a/compiler/rustc_codegen_llvm/src/gotoc/operand.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/operand.rs
@@ -332,6 +332,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     let rlinkage = ctx.tcx.codegen_fn_attrs(def_id).linkage;
 
                     // we believe rlinkage being `Some` means the static not extern
+                    // based on compiler/rustc_codegen_cranelift/src/linkage.rs#L21
                     // see https://github.com/model-checking/rmc/issues/388
                     assert!(rlinkage.is_none());
 

--- a/compiler/rustc_codegen_llvm/src/gotoc/operand.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/operand.rs
@@ -323,20 +323,28 @@ impl<'tcx> GotocCtx<'tcx> {
                 // here we have a function pointer
                 self.codegen_func_expr(instance, span).address_of()
             }
-            GlobalAlloc::Static(defid) => {
+            GlobalAlloc::Static(def_id) => {
                 // here we have a potentially unevaluated static
-                let instance = Instance::mono(self.tcx, defid);
-                let name = self.symbol_name(instance);
-                self.ensure(&name, |tcx, _| {
-                    let span = tcx.tcx.def_span(defid);
-                    Symbol::variable(
-                        name.clone(),
-                        name.clone(),
-                        tcx.codegen_ty(instance.ty(tcx.tcx, ty::ParamEnv::reveal_all())),
-                        tcx.codegen_span2(&span),
+                let instance = Instance::mono(self.tcx, def_id);
+
+                let sym = self.ensure(&self.symbol_name(instance), |ctx, name| {
+                    // check if this static is extern
+                    // TODO: copying what cranelift did here
+                    let rlinkage = ctx.tcx.codegen_fn_attrs(def_id).linkage;
+
+                    // we believe rlinkage some => not extern
+                    assert!(rlinkage.is_none()); // leave assert, add comment to make ticket
+
+                    let span = ctx.tcx.def_span(def_id);
+                    Symbol::static_variable(
+                        name.to_string(),
+                        name.to_string(),
+                        ctx.codegen_ty(instance.ty(ctx.tcx, ty::ParamEnv::reveal_all())),
+                        ctx.codegen_span2(&span),
                     )
+                    .with_is_extern(rlinkage.is_none())
                 });
-                self.symbol_table.lookup(&name).unwrap().clone().to_expr().address_of()
+                sym.clone().to_expr().address_of()
             }
             GlobalAlloc::Memory(alloc) => {
                 // crate_name added so that allocations in different crates don't clash


### PR DESCRIPTION
### Description of changes: 

Currently, given code like the following, the symbol for `A` is not labelled as extern. This PR fixes that, and also cleans up how static variable symbols are created.

```Rust
extern "C" {
    static mut A: u32;
}
```

### Resolved issues:

Resolves #369 

### Call-outs:

### Testing:

* How is this change tested? Existing regression suite.

* Is this a refactor change? None.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
