### PR TITLE
Stub testing support

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -472,6 +472,7 @@ impl<'a> Builder<'a> {
                 test::CargoRMC,
                 test::Expected,
                 test::Dashboard,
+                test::Stub,
                 // Run run-make last, since these won't pass without make on Windows
                 test::RunMake,
             ),

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1216,6 +1216,8 @@ default_test!(Expected { path: "src/test/expected", mode: "expected", suite: "ex
 
 default_test!(Dashboard { path: "src/test/dashboard", mode: "rmc", suite: "dashboard" });
 
+default_test!(Stub { path: "src/test/stub-tests", mode: "stub-tests", suite: "stub-tests" });
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 struct Compiletest {
     compiler: Compiler,

--- a/src/test/benchmarks/README.md
+++ b/src/test/benchmarks/README.md
@@ -1,0 +1,2 @@
+This folder contains benchmarks tests which can be used to test the performance
+of the various abstractions against the standard library implementation.

--- a/src/test/benchmarks/Vector/append.rs
+++ b/src/test/benchmarks/Vector/append.rs
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// This benchmark tests the performance of the abstraction on the append()
+// operation.
+
+include!{"../benchmark-prelude.rs"}
+
+fn operate_on_vec(times: usize) {
+    let mut v: Vec<u32> = Vec::with_capacity(times);
+    for i in 0..times {
+        v.push(__nondet());
+    }
+    let mut v2: Vec<u32> = Vec::with_capacity(times);
+    for i in 0..times {
+        v2.push(__nondet());
+    }
+    v.append(&mut v2);
+    assert!(v.len() == times * 2);
+}
+
+fn main() {
+    operate_on_vec(TEST_SIZE);
+}

--- a/src/test/benchmarks/Vector/extend.rs
+++ b/src/test/benchmarks/Vector/extend.rs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// This benchmark tests the performance of the abstraction on the extend()
+// operation.
+
+include!{"../benchmark-prelude.rs"}
+
+fn operate_on_vec(times: usize) {
+    let mut v = Vec::with_capacity(times);
+    v.extend(1..times);
+}
+
+fn main() {
+    operate_on_vec(TEST_SIZE);
+}

--- a/src/test/benchmarks/Vector/insert.rs
+++ b/src/test/benchmarks/Vector/insert.rs
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// This benchmark checks the performance of the abstraction for its insert and
+// remove operations. They are particularly interesting as they perform memory 
+// move operations to insert element.
+include!{"../benchmark-prelude.rs"}
+
+fn operate_on_vec(times: usize) {
+    let mut v: Vec<u32> = Vec::with_capacity(times);
+    for i in 0..times {
+        v.push(__nondet());
+    }
+    let sentinel = __nondet();
+    v.push(sentinel);
+    v.insert(v.len()/2, __nondet());
+    assert!(v.pop() == Some(sentinel));
+}
+
+fn main() {
+    operate_on_vec(TEST_SIZE);
+}

--- a/src/test/benchmarks/Vector/push.rs
+++ b/src/test/benchmarks/Vector/push.rs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// This benchmark tests the performance of the abstraction for push() operations
+// when the capacity is known
+
+include!{"../benchmark-prelude.rs"}
+
+fn operate_on_vec(times: usize) {
+    let mut v: Vec<u32> = Vec::with_capacity(times);
+    for i in 0..times {
+        v.push(__nondet());
+    }
+}
+
+fn main() {
+    operate_on_vec(100);
+}

--- a/src/test/benchmarks/Vector/push_and_pop.rs
+++ b/src/test/benchmarks/Vector/push_and_pop.rs
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// This benchmark tests the performance of the abstraction on push and pop operations.
+// This is also used to test the noback vec abstraction
+
+include!{"../benchmark-prelude.rs"}
+
+fn operate_on_vec(times: usize) {
+    let mut v: Vec<u32> = Vec::new();
+    for i in 0..times {
+        v.push(__nondet());
+    }
+    assert!(v.len() == times);
+    v.push(1);
+    assert!(v.pop() == Some(1));
+}
+
+fn operate_on_vec_len(times: usize) {
+    let mut v: Vec<u32> = Vec::new();
+    for i in 0..times {
+        v.push(__nondet());
+    }
+    assert!(v.len() == times);
+    v.push(1);
+    assert!(v.pop() == Some(1));
+}
+
+fn main() {
+    operate_on_vec_len(5);
+}

--- a/src/test/benchmarks/Vector/remove.rs
+++ b/src/test/benchmarks/Vector/remove.rs
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// This benchmark checks the performance of the abstraction for its insert and
+// remove operations. They are particularly interesting as they perform memory 
+// move operations to insert element.
+include!{"../benchmark-prelude.rs"}
+
+fn operate_on_vec(times: usize) {
+    let mut v: Vec<u32> = Vec::with_capacity(times);
+    for i in 0..times {
+        v.push(__nondet());
+    }
+    let sentinel = __nondet();
+    v.push(sentinel);
+    // We remove elements to perform more memmoves. These are done to fill up
+    // "holes" created due to elements removed from the middle of the Vec.
+    for i in 0..times/2 {
+        v.remove(v.len()/2);
+    }
+    assert!(v.pop() == Some(sentinel));
+    assert!(v.len() == times/2 || v.len() == (times/2 + 1));
+}
+
+fn main() {
+    operate_on_vec(TEST_SIZE);
+}

--- a/src/test/benchmarks/Vector/shrink_and_clear.rs
+++ b/src/test/benchmarks/Vector/shrink_and_clear.rs
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// This benchmark checks the performance of the abstraction for its shrink and
+// truncate operations.
+include!{"../benchmark-prelude.rs"}
+
+fn operate_on_vec(times: usize) {
+    // Create vector with known capacity
+    let mut v: Vec<u32> = Vec::with_capacity(times);
+    for i in 0..times {
+        v.push(__nondet());
+    }
+    assert!(v.len() == times);
+    // Here, Vecs with grow() internally
+    let i: usize = __nondet();
+    __VERIFIER_assume(i >= 0 && i < v.len());
+    let saved = v[i];
+    // Completely shrink the array to remove additional allocations
+    v.shrink_to_fit();
+    assert!(v[i] == saved);
+    // Push some new elements to grow() again
+    for i in 0..times {
+        v.push(__nondet());
+    }
+    // Drop all elements in the Vec
+    v.clear();
+    // Add some more new elements
+    for i in 0..times {
+        v.push(__nondet());
+    }
+    // Assert!
+    let sentinel = __nondet();
+    v.push(sentinel);
+    assert!(v.pop() == Some(sentinel));
+}
+
+fn main() {
+    operate_on_vec(TEST_SIZE);
+}

--- a/src/test/benchmarks/benchmark-prelude.rs
+++ b/src/test/benchmarks/benchmark-prelude.rs
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+include!{"../rmc-prelude.rs"}
+
+const TEST_SIZE: usize = 5;

--- a/src/test/benchmarks/run-benchmarks.sh
+++ b/src/test/benchmarks/run-benchmarks.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# A simple script to run all benchmarks against the RMCVec abstraction
+for file in $(ls Vector) 
+do
+	time rmc --use-abs --abs-type rmc Vector/$file
+done

--- a/src/test/stub-tests/HashSet/concrete.rs
+++ b/src/test/stub-tests/HashSet/concrete.rs
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// rmc-flags: --use-abs --abs-type c-ffi
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    let mut h: HashSet<u16> = HashSet::new();
+
+    // TODO: This test should ideally work with nondeterminstic values but for
+    // for the moment it does not.
+    //
+    // let a: u16 = __nondet();
+    // let b: u16 = __nondet();
+    // let c: u16 = __nondet();
+    // __VERIFIER_assume(a != b);
+    // __VERIFIER_assume(a != c);
+    // __VERIFIER_assume(b != c);
+
+    assert!(h.insert(5));
+    assert!(h.contains(&5));
+    assert!(!h.contains(&10));
+    assert!(h.remove(5));
+    assert!(!h.contains(&10));
+    assert!(!h.contains(&5));
+    assert!(h.insert(0));
+    assert!(h.contains(&0));
+    assert!(h.remove(0));
+    assert!(!h.contains(&0));
+    assert!(!h.remove(0));
+    assert!(h.insert(6));
+    assert!(!h.insert(6));
+}

--- a/src/test/stub-tests/HashSet/ignore-nondet.rs
+++ b/src/test/stub-tests/HashSet/ignore-nondet.rs
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// rmc-flags: --use-abs --abs-type c-ffi
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    let mut h: HashSet<u16> = HashSet::new();
+
+    // TODO: This test should ideally work with nondeterminstic values but for
+    // for the moment it does not.
+    let a: u16 = __nondet();
+    let b: u16 = __nondet();
+    let c: u16 = __nondet();
+    __VERIFIER_assume(a != b);
+    __VERIFIER_assume(a != c);
+    __VERIFIER_assume(b != c);
+
+    assert!(h.insert(a));
+    assert!(h.contains(&a));
+    assert!(!h.contains(&b));
+    assert!(h.remove(a));
+    assert!(!h.contains(&a));
+    assert!(!h.contains(&b));
+    assert!(h.insert(b));
+    assert!(h.contains(&b));
+    assert!(h.remove(b));
+    assert!(!h.contains(&b));
+    assert!(!h.remove(b));
+    assert!(h.insert(c));
+    assert!(!h.insert(c));
+}

--- a/src/test/stub-tests/README.md
+++ b/src/test/stub-tests/README.md
@@ -1,0 +1,11 @@
+This folder contains tests which can be used to test the compatibility of the
+various abstractions against the standard library implementation.
+
+They are extracted mostly verbatim directly from the [Rust reference manual for the
+Vector](https://doc.rust-lang.org/std/vec/struct.Vec.html).
+
+To run these tests through the compiletest framework for the rmc abstraction:
+
+```bash
+$ ./x.py test -i stub-tests
+```

--- a/src/test/stub-tests/Vec/append.rs
+++ b/src/test/stub-tests/Vec/append.rs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn append_test() {
+        let mut vec = rmc_vec![1, 2, 3];
+        let mut vec2 = rmc_vec![4, 5, 6];
+        vec.append(&mut vec2);
+        assert!(vec  == [1, 2, 3, 4, 5, 6]);
+        assert!(vec2 == []);
+    }
+
+    append_test();
+}

--- a/src/test/stub-tests/Vec/as_mut_ptr.rs
+++ b/src/test/stub-tests/Vec/as_mut_ptr.rs
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn as_mut_ptr_test() {
+        let size = 4;
+        let mut x: Vec<i32> = Vec::with_capacity(size);
+        let x_ptr = x.as_mut_ptr();
+
+        // Initialize elements via raw pointer writes, then set length.
+        unsafe {
+            for i in 0..size {
+                *x_ptr.add(i) = i as i32;
+            }
+            x.set_len(size);
+        }
+        assert_eq!(&*x, &[0, 1, 2, 3]);
+    }
+
+    as_mut_ptr_test();
+}

