### PR TITLE
Conform with recent rustc changes (path trimming)

### DIFF
--- a/scripts/rmc.py
+++ b/scripts/rmc.py
@@ -140,8 +140,9 @@ def compile_single_rust_file(input_filename, output_filename, verbose=False, deb
         atexit.register(delete_file, output_filename)
         
     build_cmd = [RMC_RUSTC_EXE, 
-                 "-Z", "codegen-backend=gotoc", 
-                 "-Z", f"symbol-mangling-version={mangler}", 
+                 "-Z", "codegen-backend=gotoc",
+                 "-Z", "trim-diagnostic-paths=no",
+                 "-Z", f"symbol-mangling-version={mangler}",
                  "-Z", f"symbol_table_passes={' '.join(symbol_table_passes)}",
                  f"--cfg={RMC_CFG}", "-o", output_filename, input_filename]
     if "RUSTFLAGS" in os.environ:
@@ -157,8 +158,9 @@ def cargo_build(crate, target_dir="target", verbose=False, debug=False, mangler=
     ensure(os.path.isdir(crate), f"Invalid path to crate: {crate}")
 
     rustflags = [
-        "-Z", "codegen-backend=gotoc", 
-        "-Z", f"symbol-mangling-version={mangler}", 
+        "-Z", "codegen-backend=gotoc",
+        "-Z", "trim-diagnostic-paths=no",
+        "-Z", f"symbol-mangling-version={mangler}",
         "-Z", f"symbol_table_passes={' '.join(symbol_table_passes)}", 
         f"--cfg={RMC_CFG}"]
     rustflags = " ".join(rustflags)

--- a/src/test/expected/dry-run/expected
+++ b/src/test/expected/dry-run/expected
@@ -1,4 +1,4 @@
-rmc-rustc -Z codegen-backend=gotoc -Z symbol-mangling-version=v0 -Z symbol_table_passes= --cfg=rmc
+rmc-rustc -Z codegen-backend=gotoc -Z trim-diagnostic-paths=no -Z symbol-mangling-version=v0 -Z symbol_table_passes= --cfg=rmc
 symtab2gb
 goto-cc --function main
 cbmc --bounds-check --pointer-check --pointer-primitive-check --conversion-check --div-by-zero-check --float-overflow-check --nan-check --pointer-overflow-check --signed-overflow-check --undefined-shift-check --unsigned-overflow-check --unwinding-assertions --function main

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2435,7 +2435,14 @@ impl<'test> TestCx<'test> {
         let mut rustc = Command::new("rmc-rustc");
         rustc
             .args(self.props.compile_flags.clone())
-            .args(["-Z", "codegen-backend=gotoc", "--cfg=rmc", "--out-dir"])
+            .args([
+                "-Z",
+                "codegen-backend=gotoc",
+                "-Z",
+                "trim-diagnostic-paths=no",
+                "--cfg=rmc",
+                "--out-dir",
+            ])
             .arg(self.output_base_dir())
             .arg(&self.testpaths.file);
         self.add_rmc_dir_to_path(&mut rustc);


### PR DESCRIPTION
### Description of changes: 

Fixes an ICE that we got during the last rebase in #380 by passing `"-Z trim-diagnostic-paths=no"` whenever we call RMC in any form. We used to pass this option when compiling crates (e.g., the balloon demo), but it is not clear why (opened #434 for that).

### Resolved issues:

Resolves #433 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing regression.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
