### PR TITLE
Use stable hash as unique identifier for types, instead of unstable human-readable names

### DIFF
--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/symbol.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/symbol.rs
@@ -100,11 +100,11 @@ impl Symbol {
 
     /// The symbol that defines the type of the struct or union.
     /// For a struct foo this is the symbol "tag-foo" that maps to the type struct foo.
-    pub fn aggr_ty(t: Type) -> Symbol {
+    pub fn aggr_ty(t: Type, pretty_name: Option<String>) -> Symbol {
         //TODO take location
         let base_name = t.tag().unwrap().to_string();
         let name = aggr_name(&base_name);
-        Symbol::new(name, Location::none(), t, SymbolValues::None, Some(base_name), None)
+        Symbol::new(name, Location::none(), t, SymbolValues::None, Some(base_name), pretty_name)
             .with_is_type(true)
     }
 
@@ -181,28 +181,36 @@ impl Symbol {
             .with_is_static_lifetime(true)
     }
 
-    pub fn struct_type(name: &str, components: Vec<DatatypeComponent>) -> Symbol {
-        Symbol::aggr_ty(Type::struct_type(name, components))
+    pub fn struct_type(
+        name: &str,
+        pretty_name: Option<String>,
+        components: Vec<DatatypeComponent>,
+    ) -> Symbol {
+        Symbol::aggr_ty(Type::struct_type(name, components), pretty_name)
     }
 
-    pub fn union_type(name: &str, components: Vec<DatatypeComponent>) -> Symbol {
-        Symbol::aggr_ty(Type::union_type(name, components))
+    pub fn union_type(
+        name: &str,
+        pretty_name: Option<String>,
+        components: Vec<DatatypeComponent>,
+    ) -> Symbol {
+        Symbol::aggr_ty(Type::union_type(name, components), pretty_name)
     }
 
-    pub fn empty_struct(name: &str) -> Symbol {
-        Symbol::aggr_ty(Type::empty_struct(name))
+    pub fn empty_struct(name: &str, pretty_name: Option<String>) -> Symbol {
+        Symbol::aggr_ty(Type::empty_struct(name), pretty_name)
     }
 
-    pub fn empty_union(name: &str) -> Symbol {
-        Symbol::aggr_ty(Type::empty_union(name))
+    pub fn empty_union(name: &str, pretty_name: Option<String>) -> Symbol {
+        Symbol::aggr_ty(Type::empty_union(name), pretty_name)
     }
 
-    pub fn incomplete_struct(name: &str) -> Symbol {
-        Symbol::aggr_ty(Type::incomplete_struct(name))
+    pub fn incomplete_struct(name: &str, pretty_name: Option<String>) -> Symbol {
+        Symbol::aggr_ty(Type::incomplete_struct(name), pretty_name)
     }
 
-    pub fn incomplete_union(name: &str) -> Symbol {
-        Symbol::aggr_ty(Type::incomplete_union(name))
+    pub fn incomplete_union(name: &str, pretty_name: Option<String>) -> Symbol {
+        Symbol::aggr_ty(Type::incomplete_union(name), pretty_name)
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/symtab_transformer/identity_transformer.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/cbmc/goto_program/symtab_transformer/identity_transformer.rs
@@ -273,6 +273,7 @@ mod tests {
 
         let struct_type = Symbol::struct_type(
             "s",
+            None,
             vec![
                 DatatypeComponent::Field { name: "a".to_string(), typ: Type::float() },
                 DatatypeComponent::Padding { name: "b".to_string(), bits: 4 },
@@ -308,6 +309,7 @@ mod tests {
 
         let union_type = Symbol::union_type(
             "u",
+            None,
             vec![
                 DatatypeComponent::Field { name: "a".to_string(), typ: Type::float() },
                 DatatypeComponent::Field { name: "c".to_string(), typ: Type::double() },

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/operand.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/codegen/operand.rs
@@ -453,7 +453,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // initializers. For example, for a boolean static variable, the variable will have type
         // CBool and the initializer will be a single byte (a one-character array) representing the
         // bit pattern for the boolean value.
-        let alloc_typ_ref = self.ensure_struct(&format!("{}::struct", name), |ctx, _| {
+        let alloc_typ_ref = self.ensure_struct(&format!("{}::struct", name), None, |ctx, _| {
             ctx.codegen_allocation_data(alloc)
                 .iter()
                 .enumerate()

--- a/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/context/goto_ctx.rs
+++ b/compiler/rustc_codegen_llvm/src/gotoc/mir_to_goto/context/goto_ctx.rs
@@ -161,14 +161,15 @@ impl<'tcx> GotocCtx<'tcx> {
     pub fn ensure_struct<F: FnOnce(&mut GotocCtx<'tcx>, &str) -> Vec<DatatypeComponent>>(
         &mut self,
         struct_name: &str,
+        pretty_name: Option<String>,
         f: F,
     ) -> Type {
         assert!(!struct_name.starts_with("tag-"));
         if !self.symbol_table.contains(&aggr_name(struct_name)) {
             // Prevent recursion by inserting an incomplete value.
-            self.symbol_table.insert(Symbol::incomplete_struct(struct_name));
+            self.symbol_table.insert(Symbol::incomplete_struct(struct_name, pretty_name.clone()));
             let components = f(self, struct_name);
-            let sym = Symbol::struct_type(struct_name, components);
+            let sym = Symbol::struct_type(struct_name, pretty_name, components);
             self.symbol_table.replace_with_completion(sym);
         }
         Type::struct_tag(struct_name)
@@ -180,14 +181,15 @@ impl<'tcx> GotocCtx<'tcx> {
     pub fn ensure_union<F: FnOnce(&mut GotocCtx<'tcx>, &str) -> Vec<DatatypeComponent>>(
         &mut self,
         union_name: &str,
+        pretty_name: Option<String>,
         f: F,
     ) -> Type {
         assert!(!union_name.starts_with("tag-"));
         if !self.symbol_table.contains(&aggr_name(union_name)) {
             // Prevent recursion by inserting an incomplete value.
-            self.symbol_table.insert(Symbol::incomplete_union(union_name));
+            self.symbol_table.insert(Symbol::incomplete_union(union_name, pretty_name.clone()));
             let components = f(self, union_name);
-            let sym = Symbol::union_type(union_name, components);
+            let sym = Symbol::union_type(union_name, pretty_name, components);
             self.symbol_table.replace_with_completion(sym);
         }
         Type::union_tag(union_name)

--- a/scripts/rmc-regression.sh
+++ b/scripts/rmc-regression.sh
@@ -41,6 +41,9 @@ $SCRIPT_DIR/codegen-firecracker.sh
 #         dependency2
 ./src/test/rmc-dependency-test/diamond-dependency/run-dependency-test.sh
 
+# Check that we don't have type mismatches across different crates
+./src/test/rmc-multicrate/type-mismatch/run-mismatch-test.sh
+
 echo
 echo "All RMC regression tests completed successfully."
 echo

--- a/scripts/setup/install_viewer.sh
+++ b/scripts/setup/install_viewer.sh
@@ -17,4 +17,4 @@ URL="https://github.com/awslabs/aws-viewer-for-cbmc/releases/download/viewer-$1/
 set -x
 
 wget -O "$FILE" "$URL"
-sudo python3 -m pip install --upgrade "$FILE"
+sudo -H python3 -m pip install --upgrade "$FILE"

--- a/scripts/setup/ubuntu/install_deps.sh
+++ b/scripts/setup/ubuntu/install_deps.sh
@@ -22,6 +22,7 @@ DEPS=(
   patch
   pkg-config
   python3-pip # Default in CI, but missing in AWS AMI
+  python3-setuptools
   software-properties-common
   wget
   zlib1g

--- a/src/test/rmc-multicrate/type-mismatch/mismatch/Cargo.toml
+++ b/src/test/rmc-multicrate/type-mismatch/mismatch/Cargo.toml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
 [package]
 name = "mismatch"
 version = "0.1.0"

--- a/src/test/rmc-multicrate/type-mismatch/mismatch/Cargo.toml
+++ b/src/test/rmc-multicrate/type-mismatch/mismatch/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mismatch"
+version = "0.1.0"
+authors = ["Daniel Schwartz-Narbonne <dsn@amazon.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+uses_core = { path = "../uses_core" }
+uses_std = { path = "../uses_std" }
+
+[workspace]

--- a/src/test/rmc-multicrate/type-mismatch/mismatch/src/lib.rs
+++ b/src/test/rmc-multicrate/type-mismatch/mismatch/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 #[no_mangle]
 fn main() {
     let arr = [1, 2, 3];

--- a/src/test/rmc-multicrate/type-mismatch/mismatch/src/lib.rs
+++ b/src/test/rmc-multicrate/type-mismatch/mismatch/src/lib.rs
@@ -1,0 +1,7 @@
+#[no_mangle]
+fn main() {
+    let arr = [1, 2, 3];
+    let r: core::ops::Range<usize> = uses_core::foo(&arr[..2]);
+    let i = uses_std::bar(r);
+    assert!(i.start == 10);
+}

--- a/src/test/rmc-multicrate/type-mismatch/run-mismatch-test.sh
+++ b/src/test/rmc-multicrate/type-mismatch/run-mismatch-test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# Compile crates with RMC backend
+cd $(dirname $0)
+rm -rf build
+cd mismatch
+CARGO_TARGET_DIR=../build RUST_BACKTRACE=1 RUSTFLAGS="-Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo build
+
+# Convert from JSON to Gotoc 
+cd ../build/debug/deps/
+ls *.json | xargs symtab2gb
+
+# Add the entry point and remove unused functions
+goto-cc --function main *.out -o a.out 
+goto-instrument --drop-unused-functions a.out b.out 
+
+# Run the solver
+RESULT="/tmp/dependency_test_result.txt"
+cbmc b.out &> $RESULT
+if grep -q "VERIFICATION SUCCESSFUL" $RESULT; then
+  cat $RESULT
+  echo "Successful dependency test"
+  exit 0
+else 
+  cat $RESULT
+  echo "Failed dependency test"
+  exit 1
+fi

--- a/src/test/rmc-multicrate/type-mismatch/uses_core/Cargo.toml
+++ b/src/test/rmc-multicrate/type-mismatch/uses_core/Cargo.toml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
 [package]
 name = "uses_core"
 version = "0.1.0"

--- a/src/test/rmc-multicrate/type-mismatch/uses_core/Cargo.toml
+++ b/src/test/rmc-multicrate/type-mismatch/uses_core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "uses_core"
+version = "0.1.0"
+authors = ["Daniel Schwartz-Narbonne <dsn@amazon.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[workspace]

--- a/src/test/rmc-multicrate/type-mismatch/uses_core/src/lib.rs
+++ b/src/test/rmc-multicrate/type-mismatch/uses_core/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 #![no_std]
 
 pub fn foo(_x: &[usize]) -> core::ops::Range<usize> {

--- a/src/test/rmc-multicrate/type-mismatch/uses_core/src/lib.rs
+++ b/src/test/rmc-multicrate/type-mismatch/uses_core/src/lib.rs
@@ -1,0 +1,11 @@
+#![no_std]
+
+pub fn foo(_x: &[usize]) -> core::ops::Range<usize> {
+    core::ops::Range { start: 5, end: 25 }
+}
+
+pub fn bar(r: core::ops::Range<usize>) -> core::ops::Range<usize> {
+    let a = [1, 2, 3];
+    let b = &a[..1];
+    core::ops::Range { start: r.start + b[0], end: r.end }
+}

--- a/src/test/rmc-multicrate/type-mismatch/uses_std/Cargo.toml
+++ b/src/test/rmc-multicrate/type-mismatch/uses_std/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "uses_std"
+version = "0.1.0"
+authors = ["Daniel Schwartz-Narbonne <dsn@amazon.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[workspace]

--- a/src/test/rmc-multicrate/type-mismatch/uses_std/Cargo.toml
+++ b/src/test/rmc-multicrate/type-mismatch/uses_std/Cargo.toml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
 [package]
 name = "uses_std"
 version = "0.1.0"

--- a/src/test/rmc-multicrate/type-mismatch/uses_std/src/lib.rs
+++ b/src/test/rmc-multicrate/type-mismatch/uses_std/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn bar(r: std::ops::Range<usize>) -> std::ops::Range<usize> {
+    std::ops::Range { start: r.start + 5, end: r.end + 5 }
+}

--- a/src/test/rmc-multicrate/type-mismatch/uses_std/src/lib.rs
+++ b/src/test/rmc-multicrate/type-mismatch/uses_std/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 pub fn bar(r: std::ops::Range<usize>) -> std::ops::Range<usize> {
     std::ops::Range { start: r.start + 5, end: r.end + 5 }
 }


### PR DESCRIPTION
### Description of changes: 

Describe RMC's current behavior and how your code changes that behavior. If there are no issues this PR is resolving, explain why this change is necessary.

### Resolved issues:

Resolves #300 

### Call-outs:

Although this sets the `pretty_name` in the symbol table, it seems that `--dump-c` doesn't actually use that.  This will make debugging harder.

### Testing:

* How is this change tested? Existing reg tests, plus a new test that failed before the change and passes now.

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