--- a/src/test/stub-tests/Vec/as_mut_slice.rs
+++ b/src/test/stub-tests/Vec/as_mut_slice.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn as_mut_slice_test() {
+        let mut buffer = rmc_vec![1, 2, 3];
+        buffer.as_mut_slice().reverse();
+        assert!(buffer == [3, 2, 1]);
+    }
+
+    as_mut_slice_test();
+}

--- a/src/test/stub-tests/Vec/as_ptr.rs
+++ b/src/test/stub-tests/Vec/as_ptr.rs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn as_ptr_test() {
+        let x = rmc_vec![1, 2, 4];
+        let x_ptr = x.as_ptr();
+
+        unsafe {
+            for i in 0..x.len() {
+                assert_eq!(*x_ptr.add(i), 1 << i);
+            }
+        }
+    }
+
+    as_ptr_test()
+}

--- a/src/test/stub-tests/Vec/as_slice.rs
+++ b/src/test/stub-tests/Vec/as_slice.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn as_slice_test() {
+        use std::io::{self, Write};
+        let buffer = rmc_vec![1, 2, 3, 5, 8];
+        io::sink().write(buffer.as_slice()).unwrap();
+    }
+
+    as_slice_test();
+}

--- a/src/test/stub-tests/Vec/capacity.rs
+++ b/src/test/stub-tests/Vec/capacity.rs
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn capacity_test() {
+        let mut vec = Vec::with_capacity(10);
+
+        // The vector contains no items, even though it has capacity for more
+        assert_eq!(vec.len(), 0);
+        assert_eq!(vec.capacity(), 10);
+
+        // These are all done without reallocating...
+        for i in 0..10 {
+            vec.push(i);
+        }
+
+        assert_eq!(vec.len(), 10);
+        assert_eq!(vec.capacity(), 10);
+
+        // ...but this may make the vector reallocate
+        vec.push(11);
+        assert_eq!(vec.len(), 11);
+        assert!(vec.capacity() >= 11);
+    }
+
+    capacity_test()
+}

