### PR TITLE
Introduce simd_shuffle intrinsic

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/expr.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/expr.rs
@@ -387,7 +387,7 @@ impl Expr {
                 elems
             );
         } else {
-            unreachable!("Can't make an vector_val with non-vector target type {:?}", typ);
+            unreachable!("Can't make a vector_val with non-vector target type {:?}", typ);
         }
         expr!(Vector { elems }, typ)
     }

--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/expr.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/expr.rs
@@ -146,6 +146,10 @@ pub enum ExprValue {
         op: UnaryOperand,
         e: Expr,
     },
+    /// `vec_typ x = >>> {elems0, elems1 ...} <<<`
+    Vector {
+        elems: Vec<Expr>,
+    },
 }
 
 /// Binary operators. The names are the same as in the Irep representation.
@@ -371,6 +375,21 @@ impl Expr {
             unreachable!("Can't make an array_val with non-array target type {:?}", typ);
         }
         expr!(Array { elems }, typ)
+    }
+
+    pub fn vector_expr(typ: Type, elems: Vec<Expr>) -> Self {
+        if let Type::Vector { size, typ: value_typ } = typ.clone() {
+            assert_eq!(size as usize, elems.len());
+            assert!(
+                elems.iter().all(|x| x.typ == *value_typ),
+                "Vector type and value types don't match: \n{:?}\n{:?}",
+                typ,
+                elems
+            );
+        } else {
+            unreachable!("Can't make an vector_val with non-vector target type {:?}", typ);
+        }
+        expr!(Vector { elems }, typ)
     }
 
     /// `(__CPROVER_bool) >>> true/false <<<`. True/False as a single bit boolean.

--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/symtab_transformer/transformer.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/symtab_transformer/transformer.rs
@@ -266,6 +266,7 @@ pub trait Transformer: Sized {
             ExprValue::Typecast(child) => self.transform_expr_typecast(typ, child),
             ExprValue::Union { value, field } => self.transform_expr_union(typ, value, field),
             ExprValue::UnOp { op, e } => self.transform_expr_un_op(typ, op, e),
+            ExprValue::Vector { elems } => self.transform_expr_vector(typ, elems),
         }
         .with_location(e.location().clone())
     }
@@ -280,6 +281,13 @@ pub trait Transformer: Sized {
         let transformed_typ = self.transform_type(typ);
         let transformed_elems = elems.iter().map(|elem| self.transform_expr(elem)).collect();
         Expr::array_expr(transformed_typ, transformed_elems)
+    }
+
+    /// Transform a vector expr (`vec_typ x[] = >>> {elems0, elems1 ...} <<<`)
+    fn transform_expr_vector(&self, typ: &Type, elems: &[Expr]) -> Expr {
+        let transformed_typ = self.transform_type(typ);
+        let transformed_elems = elems.iter().map(|elem| self.transform_expr(elem)).collect();
+        Expr::vector_expr(transformed_typ, transformed_elems)
     }
 
     /// Transforms an array of expr (`typ x[width] = >>> {elem} <<<`)

--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/irep/to_irep.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/irep/to_irep.rs
@@ -175,7 +175,6 @@ impl ToIrep for ExprValue {
                 sub: vec![e.to_irep(mm), Expr::int_constant(*offset, Type::ssize_t()).to_irep(mm)],
                 named_sub: btree_map![],
             },
