### PR TITLE
Disable `rlinkage.is_none()` assertion

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/operand.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/operand.rs
@@ -334,7 +334,12 @@ impl<'tcx> GotocCtx<'tcx> {
                     // we believe rlinkage being `Some` means the static not extern
                     // based on compiler/rustc_codegen_cranelift/src/linkage.rs#L21
                     // see https://github.com/model-checking/rmc/issues/388
-                    assert!(rlinkage.is_none());
+                    //
+                    // Update: The assertion below may fail in similar environments.
+                    // We are disabling it until we find out the root cause, see
+                    // https://github.com/model-checking/rmc/issues/400
+                    //
+                    // assert!(rlinkage.is_none());
 
                     let span = ctx.tcx.def_span(def_id);
                     Symbol::static_variable(


### PR DESCRIPTION
### Description of changes: 

Disables the `rlinkage.is_none()` assertion in `codegen_alloc_pointer` which is failing in my remote desktop when codegen'ing the standard library. See #400 for a backtrace.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing regression.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