--- a/src/test/stub-tests/Vec/clear.rs
+++ b/src/test/stub-tests/Vec/clear.rs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn clear_test() {
+        let mut v = rmc_vec![1, 2, 3];
+
+        v.clear();
+
+        assert!(v.is_empty());
+    }
+
+    clear_test();
+}

--- a/src/test/stub-tests/Vec/clone.rs
+++ b/src/test/stub-tests/Vec/clone.rs
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn clone_test() {
+        let v = rmc_vec![1, 2, 3];
+        let p = v.clone();
+
+        assert!(p == [1, 2, 3]);
+    }
+
+    clone_test();
+}

--- a/src/test/stub-tests/Vec/drop.rs
+++ b/src/test/stub-tests/Vec/drop.rs
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+
+include!{"../../rmc-prelude.rs"}
+
+static mut GLOB: i32 = 1;
+
+struct Test {
+    _marker: u32
+}
+
+impl Drop for Test {
+    fn drop(&mut self) {
+        unsafe {
+            GLOB += 1;
+        }
+    }
+}
+
+fn main() {
+    fn drop_test() {
+        {
+            let mut v = Vec::new();
+            v.push(Test { _marker: 0 });
+            v.push(Test { _marker: 0 });
+        }
+
+        unsafe {
+            assert!(GLOB == 3);
+        }
+    }
+
+    drop_test();
+}