-
             ExprValue::CBoolConstant(i) => Irep {
                 id: IrepId::Constant,
                 sub: vec![],
@@ -292,6 +291,11 @@ impl ToIrep for ExprValue {
             ExprValue::UnOp { op, e } => {
                 Irep { id: op.to_irep_id(), sub: vec![e.to_irep(mm)], named_sub: btree_map![] }
             }
+            ExprValue::Vector { elems } => Irep {
+                id: IrepId::Vector,
+                sub: elems.iter().map(|x| x.to_irep(mm)).collect(),
+                named_sub: btree_map![],
+            },
         }
     }
 }

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/intrinsic.rs
@@ -844,6 +844,7 @@ impl<'tcx> GotocCtx<'tcx> {
     ///
     /// We can't use shuffle_vector_exprt because it's not understood by the CBMC backend,
     /// it's immediately lowered by the C frontend.
+    /// Issue: https://github.com/diffblue/cbmc/issues/6297
     pub fn codegen_intrinsic_simd_shuffle(
         &mut self,
         mut fargs: Vec<Expr>,
@@ -857,9 +858,9 @@ impl<'tcx> GotocCtx<'tcx> {
         // [u32; n]: translated wrapped in a struct
         let indexes = fargs.remove(0);
 
-        // TODO: Why is this signed? Unsigned causes an invariant violation in CBMC in my tests.
-        // But it doesn't make sense why an array index type should be signed?
-        let st_rep = Type::CInteger(CIntType::SSizeT);
+        // An unsigned type here causes an invariant violation in CBMC.
+        // Issue: https://github.com/diffblue/cbmc/issues/6298
+        let st_rep = Type::ssize_t();
         let n_rep = Expr::int_constant(n, st_rep.clone());
 
         // P = indexes.expanded_map(v -> if v < N then vec1[v] else vec2[v-N])

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/intrinsic.rs
@@ -820,6 +820,7 @@ impl<'tcx> GotocCtx<'tcx> {
         cbmc_ret_ty: Type,
         loc: Location,
     ) -> Stmt {
+        assert!(fargs.len() == 3, "simd_insert had unexpected arguments {:?}", fargs);
         let vec = fargs.remove(0);
         let index = fargs.remove(0);
         let newval = fargs.remove(0);
@@ -852,6 +853,7 @@ impl<'tcx> GotocCtx<'tcx> {
         cbmc_ret_ty: Type,
         n: u64,
     ) -> Stmt {
+        assert!(fargs.len() == 3, "simd_shuffle had unexpected arguments {:?}", fargs);
         // vector, size n: translated as vector types which cbmc treats as arrays
         let vec1 = fargs.remove(0);
         let vec2 = fargs.remove(0);

--- a/src/test/cbmc/SIMD/Construction/main.rs
+++ b/src/test/cbmc/SIMD/Construction/main.rs
@@ -7,9 +7,16 @@
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i64x2(i64, i64);
 
+#[repr(simd)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct i64x4(i64, i64, i64, i64);
+
 extern "platform-intrinsic" {
     fn simd_extract<T, U>(x: T, idx: u32) -> U;
     fn simd_insert<T, U>(x: T, idx: u32, b: U) -> T;
+    fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
+    fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
 }
 
 fn main() {
@@ -35,5 +42,18 @@ fn main() {
         assert!(n.0 == 0 && n.1 == 5);
         // Original unchanged
         assert!(y.0 == 0 && y.1 == 1);
+    }
+    {
+        const I: [u32; 2] = [1, 2];
+        let x: i64x2 = unsafe { simd_shuffle2(y, z, I) };
+        assert!(x.0 == 1);
+        assert!(x.1 == 1);
+    }
+    {
+        let a = i64x4(1, 2, 3, 4);
+        let b = i64x4(5, 6, 7, 8);
+        const I: [u32; 4] = [1, 3, 5, 7];
+        let c: i64x4 = unsafe { simd_shuffle4(a, b, I) };
+        assert!(c == i64x4(2, 4, 6, 8));
     }
 }

--- a/src/test/cbmc/SIMD/Construction/main.rs
+++ b/src/test/cbmc/SIMD/Construction/main.rs
@@ -7,16 +7,9 @@
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct i64x2(i64, i64);
 
-#[repr(simd)]
-#[allow(non_camel_case_types)]
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct i64x4(i64, i64, i64, i64);
-
 extern "platform-intrinsic" {
     fn simd_extract<T, U>(x: T, idx: u32) -> U;
     fn simd_insert<T, U>(x: T, idx: u32, b: U) -> T;
-    fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
-    fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
 }
 
 fn main() {
@@ -42,18 +35,5 @@ fn main() {
         assert!(n.0 == 0 && n.1 == 5);
         // Original unchanged
         assert!(y.0 == 0 && y.1 == 1);
-    }
-    {
-        const I: [u32; 2] = [1, 2];
-        let x: i64x2 = unsafe { simd_shuffle2(y, z, I) };
-        assert!(x.0 == 1);
-        assert!(x.1 == 1);
-    }
-    {
-        let a = i64x4(1, 2, 3, 4);
-        let b = i64x4(5, 6, 7, 8);
-        const I: [u32; 4] = [1, 3, 5, 7];
-        let c: i64x4 = unsafe { simd_shuffle4(a, b, I) };
-        assert!(c == i64x4(2, 4, 6, 8));
     }
 }

--- a/src/test/cbmc/SIMD/Shuffle/main.rs
+++ b/src/test/cbmc/SIMD/Shuffle/main.rs
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+#![feature(repr_simd, platform_intrinsics)]
+
+#[repr(simd)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct i64x2(i64, i64);
+
+#[repr(simd)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct i64x4(i64, i64, i64, i64);
+
+extern "platform-intrinsic" {
+    fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
+    fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
+}
+
+fn main() {
+    {
+        let y = i64x2(0, 1);
+        let z = i64x2(1, 2);
+        const I: [u32; 2] = [1, 2];
+        let x: i64x2 = unsafe { simd_shuffle2(y, z, I) };
+        assert!(x.0 == 1);
+        assert!(x.1 == 1);
+    }
+    {
+        let a = i64x4(1, 2, 3, 4);
+        let b = i64x4(5, 6, 7, 8);
+        const I: [u32; 4] = [1, 3, 5, 7];
+        let c: i64x4 = unsafe { simd_shuffle4(a, b, I) };
+        assert!(c == i64x4(2, 4, 6, 8));
+    }
+}


### PR DESCRIPTION
### Description of changes: 

1. Add CBMC's `vector_exprt` to our gotoc representation.
2. Add support for the `simd_shuffle` instrinsics.
3. Add a test of the above.

### Resolved issues:

Resolves #309 

### Call-outs:

1. TODO: I need to create some new issues about future follow-ups (e.g. getting CBMC to expose `shuffle_vector_exprt` for us?) and possibly link to them from the code.
2. I still have a TODO in the code about the type of the array index expressions we generate. Currently, I use a signed index. Unsigned causes CBMC to object:

```
--- begin invariant violation report ---
Invariant check failed
File: ../src/solvers/flattening/boolbv_mult.cpp:73 function: convert_mult
Condition: it->type() == expr.type()
Reason: multiplication operands should have same type as expression
```

I'm going to investigate this before merging. It's possible I should be picking the type in some other way, but this is difficult to diagnose because it seems to be internal to CBMC's transformations (e.g. I think we put "array index" in the symbol table, but them CBMC is transforming that into "pointer + index*size" internally, and that's where the "mult" is coming from. A guess, for now. Perplexing because it would seem to imply that the "sizeof" a type has signed type internally?)

### Testing:

* How is this change tested? Added tests.

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
