### PR TITLE
Add unwind flags to examples not terminating

### DIFF
--- a/src/tools/dashboard/configs/books/The Rust Reference/Patterns/368.props
+++ b/src/tools/dashboard/configs/books/The Rust Reference/Patterns/368.props
@@ -1,0 +1,1 @@
+// rmc-flags: --cbmc-args --unwind 2

--- a/src/tools/dashboard/configs/books/The Rust Reference/Patterns/368.props
+++ b/src/tools/dashboard/configs/books/The Rust Reference/Patterns/368.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 2
+// rmc-flags: --cbmc-args --unwind 0

--- a/src/tools/dashboard/configs/books/The Rust Reference/Type system/Types/113.props
+++ b/src/tools/dashboard/configs/books/The Rust Reference/Type system/Types/113.props
@@ -1,0 +1,1 @@
+// rmc-flags: --cbmc-args --unwind 2

--- a/src/tools/dashboard/configs/books/The Rust Reference/Type system/Types/113.props
+++ b/src/tools/dashboard/configs/books/The Rust Reference/Type system/Types/113.props
@@ -1,1 +1,1 @@
-// rmc-flags: --cbmc-args --unwind 2
+// rmc-flags: --cbmc-args --unwind 0


### PR DESCRIPTION
### Description of changes: 

These changes restore the dashboard functionality. Previously, there were a couple of examples that were not terminating which caused the dashboard generation to not terminate.

This seems to affect both versions: the terminal dashboard and litani's (HTML).

In the first case, there is little we can do since we do not consider timeouts in RMC. In the second case, and despite passing timeouts when running the `add-job` commands, the litani timeout feature seems to not take into account sub-processes spawned by `rmc` (e.g., `cbmc`), failing to stop them.

To be clear, there are three types of testing being done when running the litani dashboard:
 * `check` jobs (timeout = 5s): This check only uses the Rust front-end and detects if the example is valid Rust code.
 * `codegen` jobs (timeout = 5s): This check uses the Rust front-end and RMC back-end to determine if we can generate GotoC code for the example.
 * `verification` jobs (timeout = 10s): This checks uses all of above and CBMC to obtain a verification result for the example. 

This a fix but in the long term we want to use timeouts to halt non-terminating jobs. A timeout feature for `run-build` is on the works and may work well here. Opened #491 to try that once it is available.

Things to consider:
 * Removing the terminal dashboard. We may work on a terminal dashboard that uses litani's output, so we test once and display both dashboards.
 * Built-in timeouts for RMC/CBMC.

### Resolved issues:

Resolves #482 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Running the dashboard locally with `./x.py run -i --stage 1 dashboard`.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