--- a/src/test/stub-tests/Vec/extend.rs
+++ b/src/test/stub-tests/Vec/extend.rs
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn extend_test() {
+        let mut vec = Vec::new();
+        vec.push(1);
+        vec.push(2);
+
+        assert!(vec.len() == 2);
+        assert!(vec[0] == 1);
+
+        assert!(vec.pop() == Some(2));
+        assert!(vec.len() == 1);
+
+        vec[0] = 7;
+        assert!(vec[0] == 7);
+
+        vec.extend([1, 2, 3]);
+
+        assert!(vec == [7, 1, 2, 3]);
+    }
+
+    extend_test();
+}

--- a/src/test/stub-tests/Vec/extend_from_slice.rs
+++ b/src/test/stub-tests/Vec/extend_from_slice.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn extend_from_slice_test() {
+        let mut vec = rmc_vec![1];
+        vec.extend_from_slice(&[2, 3, 4]);
+        assert!(vec == [1, 2, 3, 4]);
+    }
+
+    extend_from_slice_test();
+}

--- a/src/test/stub-tests/Vec/from_raw_parts.rs
+++ b/src/test/stub-tests/Vec/from_raw_parts.rs
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+use std::ptr;
+
+fn main() {
+    fn from_raw_parts_test() {
+        let v = rmc_vec![1, 2, 3];
+
+        // Prevent running `v`'s destructor so we are in complete control
+        // of the allocation.
+        let mut v = mem::ManuallyDrop::new(v);
+
+        // Pull out the various important pieces of information about `v`
+        let p = v.as_mut_ptr();
+        let len = v.len();
+        let cap = v.capacity();
+
+        unsafe {
+            // Overwrite memory with 4, 5, 6
+            for i in 0..len as isize {
+                ptr::write(p.offset(i), 4 + i);
+            }
+
+            // Put everything back together into a Vec
+            let rebuilt = Vec::from_raw_parts(p, len, cap);
+            assert_eq!(rebuilt, [4, 5, 6]);
+        }
+    }
+}

