### PR TITLE
Ensure only Rust files are parsed in Litani runs

### DIFF
--- a/src/tools/dashboard/src/books.rs
+++ b/src/tools/dashboard/src/books.rs
@@ -449,7 +449,7 @@ fn litani_run_tests() {
         if entry.is_file() {
             // Ensure that we parse only Rust files by checking their extension
             let entry_ext = &entry.extension().and_then(OsStr::to_str);
-            if entry_ext.is_some() && entry_ext.unwrap() == "rs" {
+            if let Some("rs") = entry_ext {
                 let test_props = util::parse_test_header(&entry);
                 util::add_test_pipeline(&mut litani, &test_props);
             }

--- a/src/tools/dashboard/src/books.rs
+++ b/src/tools/dashboard/src/books.rs
@@ -285,8 +285,6 @@ fn prepend_props(path: &Path, example: &mut Example, config_paths: &mut HashSet<
 /// pre-processes those examples, and saves them in the directory specified by
 /// `par_to`.
 fn extract(par_from: &Path, par_to: &Path, config_paths: &mut HashSet<PathBuf>) {
-    let config_dir: PathBuf = ["src", "tools", "dashboard", "configs"].iter().collect();
-    let test_dir: PathBuf = ["src", "test", "dashboard"].iter().collect();
     let code = fs::read_to_string(&par_from).unwrap();
     let mut examples = Examples(Vec::new());
     rustdoc::html::markdown::find_testable_code(&code, &mut examples, ErrorCodes::No, false, None);
@@ -449,8 +447,12 @@ fn litani_run_tests() {
     for entry in WalkDir::new(dashboard_dir) {
         let entry = entry.unwrap().into_path();
         if entry.is_file() {
-            let test_props = util::parse_test_header(&entry);
-            util::add_test_pipeline(&mut litani, &test_props);
+            // Ensure that we parse only Rust files by checking their extension
+            let entry_ext = &entry.extension().and_then(OsStr::to_str);
+            if entry_ext.is_some() && entry_ext.unwrap() == "rs" {
+                let test_props = util::parse_test_header(&entry);
+                util::add_test_pipeline(&mut litani, &test_props);
+            }
         }
     }
     litani.run_build();


### PR DESCRIPTION
### Description of changes: 

These changes ensure that only Rust files are parsed in Litani runs. Other files in `src/test/dashboard` (e.g., `.goto` or `.json`) would cause the "invalid UTF-8" error from issue #498.

### Resolved issues:

Resolves #498 

### Call-outs:

Also removes a couple of variables that were not being used (and causing warnings).
<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing regression + dashboard run.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
