### PR TITLE
Fix failing codegen in due to incorrect boolean types

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
@@ -52,21 +52,21 @@ impl<'tcx> GotocCtx<'tcx> {
             BinOp::Rem => ce1.rem(ce2),
             BinOp::BitXor => {
                 if self.operand_ty(e1).is_bool() {
-                    ce1.xor(ce2)
+                    ce1.cast_to(Type::bool()).xor(ce2.cast_to(Type::bool()))
                 } else {
                     ce1.bitxor(ce2)
                 }
             }
             BinOp::BitAnd => {
                 if self.operand_ty(e1).is_bool() {
-                    ce1.and(ce2)
+                    ce1.cast_to(Type::bool()).and(ce2.cast_to(Type::bool()))
                 } else {
                     ce1.bitand(ce2)
                 }
             }
             BinOp::BitOr => {
                 if self.operand_ty(e1).is_bool() {
-                    ce1.or(ce2)
+                    ce1.cast_to(Type::bool()).or(ce2.cast_to(Type::bool()))
                 } else {
                     ce1.bitor(ce2)
                 }

--- a/src/test/cbmc/Bool-BoolOperators/xor.rs
+++ b/src/test/cbmc/Bool-BoolOperators/xor.rs
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+include!("../../rmc-prelude.rs");
+
+fn main() {
+    let a: bool = __nondet();
+    let b: bool = __nondet();
+    let c = a ^ b;
+    assert!((a == b && !c) || (a != b && c));
+}


### PR DESCRIPTION
### Description of changes: 

RMC fails in codegen when generating expression with boolean XOR if the type of operands is `CInteger(Bool)` as CBMC requires them to be `Bool` (https://github.com/diffblue/cbmc/blob/develop/src/solvers/prop/prop_conv_solver.cpp#L194)

### Resolved issues:

Resolves #394 

### Call-outs:

None

### Testing:

* How is this change tested?
Created a new test case out of #394 

* Is this a refactor change?
No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