--- a/src/test/stub-tests/Vec/from_slice.rs
+++ b/src/test/stub-tests/Vec/from_slice.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn from_slice_test() {
+        assert_eq!(Vec::from(&[1, 2, 3][..]), rmc_vec![1, 2, 3]);
+        assert_eq!(Vec::from(&mut [1, 2, 3][..]), rmc_vec![1, 2, 3]);
+        assert_eq!(Vec::from([3; 4]), rmc_vec![3, 3, 3, 3]);
+    }
+
+    from_slice_test();
+}

--- a/src/test/stub-tests/Vec/from_str.rs
+++ b/src/test/stub-tests/Vec/from_str.rs
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn from_str_test() {
+        assert_eq!(Vec::from("123"), rmc_vec![b'1', b'2', b'3']);
+    }
+
+    from_str_test()
+}

--- a/src/test/stub-tests/Vec/insert.rs
+++ b/src/test/stub-tests/Vec/insert.rs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn insert_test() {
+        let mut vec = rmc_vec![1, 2, 3];
+        vec.insert(1, 4);
+        assert!(vec == [1, 4, 2, 3]);
+        vec.insert(4, 5);
+        assert!(vec == [1, 4, 2, 3, 5]);
+    }
+
+    insert_test();
+}

--- a/src/test/stub-tests/Vec/into_iter.rs
+++ b/src/test/stub-tests/Vec/into_iter.rs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn into_iter_test() {
+        let v = rmc_vec![1, 4, 5];
+        let mut iter = v.into_iter();
+
+        assert!(iter.next() == Some(1));
+        assert!(iter.next() == Some(4));
+        assert!(iter.next() == Some(5));
+        assert!(iter.next() == None);
+
+    }
+
+    into_iter_test();
+}

--- a/src/test/stub-tests/Vec/is_empty.rs
+++ b/src/test/stub-tests/Vec/is_empty.rs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn is_empty_test() {
+        let mut v = Vec::new();
+        assert!(v.is_empty());
+
+        v.push(1);
+        assert!(!v.is_empty());
+    }
+
+    is_empty_test();
+}

--- a/src/test/stub-tests/Vec/len.rs
+++ b/src/test/stub-tests/Vec/len.rs
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type no-back
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn append_test() {
+        let mut vec = rmc_vec![1, 2, 3];
+        assert!(vec.len() == 3);
+        vec.push(10);
+        vec.push(15);
+        assert!(vec.len() == 5);
+        vec.pop();
+        assert!(vec.len() == 4);
+        vec.pop();
+        vec.pop();
+        vec.pop();
+        vec.pop();
+        vec.pop();
+        vec.pop();
+        assert!(vec.len() == 0);
+        vec.push(15);
+        assert!(vec.len() == 1);
+    }
+
+    append_test();
+}

--- a/src/test/stub-tests/Vec/new.rs
+++ b/src/test/stub-tests/Vec/new.rs
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn new_test() {
+        let v: Vec<i32> = Vec::new();
+    }
+
+    new_test();
+}

--- a/src/test/stub-tests/Vec/pop.rs
+++ b/src/test/stub-tests/Vec/pop.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn pop_test() {
+        let mut vec = rmc_vec![1, 2, 3];
+        assert_eq!(vec.pop(), Some(3));
+        assert_eq!(vec, [1, 2]);
+    }
+
+    pop_test();
+}

--- a/src/test/stub-tests/Vec/push.rs
+++ b/src/test/stub-tests/Vec/push.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn push_test() {
+        let mut vec = rmc_vec![1, 2];
+        vec.push(3);
+        assert!(vec == [1, 2, 3]);
+    }
+
+    push_test();
+}

--- a/src/test/stub-tests/Vec/remove.rs
+++ b/src/test/stub-tests/Vec/remove.rs
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn remove_test() {
+        let mut v = rmc_vec![1, 2, 3];
+        assert_eq!(v.remove(2), 3);
+        assert_eq!(v, [1, 2]);
+        assert_eq!(v.remove(1), 2);
+        assert_eq!(v.remove(0), 1);
+
+        let mut p = rmc_vec![1, 2, 3];
+        assert_eq!(p.remove(0), 1);
+        assert_eq!(p, [2, 3]);
+    }
+
+    remove_test();
+}

