### PR TITLE
Print location information for panic in codegen

### DIFF
--- a/compiler/rustc_codegen_rmc/src/compiler_interface.rs
+++ b/compiler/rustc_codegen_rmc/src/compiler_interface.rs
@@ -69,14 +69,14 @@ impl CodegenBackend for GotocCodegenBackend {
                         c.call_with_panic_debug_info(
                             |ctx| ctx.declare_function(instance),
                             format!("declare_function: {}", c.readable_instance_name(instance)),
-                            Some(c.codegen_span(&tcx.instance_mir(instance.def).span)),
+                            instance.def_id(),
                         );
                     }
                     MonoItem::Static(def_id) => {
                         c.call_with_panic_debug_info(
                             |ctx| ctx.declare_static(def_id, item),
                             format!("declare_static: {:?}", def_id),
-                            Some(c.codegen_span(&tcx.def_span(def_id))),
+                            def_id,
                         );
                     }
                     MonoItem::GlobalAsm(_) => {
@@ -102,14 +102,14 @@ impl CodegenBackend for GotocCodegenBackend {
                                 c.readable_instance_name(instance),
                                 c.symbol_name(instance)
                             ),
-                            Some(c.codegen_span(&tcx.instance_mir(instance.def).span)),
+                            instance.def_id(),
                         );
                     }
                     MonoItem::Static(def_id) => {
                         c.call_with_panic_debug_info(
                             |ctx| ctx.codegen_static(def_id, item),
                             format!("codegen_static: {:?}", def_id),
-                            Some(c.codegen_span(&tcx.def_span(def_id))),
+                            def_id,
                         );
                     }
                     MonoItem::GlobalAsm(_) => {} // We have already warned above

--- a/compiler/rustc_codegen_rmc/src/compiler_interface.rs
+++ b/compiler/rustc_codegen_rmc/src/compiler_interface.rs
@@ -69,12 +69,14 @@ impl CodegenBackend for GotocCodegenBackend {
                         c.call_with_panic_debug_info(
                             |ctx| ctx.declare_function(instance),
                             format!("declare_function: {}", c.readable_instance_name(instance)),
+                            Some(c.codegen_span(&tcx.instance_mir(instance.def).span)),
                         );
                     }
                     MonoItem::Static(def_id) => {
                         c.call_with_panic_debug_info(
                             |ctx| ctx.declare_static(def_id, item),
                             format!("declare_static: {:?}", def_id),
+                            None,
                         );
                     }
                     MonoItem::GlobalAsm(_) => {
@@ -100,12 +102,14 @@ impl CodegenBackend for GotocCodegenBackend {
                                 c.readable_instance_name(instance),
                                 c.symbol_name(instance)
                             ),
+                            Some(c.codegen_span(&tcx.instance_mir(instance.def).span)),
                         );
                     }
                     MonoItem::Static(def_id) => {
                         c.call_with_panic_debug_info(
                             |ctx| ctx.codegen_static(def_id, item),
                             format!("codegen_static: {:?}", def_id),
+                            None,
                         );
                     }
                     MonoItem::GlobalAsm(_) => {} // We have already warned above

--- a/compiler/rustc_codegen_rmc/src/compiler_interface.rs
+++ b/compiler/rustc_codegen_rmc/src/compiler_interface.rs
@@ -76,7 +76,7 @@ impl CodegenBackend for GotocCodegenBackend {
                         c.call_with_panic_debug_info(
                             |ctx| ctx.declare_static(def_id, item),
                             format!("declare_static: {:?}", def_id),
-                            None,
+                            Some(c.codegen_span(&tcx.def_span(def_id))),
                         );
                     }
                     MonoItem::GlobalAsm(_) => {
@@ -109,7 +109,7 @@ impl CodegenBackend for GotocCodegenBackend {
                         c.call_with_panic_debug_info(
                             |ctx| ctx.codegen_static(def_id, item),
                             format!("codegen_static: {:?}", def_id),
-                            None,
+                            Some(c.codegen_span(&tcx.def_span(def_id))),
                         );
                     }
                     MonoItem::GlobalAsm(_) => {} // We have already warned above

--- a/compiler/rustc_codegen_rmc/src/utils/debug.rs
+++ b/compiler/rustc_codegen_rmc/src/utils/debug.rs
@@ -8,6 +8,7 @@ use cbmc::goto_program::Location;
 use rustc_middle::mir::Body;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::Instance;
+use rustc_span::def_id::DefId;
 use std::cell::RefCell;
 use std::lazy::SyncLazy;
 use std::panic;
@@ -78,10 +79,11 @@ impl<'tcx> GotocCtx<'tcx> {
         &mut self,
         call: F,
         panic_debug: String,
-        loc: Option<Location>,
+        def_id: DefId,
     ) {
         CURRENT_CODEGEN_ITEM.with(|odb_cell| {
-            odb_cell.replace((Some(panic_debug), loc));
+            odb_cell
+                .replace((Some(panic_debug), Some(self.codegen_span(&self.tcx.def_span(def_id)))));
             call(self);
             odb_cell.replace((None, None));
         });

--- a/compiler/rustc_codegen_rmc/src/utils/debug.rs
+++ b/compiler/rustc_codegen_rmc/src/utils/debug.rs
@@ -48,13 +48,13 @@ static DEFAULT_HOOK: SyncLazy<Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 
                 let t = cell.borrow().clone();
                 if let Some(current_item) = t.0 {
                     eprintln!("[RMC] current codegen item: {}", current_item);
-                    if let Some(current_loc) = t.1 {
-                        eprintln!("[RMC] current codegen location: {:?}", current_loc);
-                    } else {
-                        eprintln!("[RMC] no current codegen location.");
-                    }
                 } else {
                     eprintln!("[RMC] no current codegen item.");
+                }
+                if let Some(current_loc) = t.1 {
+                    eprintln!("[RMC] current codegen location: {:?}", current_loc);
+                } else {
+                    eprintln!("[RMC] no current codegen location.");
                 }
             });
 

--- a/compiler/rustc_codegen_rmc/src/utils/debug.rs
+++ b/compiler/rustc_codegen_rmc/src/utils/debug.rs
@@ -4,7 +4,7 @@
 //! This file contains functionality that makes RMC easier to debug
 
 use crate::GotocCtx;
-use crate::cbmc::goto_program::Location;
+use cbmc::goto_program::Location;
 use rustc_middle::mir::Body;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::Instance;


### PR DESCRIPTION
### Description of changes: 

When codegen panics, in addition to printing the current codegen item, also print the location information (filename, line number, etc.) to help with debugging.

For instance, we currently print
```
[RMC] current codegen item: codegen_function: std::ptr::drop_in_place
_ZN4core3ptr83drop_in_place$LT$alloc..boxed..Box$LT$crossbeam_epoch..internal..no_op_func$GT$$GT$17hacb4960c6aa3ff74E
```
The PR adds one more line to the output:
```
[RMC] current codegen location: Loc { file: "/home/ubuntu/tools/rmc/library/core/src/ptr/mod.rs", function: None, line: 188, col: Some(1) }
```

### Resolved issues:

None.


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->
None

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
