### PR TITLE
Enable assertion the lhs.typ() and rhs.typ() are equal for assignments

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/stmt.rs
@@ -153,25 +153,7 @@ impl Stmt {
     pub fn assign(lhs: Expr, rhs: Expr, loc: Location) -> Self {
         //Temporarily work around https://github.com/model-checking/rmc/issues/95
         //by disabling the assert and soundly assigning nondet
-        //assert_eq!(lhs.typ(), rhs.typ());
-        if lhs.typ() != rhs.typ() {
-            debug!(
-                "WARNING: assign statement with unequal types lhs {:?} rhs {:?}",
-                lhs.typ(),
-                rhs.typ()
-            );
-            let assert_stmt = Stmt::assert_false(
-                &format!(
-                    "Reached assignment statement with unequal types {:?} {:?}",
-                    lhs.typ(),
-                    rhs.typ()
-                ),
-                loc.clone(),
-            );
-            let nondet_value = lhs.typ().nondet();
-            let nondet_assign_stmt = stmt!(Assign { lhs, rhs: nondet_value }, loc.clone());
-            return Stmt::block(vec![assert_stmt, nondet_assign_stmt], loc);
-        }
+        assert_eq!(lhs.typ(), rhs.typ());
         stmt!(Assign { lhs, rhs }, loc)
     }
 


### PR DESCRIPTION
### Description of changes: 

RMC had a workaround because some tests failed when we asserted that assignments must have matching types. The underlying bugs appear to have been fixed, so enable the assertion

### Resolved issues:

Resolves #95 

### Call-outs:

### Testing:

* How is this change tested? Existing regression suite

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