--- a/src/test/stub-tests/Vec/reserve.rs
+++ b/src/test/stub-tests/Vec/reserve.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn reserve_test() {
+        let mut vec = rmc_vec![1];
+        vec.reserve(10);
+        assert!(vec.capacity() >= 11);
+    }
+
+    reserve_test();
+}

--- a/src/test/stub-tests/Vec/reserve_exact.rs
+++ b/src/test/stub-tests/Vec/reserve_exact.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn reserve_exact_test() {
+        let mut vec = rmc_vec![1];
+        vec.reserve_exact(10);
+        assert!(vec.capacity() >= 11);
+    }
+
+    reserve_exact_test();
+}

--- a/src/test/stub-tests/Vec/resize.rs
+++ b/src/test/stub-tests/Vec/resize.rs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn resize_test() {
+        let mut vec = rmc_vec![1];
+        vec.resize(3, 2);
+        assert!(vec == [1, 2, 2]);
+
+        let mut vec = rmc_vec![1, 2, 3, 4];
+        vec.resize(2, 0);
+        assert!(vec == [1, 2]);
+    }
+
+    resize_test();
+}

--- a/src/test/stub-tests/Vec/resize_with.rs
+++ b/src/test/stub-tests/Vec/resize_with.rs
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn resize_with_test() {
+        let mut vec = rmc_vec![1, 2, 3];
+        vec.resize_with(5, Default::default);
+        assert_eq!(vec, [1, 2, 3, 0, 0]);
+
+        let mut vec = rmc_vec![];
+        let mut p = 1;
+        vec.resize_with(4, || {
+            p *= 2;
+            p
+        });
+        assert_eq!(vec, [2, 4, 8, 16]);
+    }
+
+    resize_with_test();
+}

--- a/src/test/stub-tests/Vec/shrink_to.rs
+++ b/src/test/stub-tests/Vec/shrink_to.rs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn shrink_to_test() {
+        let mut vec = Vec::with_capacity(10);
+        vec.extend([1, 2, 3]);
+        assert!(vec.capacity() == 10);
+        vec.shrink_to(4);
+        assert!(vec.capacity() >= 4);
+        vec.shrink_to(0);
+        __VERIFIER_expect_fail(vec.capacity() >= 3, "Capacity shrinked to 0");
+    }
+
+    shrink_to_test()
+}

--- a/src/test/stub-tests/Vec/shrink_to_fit.rs
+++ b/src/test/stub-tests/Vec/shrink_to_fit.rs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn shrink_to_fit_test() {
+        let mut vec = Vec::with_capacity(10);
+        vec.extend([1, 2, 3]);
+        assert_eq!(vec.capacity(), 10);
+        vec.shrink_to_fit();
+        assert!(vec.capacity() >= 3);
+    }
+
+    shrink_to_fit_test();
+}

--- a/src/test/stub-tests/Vec/simple.rs
+++ b/src/test/stub-tests/Vec/simple.rs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn simple_test() {
+        let mut vec: Vec<u32> = rmc_vec![1, 2, 3];
+        vec.push(3);
+        vec.push(4);
+        vec.pop();
+        assert!(vec.pop() == Some(3));
+    }
+    
+    simple_test();
+}

--- a/src/test/stub-tests/Vec/split_off.rs
+++ b/src/test/stub-tests/Vec/split_off.rs
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn split_off_test() {
+        let mut vec = rmc_vec![1, 2, 3];
+        let vec2 = vec.split_off(1);
+        assert!(vec == [1]);
+        assert!(vec2 == [2, 3]);
+
+        let mut vec = rmc_vec![1, 2, 3];
+        let vec2 = vec.split_off(0);
+        assert!(vec == []);
+        assert!(vec2 == [1, 2, 3]);
+
+        let mut vec = rmc_vec![1, 2, 3];
+        let vec2 = vec.split_off(3);
+        assert!(vec == [1, 2, 3]);
+        assert!(vec2 == []);
+    }
+
+    split_off_test();
+}

