### PR TITLE
Removed incorrect special case for Rust bitwise operators

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/rvalue.rs
@@ -48,30 +48,12 @@ impl<'tcx> GotocCtx<'tcx> {
         let ce1 = self.codegen_operand(e1);
         let ce2 = self.codegen_operand(e2);
         match op {
+            BinOp::BitAnd => ce1.bitand(ce2),
+            BinOp::BitOr => ce1.bitor(ce2),
+            BinOp::BitXor => ce1.bitxor(ce2),
             BinOp::Div => ce1.div(ce2),
             BinOp::Rem => ce1.rem(ce2),
-            BinOp::BitXor => {
-                if self.operand_ty(e1).is_bool() {
-                    ce1.xor(ce2)
-                } else {
-                    ce1.bitxor(ce2)
-                }
-            }
-            BinOp::BitAnd => {
-                if self.operand_ty(e1).is_bool() {
-                    ce1.and(ce2)
-                } else {
-                    ce1.bitand(ce2)
-                }
-            }
-            BinOp::BitOr => {
-                if self.operand_ty(e1).is_bool() {
-                    ce1.or(ce2)
-                } else {
-                    ce1.bitor(ce2)
-                }
-            }
-            _ => unreachable!(),
+            _ => unreachable!("Unexpected {:?}", op),
         }
     }
 

--- a/src/test/cbmc/BitwiseArithOperators/bool.rs
+++ b/src/test/cbmc/BitwiseArithOperators/bool.rs
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+include!("../../rmc-prelude.rs");
+
+fn main() {
+    let a: bool = __nondet();
+    let b: bool = __nondet();
+    let c = a ^ b;
+    assert!((a == b && !c) || (a != b && c));
+}


### PR DESCRIPTION
### Description of changes: 

RMC crashes in codegen for logic operators (And, Or, Xor) applied on bool types.

### Resolved issues:

Resolves #394 


### Call-outs:

None.

### Testing:

* How is this change tested?
Added a new test in the commit: src/test/cbmc/BitwiseArithOperators/bool.rs

* Is this a refactor change?
No.

### Checklist
- [X ] Each commit message has a non-empty body, explaining why the change was made
- [X ] Methods or procedures are documented
- [X ] Regression or unit tests are included, or existing tests cover the modified code
- [X ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
