### PR TITLE
Initial hello world for RMC documentation

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Get paths for files added
         id: git-diff
         run: |
-          ignore='(.toml|.diff|.md|.props|expected|ignore|gitignore)$'
+          ignore='(.diff|.md|.props|expected|ignore|gitignore)$'
           files=$(git diff --ignore-submodules=all --name-only --diff-filter=A ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -v -E $ignore | xargs)
           echo "::set-output name=paths::$files"
 

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Get paths for files added
         id: git-diff
         run: |
-          ignore='(.diff|.md|.props|expected|ignore|gitignore)$'
+          ignore='(.toml|.diff|.md|.props|expected|ignore|gitignore)$'
           files=$(git diff --ignore-submodules=all --name-only --diff-filter=A ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -v -E $ignore | xargs)
           echo "::set-output name=paths::$files"
 

--- a/.github/workflows/rmc.yml
+++ b/.github/workflows/rmc.yml
@@ -46,3 +46,16 @@ jobs:
 
       - name: Execute RMC regression
         run: ./scripts/rmc-regression.sh
+
+      # On one OS only, build the documentation, too.
+      - name: Build Documentation
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: ./rmc-docs/build-docs.sh
+
+      # When we're pushed to main branch, only then actually publish the docs.
+      - name: Publish Documentation
+        if: ${{ matrix.os == 'ubuntu-20.04' && github.event_name == 'push' && startsWith('refs/heads/main', github.ref) }}
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: rmc-docs/book/

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ src/test/rustdoc-gui/src/**.lock
 /src/test/dashboard
 *Cargo.lock
 src/test/rmc-dependency-test/diamond-dependency/build
+/rmc-docs/book
+/rmc-docs/mdbook*

--- a/rmc-docs/README.md
+++ b/rmc-docs/README.md
@@ -1,0 +1,10 @@
+## RMC documentation development
+
+A good trick when developing RMC on a remote machine is to SSH forward to test documentation changes.
+
+```
+ssh -t -L 3000:127.0.0.1:3000 rmc-host 'cd rmc/rmc-docs/ && ./mdbook serve'
+```
+
+This command will connect to `rmc-host` where it assumes RMC is checked out in `rmc/` and the documentation has been build once successfully.
+It will automatically detect changes to the docs and rebuild, allowing you to quickly refresh in your browser when you visit: `http://127.0.0.1:3000/`

--- a/rmc-docs/README.md
+++ b/rmc-docs/README.md
@@ -6,5 +6,5 @@ A good trick when developing RMC on a remote machine is to SSH forward to test d
 ssh -t -L 3000:127.0.0.1:3000 rmc-host 'cd rmc/rmc-docs/ && ./mdbook serve'
 ```
 
-This command will connect to `rmc-host` where it assumes RMC is checked out in `rmc/` and the documentation has been build once successfully.
-It will automatically detect changes to the docs and rebuild, allowing you to quickly refresh in your browser when you visit: `http://127.0.0.1:3000/`
+This command will connect to `rmc-host` where it assumes RMC is checked out in `rmc/` and the documentation has been built once successfully.
+It will automatically detect changes to the docs and rebuild, allowing you to quickly refresh in your local browser when you visit: `http://127.0.0.1:3000/`

--- a/rmc-docs/book.toml
+++ b/rmc-docs/book.toml
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 [book]
 title = "The Rust Model Checker"
 description = "Documentation for the Rust Model Checker (RMC)"

--- a/rmc-docs/book.toml
+++ b/rmc-docs/book.toml
@@ -1,0 +1,13 @@
+[book]
+title = "The Rust Model Checker"
+description = "Documentation for the Rust Model Checker (RMC)"
+authors = ["RMC Developers"]
+src = "src"
+language = "en"
+multilingual = false
+
+[output.html]
+site-url = "/rmc/"
+git-repository-url = "https://github.com/model-checking/rmc"
+# If we get a stable default branch, we can use this feature, but HEAD doesn't work
+#edit-url-template = "https://github.com/model-checking/rmc/edit/HEAD/rmc-docs/{path}"

--- a/rmc-docs/build-docs.sh
+++ b/rmc-docs/build-docs.sh
@@ -4,7 +4,7 @@
 
 set -eu
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd $SCRIPT_DIR
 
 # Download mdbook release (vs spending time building it via cargo install)

--- a/rmc-docs/build-docs.sh
+++ b/rmc-docs/build-docs.sh
@@ -10,9 +10,11 @@ cd $SCRIPT_DIR
 # Download mdbook release (vs spending time building it via cargo install)
 FILE="mdbook-v0.4.12-x86_64-unknown-linux-gnu.tar.gz"
 URL="https://github.com/rust-lang/mdBook/releases/download/v0.4.12/$FILE"
+EXPECTED_HASH="2a0953c50d8156e84f193f15a506ef0adbac66f1942b794de5210ca9ca73dd33"
 if [ ! -x mdbook ]; then
-    wget -O "$FILE" "$URL"
-    tar zxvf $FILE
+    curl -sSL -o "$FILE" "$URL"
+    echo "$EXPECTED_HASH $FILE" | sha256sum -c -
+    tar zxf $FILE
 fi
 
 # Build the book into ./book/

--- a/rmc-docs/build-docs.sh
+++ b/rmc-docs/build-docs.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+set -eu
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $SCRIPT_DIR
+
+# Download mdbook release (vs spending time building it via cargo install)
+FILE="mdbook-v0.4.12-x86_64-unknown-linux-gnu.tar.gz"
+URL="https://github.com/rust-lang/mdBook/releases/download/v0.4.12/$FILE"
+if [ ! -x mdbook ]; then
+    wget -O "$FILE" "$URL"
+    tar zxvf $FILE
+fi
+
+# Build the book into ./book/
+mkdir -p book
+./mdbook build
+touch book/.nojekyll
+
+# TODO: Test all the code examples from our documentation
+# TODO: Build the dashboard and publish into our documentation
+
+echo "Finished documentation build successfully."

--- a/rmc-docs/src/SUMMARY.md
+++ b/rmc-docs/src/SUMMARY.md
@@ -1,0 +1,12 @@
+# The Rust Model Checker
+
+- [Getting started with RMC](./getting-started.md)
+  - [Installation]()
+  - [Comparison with other tools]()
+  - [RMC on a single file]()
+  - [RMC on a crate]()
+  - [Debugging failures]()
+  
+- [RMC tutorial]()
+
+- [RMC developer documentation]()

--- a/rmc-docs/src/getting-started.md
+++ b/rmc-docs/src/getting-started.md
@@ -1,0 +1,9 @@
+# Getting started with RMC
+
+Hello, World!
+
+```
+fn main() {
+    assert!(1 == 1);
+}
+```

--- a/rmc-docs/src/getting-started.md
+++ b/rmc-docs/src/getting-started.md
@@ -2,7 +2,7 @@
 
 Hello, World!
 
-```
+```rust
 fn main() {
     assert!(1 == 1);
 }


### PR DESCRIPTION
### Description of changes: 

This introduces:

1. A candidate CI process for building/publishing RMC documentation.
2. "Hello world" and nothing more to push there.

### Resolved issues:

N/A

### Call-outs:

1. The GitHub Actions documentations is deeply confusing about permissions. This PR will be able to test the building of the documentation, **but not the publishing of it. We may well have to merge it to find out if that part works or not!** (I have several hypotheses about what's going to happen when we try, none of them confirmed or refuted by any documentation I can find.)
2. This just tacks the documentation build onto the end of the `ubuntu-20.04` build, instead of as its own workflow. This is because we want to (not in this PR, but in a later PR) use RMC to test the code examples in the documentation, as well as build and publish Abdal's dashboard. This means we need RMC built and ready to run, so we might as well piggy back on an existing build. (Later, when we have releases of RMC available to download, we can probably separate documentation publishing into its own workflow, instead of piggybacking like this.)

### Testing:

* How is this change tested? We'll have to merge it to see! :(

* Is this a refactor change? -

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