--- a/src/test/stub-tests/Vec/swap_remove.rs
+++ b/src/test/stub-tests/Vec/swap_remove.rs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn swap_remove_test() {
+        let mut v = rmc_vec![1, 2, 3, 4];
+
+        assert_eq!(v.swap_remove(1), 2);
+        assert_eq!(v, [1, 4, 3]);
+
+        assert_eq!(v.swap_remove(0), 1);
+        assert_eq!(v, [3, 4]);
+    }
+
+    swap_remove_test();
+}

--- a/src/test/stub-tests/Vec/truncate.rs
+++ b/src/test/stub-tests/Vec/truncate.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn truncate_test() {
+        let mut vec = rmc_vec![1, 2, 3];
+        vec.truncate(8);
+        assert_eq!(vec, [1, 2, 3]);
+    }
+
+    truncate_test();
+}

--- a/src/test/stub-tests/Vec/truncate_drop.rs
+++ b/src/test/stub-tests/Vec/truncate_drop.rs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+static mut GLOB: i32 = 1;
+
+struct Test {
+    _marker: u32
+}
+
+impl Drop for Test {
+    fn drop(&mut self) {
+        unsafe {
+            GLOB += 1;
+        }
+    }
+}
+
+fn main() {
+    fn truncate_test() {
+        let mut vec = Vec::new();
+        vec.push(Test { _marker: 0 });
+        vec.push(Test { _marker: 0 });
+        vec.push(Test { _marker: 0 });
+        vec.truncate(0);
+
+        unsafe {
+            assert!(GLOB == 7);
+        }
+    }
+
+    truncate_test();
+}

--- a/src/test/stub-tests/Vec/truncate_reduce.rs
+++ b/src/test/stub-tests/Vec/truncate_reduce.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn truncate_reduce_test() {
+        let mut vec = rmc_vec![1, 2, 3, 4, 5];
+        vec.truncate(2);
+        assert_eq!(vec, [1, 2]);
+    }
+
+    truncate_reduce_test();
+}

--- a/src/test/stub-tests/Vec/truncate_zero.rs
+++ b/src/test/stub-tests/Vec/truncate_zero.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// rmc-flags: --use-abs --abs-type rmc
+include!{"../../rmc-prelude.rs"}
+
+fn main() {
+    fn truncate_zero_test() {
+        let mut vec = rmc_vec![1, 2, 3];
+        vec.truncate(0);
+        assert_eq!(vec, []);
+    }
+
+    truncate_zero_test();
+}

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -26,6 +26,7 @@ pub enum Mode {
     RMC,
     CargoRMC,
     Expected,
+    Stub,
 }
 
 impl Mode {
@@ -59,6 +60,7 @@ impl FromStr for Mode {
             "rmc" => Ok(RMC),
             "cargo-rmc" => Ok(CargoRMC),
             "expected" => Ok(Expected),
+            "stub-tests" => Ok(Stub),
             _ => Err(()),
         }
     }
@@ -83,6 +85,7 @@ impl fmt::Display for Mode {
             RMC => "rmc",
             CargoRMC => "cargo-rmc",
             Expected => "expected",
+            Stub => "stub-tests",
         };
         fmt::Display::fmt(s, f)
     }

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -916,7 +916,7 @@ pub fn make_test_description<R: Read>(
         .join(if config.host.contains("windows") { "ld.exe" } else { "ld" })
         .exists();
 
-    if config.mode == Mode::RMC {
+    if config.mode == Mode::RMC || config.mode == Mode::Stub {
         // If the path to the test contains "fixme" or "ignore", skip it.
         let file_path = path.to_str().unwrap();
         ignore |= file_path.contains("fixme") || file_path.contains("ignore");


### PR DESCRIPTION
### Description of changes: 

This PR adds support for testing stub implementations through compiletest. It also adds an initial set of tests for the `RMCVec` abstraction mostly extracted from the Rust reference and adapted for RMC.

Example:
```bash
$ ./x.py test -i --stage 1 stub-tests
```

### Resolved issues:

#372

### Call-outs:

NOTE: This PR depends on #377.

### Testing:

* How is this change tested?
This change is specifically for testing the stub implementations.

* Is this a refactor change?
No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
