### PR TITLE
Add initial support for Litani build and dashboard.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,4 +76,7 @@ __pycache__/
 src/test/rustdoc-gui/src/**.lock
 
 # Before adding new lines, see the comment at the top.
+/.litani_cache_dir
+/.ninja_deps
+/.ninja_log
 /src/test/ref

--- a/.gitmodules
+++ b/.gitmodules
@@ -47,3 +47,7 @@
 [submodule "firecracker"]
 	path = firecracker
 	url = https://github.com/firecracker-microvm/firecracker.git
+[submodule "src/tools/aws-build-accumulator"]
+	path = src/tools/aws-build-accumulator
+	url = https://github.com/awslabs/aws-build-accumulator.git
+	branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -47,7 +47,7 @@
 [submodule "firecracker"]
 	path = firecracker
 	url = https://github.com/firecracker-microvm/firecracker.git
-[submodule "src/tools/aws-build-accumulator"]
-	path = src/tools/aws-build-accumulator
+[submodule "src/tools/litani"]
+	path = src/tools/litani
 	url = https://github.com/awslabs/aws-build-accumulator.git
 	branch = develop

--- a/src/tools/dashboard/src/litani.rs
+++ b/src/tools/dashboard/src/litani.rs
@@ -50,6 +50,7 @@ impl Litani {
         pipeline: &str,
         stage: &str,
         exit_status: i32,
+        timeout: u32,
     ) {
         let mut job = Command::new("litani");
         // The given command may contain additional env vars. Prepend those vars
@@ -80,7 +81,7 @@ impl Litani {
             "--ok-returns",
             &exit_status.to_string(),
             "--timeout",
-            "10",
+            &timeout.to_string(),
         ]);
         if !inputs.is_empty() {
             job.arg("--inputs").args(inputs);

--- a/src/tools/dashboard/src/litani.rs
+++ b/src/tools/dashboard/src/litani.rs
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Utilities to interact with the `Litani` build accumulator.
+
+use pulldown_cmark::escape::StrWrite;
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::{Child, Command};
+
+/// Data structure representing a `Litani` build.
+pub struct Litani {
+    /// A buffer of the `spawn`ed Litani jobs so far. `Litani` takes some time
+    /// to execute each `add-job` command and executing thousands of them
+    /// sequentially takes a considerable amount of time. To speed up the
+    /// execution of those commands, we spawn those commands sequentially (as
+    /// normal). However, instead of `wait`ing for each process to terminate,
+    /// we add its handle to a buffer of the `spawn`ed processes and continue
+    /// with our program. Once we are done adding jobs, we wait for all of them
+    /// to terminate before we run the `run-build` command.
+    spawned_commands: Vec<Child>,
+}
+
+impl Litani {
+    /// Sets up a new [`Litani`] run.
+    pub fn init(project_name: &str, output_prefix: &Path, output_symlink: &Path) -> Self {
+        Command::new("litani")
+            .args([
+                "init",
+                "--project-name",
+                project_name,
+                "--output-prefix",
+                output_prefix.to_str().unwrap(),
+                "--output-symlink",
+                output_symlink.to_str().unwrap(),
+            ])
+            .spawn()
+            .unwrap()
+            .wait()
+            .unwrap();
+        Self { spawned_commands: Vec::new() }
+    }
+
+    /// Adds a single command with its dependencies.
+    pub fn add_job(
+        &mut self,
+        command: &Command,
+        description: &str,
+        pipeline: &str,
+        stage: &str,
+        exit_status: i32,
+    ) {
+        let mut job = Command::new("litani");
+        // The given command may contain additional env vars. Prepend those vars
+        // to the command before passing it to Litani.
+        let job_envs: HashMap<_, _> = job.get_envs().collect();
+        let mut new_envs = String::new();
+        command.get_envs().filter(|(k, _)| !job_envs.contains_key(k)).fold(
+            &mut new_envs,
+            |fmt, (k, v)| {
+                fmt.write_fmt(format_args!(
+                    "{}=\"{}\" ",
+                    k.to_str().unwrap(),
+                    v.unwrap().to_str().unwrap()
+                ))
+                .unwrap();
+                fmt
+            },
+        );
+        job.args([
+            "add-job",
+            "--command",
+            &format!("{}{:?}", new_envs, command),
+            "--description",
+            description,
+            "--pipeline-name",
+            pipeline,
+            "--ci-stage",
+            stage,
+            "--ok-returns",
+            &exit_status.to_string(),
+        ]);
+        // Start executing the command, but do not wait for it to terminate.
+        self.spawned_commands.push(job.spawn().unwrap());
+    }
+
+    /// Starts a [`Litani`] run.
+    pub fn run_build(&mut self) {
+        // Wait for all spawned processes to terminate.
+        for command in self.spawned_commands.iter_mut() {
+            command.wait().unwrap();
+        }
+        self.spawned_commands.clear();
+        // Run `run-build` command and wait for it to finish.
+        Command::new("litani").arg("run-build").spawn().unwrap().wait().unwrap();
+    }
+}

--- a/src/tools/dashboard/src/litani.rs
+++ b/src/tools/dashboard/src/litani.rs
@@ -54,18 +54,17 @@ impl Litani {
         // to the command before passing it to Litani.
         let job_envs: HashMap<_, _> = job.get_envs().collect();
         let mut new_envs = String::new();
-        command.get_envs().filter(|(k, _)| !job_envs.contains_key(k)).fold(
-            &mut new_envs,
-            |fmt, (k, v)| {
+        command.get_envs().fold(&mut new_envs, |fmt, (k, v)| {
+            if !job_envs.contains_key(k) {
                 fmt.write_fmt(format_args!(
                     "{}=\"{}\" ",
                     k.to_str().unwrap(),
                     v.unwrap().to_str().unwrap()
                 ))
                 .unwrap();
-                fmt
-            },
-        );
+            }
+            fmt
+        });
         job.args([
             "add-job",
             "--command",
@@ -78,6 +77,8 @@ impl Litani {
             stage,
             "--ok-returns",
             &exit_status.to_string(),
+            "--timeout",
+            "10",
         ]);
         // Start executing the command, but do not wait for it to terminate.
         self.spawned_commands.push(job.spawn().unwrap());

--- a/src/tools/dashboard/src/litani.rs
+++ b/src/tools/dashboard/src/litani.rs
@@ -44,6 +44,8 @@ impl Litani {
     pub fn add_job(
         &mut self,
         command: &Command,
+        inputs: &[&Path],
+        outputs: &[&Path],
         description: &str,
         pipeline: &str,
         stage: &str,
@@ -80,6 +82,12 @@ impl Litani {
             "--timeout",
             "10",
         ]);
+        if !inputs.is_empty() {
+            job.arg("--inputs").args(inputs);
+        }
+        if !outputs.is_empty() {
+            job.arg("--outputs").args(outputs).arg("--phony-outputs").args(outputs);
+        }
         // Start executing the command, but do not wait for it to terminate.
         self.spawned_commands.push(job.spawn().unwrap());
     }

--- a/src/tools/dashboard/src/main.rs
+++ b/src/tools/dashboard/src/main.rs
@@ -1,8 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+#![feature(command_access)]
 
 mod dashboard;
+mod litani;
 mod reference;
+mod util;
 
 fn main() {
     reference::display_reference_dashboard();

--- a/src/tools/dashboard/src/util.rs
+++ b/src/tools/dashboard/src/util.rs
@@ -1,0 +1,198 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! The types and procedures in this modules are similar to the ones in
+//! `compiletest`. Consider using `Litani` to run the test suites.
+
+use crate::litani::Litani;
+use std::{
+    env,
+    fs::File,
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// Step at which RMC should panic.
+#[derive(PartialEq)]
+pub enum FailStep {
+    /// RMC panics before the codegen step (up to MIR generation). This step
+    /// runs the same checks on the test code as `cargo check` including syntax,
+    /// type, name resolution, and borrow checks.
+    Check,
+    /// RMC panics at the codegen step because the test code uses unimplemented
+    /// and/or unsupported features.
+    Codegen,
+    /// RMC panics after the codegen step because of verification failures or
+    /// other CBMC errors.
+    Verification,
+}
+
+/// Data structure representing properties specific to each test.
+pub struct TestProps {
+    pub path: PathBuf,
+    /// How far this test should proceed to start failing.
+    pub fail_step: Option<FailStep>,
+    /// Extra arguments to pass to `rustc`.
+    pub rustc_args: Vec<String>,
+    /// Extra arguments to pass to RMC.
+    pub rmc_args: Vec<String>,
+}
+
+impl TestProps {
+    /// Creates a new instance of [`TestProps`] for a test.
+    pub fn new(
+        path: PathBuf,
+        fail_step: Option<FailStep>,
+        rustc_args: Vec<String>,
+        rmc_args: Vec<String>,
+    ) -> Self {
+        Self { path, fail_step, rustc_args, rmc_args }
+    }
+}
+
+/// Parses strings of the form `rmc-*-fail` and returns the step at which RMC is
+/// expected to panic.
+fn try_parse_fail_step(cur_fail_step: Option<FailStep>, line: &str) -> Option<FailStep> {
+    let fail_step = if line.contains("rmc-check-fail") {
+        Some(FailStep::Check)
+    } else if line.contains("rmc-codegen-fail") {
+        Some(FailStep::Codegen)
+    } else if line.contains("rmc-verify-fail") {
+        Some(FailStep::Verification)
+    } else {
+        None
+    };
+    match (cur_fail_step.is_some(), fail_step.is_some()) {
+        (true, true) => panic!("Error: multiple `rmc-*-fail` headers in a single test."),
+        (false, true) => fail_step,
+        _ => cur_fail_step,
+    }
+}
+
+/// Parses strings of the form `<name>-flags: ...` and returns the list of
+/// arguments.
+fn try_parse_args(cur_args: Vec<String>, name: &str, line: &str) -> Vec<String> {
+    let name = format!("{}-flags:", name);
+    let mut split = line.split(&name).skip(1);
+    let args: Vec<String> = if let Some(rest) = split.next() {
+        rest.trim().split_whitespace().map(String::from).collect()
+    } else {
+        Vec::new()
+    };
+    match (cur_args.is_empty(), args.is_empty()) {
+        (false, false) => panic!("..."),
+        (true, false) => args,
+        _ => cur_args,
+    }
+}
+
+/// Parses and returns the properties in a test file.
+pub fn parse_test_header(path: &Path) -> TestProps {
+    let mut fail_step = None;
+    let mut rustc_args = Vec::new();
+    let mut rmc_args = Vec::new();
+    let it = BufReader::new(File::open(path).unwrap());
+    for line in it.lines() {
+        let line = line.unwrap();
+        let line = line.trim_start();
+        if line.is_empty() {
+            continue;
+        }
+        if !line.starts_with("//") {
+            break;
+        }
+        fail_step = try_parse_fail_step(fail_step, line);
+        rustc_args = try_parse_args(rustc_args, "compile", line);
+        rmc_args = try_parse_args(rmc_args, "rmc", line);
+    }
+    TestProps::new(path.to_path_buf(), fail_step, rustc_args, rmc_args)
+}
+
+/// Adds RMC and Litani directories to the current `PATH` environment variable.
+pub fn add_rmc_and_litani_to_path() {
+    let cwd = env::current_dir().unwrap();
+    let rmc_dir = cwd.join("scripts");
+    let mut litani_dir = cwd.clone();
+    litani_dir.extend(["src", "tools", "aws-build-accumulator"].iter());
+    env::set_var(
+        "PATH",
+        format!("{}:{}:{}", rmc_dir.display(), litani_dir.display(), env::var("PATH").unwrap()),
+    );
+}
+
+/// Does RMC catch syntax, type, and borrow errors (if any)?
+pub fn add_check_job(litani: &mut Litani, test_props: &TestProps) {
+    // TODO: add logic to ensure that the next 2 steps run only if this step
+    // succeeds (and RMC is not expected to panic in this step).
+    let exit_status = if test_props.fail_step == Some(FailStep::Check) { 1 } else { 0 };
+    let mut rmc_rustc = Command::new("rmc-rustc");
+    rmc_rustc.args(&test_props.rustc_args).args(["-Z", "no-codegen"]).arg(&test_props.path);
+    // TODO: replace `build` with `check` when Litani adds support for custom
+    // stages.
+    litani.add_job(
+        &rmc_rustc,
+        "Is this valid Rust code?",
+        test_props.path.to_str().unwrap(),
+        "build",
+        exit_status,
+    );
+}
+
+/// Is RMC expected to codegen all the Rust features in the test?
+pub fn add_codegen_job(litani: &mut Litani, test_props: &TestProps) {
+    // TODO: again, add logic to ensure that the next step runs only if this
+    // step succeeds (and RMC is not expected to panic in this step).
+    let exit_status = if test_props.fail_step == Some(FailStep::Codegen) { 1 } else { 0 };
+    let mut rmc_rustc = Command::new("rmc-rustc");
+    rmc_rustc
+        .args(&test_props.rustc_args)
+        .args(["-Z", "codegen-backend=gotoc", "--cfg=rmc", "--out-dir", "build/tmp"])
+        .arg(&test_props.path);
+    // TODO: replace `test` with `codegen` when Litani adds support for custom
+    // stages.
+    litani.add_job(
+        &rmc_rustc,
+        "Does RMC support all the Rust features used in it?",
+        test_props.path.to_str().unwrap(),
+        "test",
+        exit_status,
+    );
+}
+
+// Does verification pass/fail as it is expected to?
+pub fn add_verification_job(litani: &mut Litani, test_props: &TestProps) {
+    let exit_status = if test_props.fail_step == Some(FailStep::Verification) { 10 } else { 0 };
+    let mut rmc = Command::new("rmc");
+    rmc.args(&test_props.rmc_args).arg(&test_props.path);
+    if !test_props.rustc_args.is_empty() {
+        rmc.env("RUSTFLAGS", test_props.rustc_args.join(" "));
+    }
+    // TODO: replace `report` with `verification` when Litani adds support for
+    // custom stages.
+    litani.add_job(
+        &rmc,
+        "Can RMC reason about it?",
+        test_props.path.to_str().unwrap(),
+        "report",
+        exit_status,
+    );
+}
+
+/// Creates a new pipeline for the test specified by `path` consisting of 3
+/// jobs/steps: `check`, `codegen`, and `verification`.
+pub fn add_test_pipeline(litani: &mut Litani, test_props: &TestProps) {
+    // The first step ensures that the Rust code in the test compiles (if it is
+    // expected to).
+    add_check_job(litani, test_props);
+    if test_props.fail_step == Some(FailStep::Check) {
+        return;
+    }
+    // The second step ensures that we can codegen the code in the test.
+    add_codegen_job(litani, test_props);
+    if test_props.fail_step == Some(FailStep::Codegen) {
+        return;
+    }
+    // The final step ensures that CBMC can verify the code in the test.
+    // Notice that 10 is the expected error code for verification failure.
+    add_verification_job(litani, test_props);
+}

--- a/src/tools/dashboard/src/util.rs
+++ b/src/tools/dashboard/src/util.rs
@@ -3,8 +3,8 @@
 //! Utilities types and procedures to parse and run tests.
 //!
 //! TODO: The types and procedures in this modules are similar to the ones in
-//! `compiletest`. Consider using `Litani` to run the test suites (see issue
-//! #390).
+//! `compiletest`. Consider using `Litani` to run the test suites (see
+//! [issue #390](https://github.com/model-checking/rmc/issues/390)).
 
 use crate::litani::Litani;
 use std::{
@@ -125,14 +125,11 @@ pub fn add_rmc_and_litani_to_path() {
 
 /// Does RMC catch syntax, type, and borrow errors (if any)?
 pub fn add_check_job(litani: &mut Litani, test_props: &TestProps) {
-    // TODO: add logic to ensure that the next 2 steps run only if this step
-    // succeeds (and RMC is not expected to panic in this step) (see issue
-    // #392).
     let exit_status = if test_props.fail_step == Some(FailStep::Check) { 1 } else { 0 };
     let mut rmc_rustc = Command::new("rmc-rustc");
     rmc_rustc.args(&test_props.rustc_args).args(["-Z", "no-codegen"]).arg(&test_props.path);
     // TODO: replace `build` with `check` when Litani adds support for custom
-    // stages (see issue #391).
+    // stages (see https://github.com/model-checking/rmc/issues/391).
     let mut phony_out = test_props.path.clone();
     phony_out.set_extension("check");
     litani.add_job(
@@ -143,14 +140,12 @@ pub fn add_check_job(litani: &mut Litani, test_props: &TestProps) {
         test_props.path.to_str().unwrap(),
         "build",
         exit_status,
+        1,
     );
 }
 
 /// Is RMC expected to codegen all the Rust features in the test?
 pub fn add_codegen_job(litani: &mut Litani, test_props: &TestProps) {
-    // TODO: again, add logic to ensure that the next step runs only if this
-    // step succeeds (and RMC is not expected to panic in this step) (see issue
-    // #392).
     let exit_status = if test_props.fail_step == Some(FailStep::Codegen) { 1 } else { 0 };
     let mut rmc_rustc = Command::new("rmc-rustc");
     rmc_rustc
@@ -158,7 +153,7 @@ pub fn add_codegen_job(litani: &mut Litani, test_props: &TestProps) {
         .args(["-Z", "codegen-backend=gotoc", "--cfg=rmc", "--out-dir", "build/tmp"])
         .arg(&test_props.path);
     // TODO: replace `test` with `codegen` when Litani adds support for custom
-    // stages (see issue #391).
+    // stages (see https://github.com/model-checking/rmc/issues/391).
     let mut phony_in = test_props.path.clone();
     phony_in.set_extension("check");
     let mut phony_out = test_props.path.clone();
@@ -171,6 +166,7 @@ pub fn add_codegen_job(litani: &mut Litani, test_props: &TestProps) {
         test_props.path.to_str().unwrap(),
         "test",
         exit_status,
+        1,
     );
 }
 
@@ -183,7 +179,7 @@ pub fn add_verification_job(litani: &mut Litani, test_props: &TestProps) {
         rmc.env("RUSTFLAGS", test_props.rustc_args.join(" "));
     }
     // TODO: replace `report` with `verification` when Litani adds support for
-    // custom stages (see issue #391).
+    // custom stages (see https://github.com/model-checking/rmc/issues/391).
     let mut phony_in = test_props.path.clone();
     phony_in.set_extension("codegen");
     litani.add_job(
@@ -194,6 +190,7 @@ pub fn add_verification_job(litani: &mut Litani, test_props: &TestProps) {
         test_props.path.to_str().unwrap(),
         "report",
         exit_status,
+        10,
     );
 }
 

--- a/src/tools/dashboard/src/util.rs
+++ b/src/tools/dashboard/src/util.rs
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//! The types and procedures in this modules are similar to the ones in
-//! `compiletest`. Consider using `Litani` to run the test suites.
+//! Utilities types and procedures to parse and run tests.
+//!
+//! TODO: The types and procedures in this modules are similar to the ones in
+//! `compiletest`. Consider using `Litani` to run the test suites (see issue
+//! #390).
 
 use crate::litani::Litani;
 use std::{
@@ -80,7 +83,7 @@ fn try_parse_args(cur_args: Vec<String>, name: &str, line: &str) -> Vec<String> 
         Vec::new()
     };
     match (cur_args.is_empty(), args.is_empty()) {
-        (false, false) => panic!("..."),
+        (false, false) => panic!("Error: multiple `{}-flags: ...` headers in a single test.", name),
         (true, false) => args,
         _ => cur_args,
     }
@@ -123,12 +126,13 @@ pub fn add_rmc_and_litani_to_path() {
 /// Does RMC catch syntax, type, and borrow errors (if any)?
 pub fn add_check_job(litani: &mut Litani, test_props: &TestProps) {
     // TODO: add logic to ensure that the next 2 steps run only if this step
-    // succeeds (and RMC is not expected to panic in this step).
+    // succeeds (and RMC is not expected to panic in this step) (see issue
+    // #392).
     let exit_status = if test_props.fail_step == Some(FailStep::Check) { 1 } else { 0 };
     let mut rmc_rustc = Command::new("rmc-rustc");
     rmc_rustc.args(&test_props.rustc_args).args(["-Z", "no-codegen"]).arg(&test_props.path);
     // TODO: replace `build` with `check` when Litani adds support for custom
-    // stages.
+    // stages (see issue #391).
     litani.add_job(
         &rmc_rustc,
         "Is this valid Rust code?",
@@ -141,7 +145,8 @@ pub fn add_check_job(litani: &mut Litani, test_props: &TestProps) {
 /// Is RMC expected to codegen all the Rust features in the test?
 pub fn add_codegen_job(litani: &mut Litani, test_props: &TestProps) {
     // TODO: again, add logic to ensure that the next step runs only if this
-    // step succeeds (and RMC is not expected to panic in this step).
+    // step succeeds (and RMC is not expected to panic in this step) (see issue
+    // #392).
     let exit_status = if test_props.fail_step == Some(FailStep::Codegen) { 1 } else { 0 };
     let mut rmc_rustc = Command::new("rmc-rustc");
     rmc_rustc
@@ -149,7 +154,7 @@ pub fn add_codegen_job(litani: &mut Litani, test_props: &TestProps) {
         .args(["-Z", "codegen-backend=gotoc", "--cfg=rmc", "--out-dir", "build/tmp"])
         .arg(&test_props.path);
     // TODO: replace `test` with `codegen` when Litani adds support for custom
-    // stages.
+    // stages (see issue #391).
     litani.add_job(
         &rmc_rustc,
         "Does RMC support all the Rust features used in it?",
@@ -168,7 +173,7 @@ pub fn add_verification_job(litani: &mut Litani, test_props: &TestProps) {
         rmc.env("RUSTFLAGS", test_props.rustc_args.join(" "));
     }
     // TODO: replace `report` with `verification` when Litani adds support for
-    // custom stages.
+    // custom stages (see issue #391).
     litani.add_job(
         &rmc,
         "Can RMC reason about it?",


### PR DESCRIPTION
### Description of changes:

This PR adds initial support for Litani build. We use Litani to run RMC on the examples and generate an HTML dashboard with the results.

### Resolved issues:

Resolves #384 & #392

### Call-outs:

- `src/tools/dashboard/src/util.rs` contains a lot of duplicated code from `compiletest`. Consider reconciling with `compiletest` or porting all of our test suites to `Litani`.
- We run the examples in the reference twice to generate the terminal dashboard and Litani's dashboard. Consider using `run.json` to generate the terminal dashboard.
- The default names stages Litani uses (`build`, `test`, and `report`) does not match with our stages (`check`, `codegen`, `verification`). Switch to custom stage names when Litani adds support for that.

### Testing:

* How is this change tested?
  * The generated HTML dashboard closely matches the terminal version.
* Is this a refactor change?
  * No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
