### PR TITLE
Add support to `--function` to rmc script (#169)

### DIFF
--- a/rmc-docs/src/install-guide.md
+++ b/rmc-docs/src/install-guide.md
@@ -82,7 +82,7 @@ Create a test file:
 
 ```rust
 // File: test.rs
-fn main() {
+pub fn main() {
     assert!(1 == 2);
 }
 ```

--- a/scripts/cargo-rmc
+++ b/scripts/cargo-rmc
@@ -40,7 +40,7 @@ def main():
 
         if EXIT_CODE_SUCCESS != rmc.goto_to_c(cbmc_runnable_filename, c_runnable_filename, args.verbose, args.dry_run):
             return 1
-        
+
         rmc.gen_c_postprocess(c_runnable_filename, args.dry_run)
 
     rmc.cargo_build(args.crate, args.target_dir,
@@ -48,7 +48,12 @@ def main():
 
     pattern = os.path.join(args.target_dir, "debug", "deps", "*.json")
     jsons = glob.glob(pattern)
-    rmc.ensure(len(jsons) == 1, f"Unexpected number of json outputs: {len(jsons)}")
+
+    if not args.dry_run:
+        rmc.ensure(len(jsons) == 1, f"Unexpected number of json outputs: {len(jsons)}")
+    else:
+        # Add a dummy value so dry-run works.
+        jsons = ["dry-run.json"]
 
     cbmc_filename = os.path.join(args.target_dir, "cbmc.out")
     c_filename = os.path.join(args.target_dir, "cbmc.c")
@@ -101,7 +106,7 @@ def parse_args():
 
         exclude_flags = []
         rmc_flags.add_flags(parser, {"default-target": "target"}, exclude_flags=exclude_flags)
-        
+
         return parser
 
     # Determine what crate to analyze from flags
@@ -109,7 +114,7 @@ def parse_args():
         validate(args)
         return args.crate or args.crate_flag or "."
 
-    # Combine the command line parameter to get a config file; 
+    # Combine the command line parameter to get a config file;
     # return None if no_config_toml is set
     def get_config_toml(no_config_toml, config_toml, args):
         crate = get_crate_from_args(args)
@@ -154,7 +159,7 @@ def parse_args():
 
     # Check for conflicting flags
     def validate(args):
-        rmc.ensure(not (args.crate and args.crate_flag), "Please provide a single crate to verify.")   
+        rmc.ensure(not (args.crate and args.crate_flag), "Please provide a single crate to verify.")
         rmc.ensure(not (args.no_config_toml and args.config_toml), "Incompatible flags: --config-toml, --no-config-toml")
 
     # Fix up args before returning
@@ -239,7 +244,7 @@ def extract_flags_from_toml(path):
             success = False
     for flag in flags:
         add_flag(flag, flags[flag])
-    
+
     rmc.ensure(success)
     return flag_list
 

--- a/scripts/rmc
+++ b/scripts/rmc
@@ -38,7 +38,7 @@ def main():
 
         if EXIT_CODE_SUCCESS != rmc.goto_to_c(goto_runnable_filename, c_runnable_filename, args.verbose, args.dry_run):
             return 1
-        
+
         rmc.gen_c_postprocess(c_runnable_filename, args.dry_run)
 
     json_filename = base + ".json"
@@ -76,7 +76,7 @@ def main():
 
     if "--function" not in args.cbmc_args:
         args.cbmc_args.extend(["--function", args.function])
-    
+
     if args.visualize:
         # Use a separate set of flags for coverage checking (empty for now)
         cover_args = []
@@ -100,14 +100,8 @@ def parse_args():
         input_group.add_argument("input", help="Rust file to verify", nargs="?")
         input_group.add_argument("--input", help="Rust file to verify", dest="input_flag", metavar="INPUT")
 
-        exclude_flags = [
-            # In the future we hope to make this configurable in the command line.
-            # For now, however, changing this from "main" breaks rmc.
-            # Issue: https://github.com/model-checking/rmc/issues/169
-            "--function"
-        ]
-        rmc_flags.add_flags(parser, {"default-target": "."}, exclude_flags=exclude_flags)
-        
+        rmc_flags.add_flags(parser, {"default-target": "."})
+
         return parser
 
     # Check for conflicting flags
@@ -123,11 +117,6 @@ def parse_args():
         # --quiet overrides --verbose
         if args.quiet:
             args.verbose = False
-
-        # In the future we hope to make this configurable in the command line.
-        # For now, however, changing this from "main" breaks rmc.
-        # Issue: https://github.com/model-checking/rmc/issues/169
-        args.function = "main"
 
         # Add some CBMC flags by default unless `--no-default-checks` is being used
         if args.default_checks:

--- a/src/test/cargo-rmc/simple-main/Cargo.toml
+++ b/src/test/cargo-rmc/simple-main/Cargo.toml
@@ -5,6 +5,9 @@ name = "empty-main"
 version = "0.1.0"
 edition = "2018"
 
+[lib]
+path="src/main.rs"
+
 [dependencies]
 
 [workspace]

--- a/src/test/cargo-rmc/simple-main/src/main.rs
+++ b/src/test/cargo-rmc/simple-main/src/main.rs
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     assert!(1 == 2);
 }

--- a/src/test/cbmc/ArithEqualOperators/main.rs
+++ b/src/test/cbmc/ArithEqualOperators/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let mut a: u32 = __nondet();
     a /= 2;
     let mut b: u32 = __nondet();

--- a/src/test/cbmc/ArithOperators/main.rs
+++ b/src/test/cbmc/ArithOperators/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let a: u32 = __nondet();
     assert!(a / 2 <= a);
     assert!(a / 2 * 2 >= a / 2);

--- a/src/test/cbmc/Asm/main_fixme.rs
+++ b/src/test/cbmc/Asm/main_fixme.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![feature(asm)]
 
-fn main() {
+pub fn main() {
     unsafe {
         asm!("nop");
     }

--- a/src/test/cbmc/Assert/UninitValid/fixme_main.rs
+++ b/src/test/cbmc/Assert/UninitValid/fixme_main.rs
@@ -4,7 +4,7 @@
 
 use std::mem::{self, MaybeUninit};
 
-fn main() {
+pub fn main() {
     // The compiler assumes that variables are properly initialized according to
     // the requirements of the variable's type (e.g., a variable of reference
     // type must be aligned and non-NULL). This is an invariant that must always

--- a/src/test/cbmc/Assert/ZeroValid/fixme_main.rs
+++ b/src/test/cbmc/Assert/ZeroValid/fixme_main.rs
@@ -7,7 +7,7 @@
 
 use std::mem;
 use std::ptr;
-fn main() {
+pub fn main() {
     let x: &mut i32 = unsafe { mem::zeroed() }; //< undefined (should fail)
     let p: *mut i32 = x;
     assert!(p == ptr::null_mut()); //< verifies with RMC

--- a/src/test/cbmc/Assert/ZeroValid/main.rs
+++ b/src/test/cbmc/Assert/ZeroValid/main.rs
@@ -18,7 +18,7 @@ fn do_test<T: std::cmp::Eq>(init: T, expected: T) {
     assert!(expected == x);
 }
 
-fn main() {
+pub fn main() {
     do_test::<bool>(true, false);
     do_test::<i8>(-42, 0);
     do_test::<i16>(-42, 0);

--- a/src/test/cbmc/Assume/main.rs
+++ b/src/test/cbmc/Assume/main.rs
@@ -3,7 +3,7 @@
 
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let i: i32 = __nondet();
     __VERIFIER_assume(i < 10);
     assert!(i < 20);

--- a/src/test/cbmc/Assume/main_fail.rs
+++ b/src/test/cbmc/Assume/main_fail.rs
@@ -3,7 +3,7 @@
 
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let i: i32 = __nondet();
     __VERIFIER_assume(i < 10);
     __VERIFIER_expect_fail(i > 20, "Blocked by assumption above.");

--- a/src/test/cbmc/Atomics/Stable/CompareExchange/main.rs
+++ b/src/test/cbmc/Atomics/Stable/CompareExchange/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::sync::atomic::{AtomicBool, Ordering};
 
-fn main() {
+pub fn main() {
     // pub fn compare_exchange(
     //     &self,
     //     current: bool,

--- a/src/test/cbmc/Atomics/Stable/Exchange/main.rs
+++ b/src/test/cbmc/Atomics/Stable/Exchange/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::sync::atomic::{AtomicBool, Ordering};
 
-fn main() {
+pub fn main() {
     let a1 = AtomicBool::new(true);
     let a2 = AtomicBool::new(true);
     let a3 = AtomicBool::new(true);

--- a/src/test/cbmc/Atomics/Stable/Fence/main.rs
+++ b/src/test/cbmc/Atomics/Stable/Fence/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::sync::atomic::{fence, Ordering};
 
-fn main() {
+pub fn main() {
     // pub fn fence(order: Ordering)
     // An atomic fence.
     // Depending on the specified order, a fence prevents the compiler

--- a/src/test/cbmc/Atomics/Stable/FetchAdd/main.rs
+++ b/src/test/cbmc/Atomics/Stable/FetchAdd/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::sync::atomic::{AtomicIsize, Ordering};
 
-fn main() {
+pub fn main() {
     // pub fn fetch_add(&self, val: isize, order: Ordering) -> isize
     // Adds to the current value, returning the previous value.
     let a1 = AtomicIsize::new(0);

--- a/src/test/cbmc/Atomics/Stable/FetchAnd/main.rs
+++ b/src/test/cbmc/Atomics/Stable/FetchAnd/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::sync::atomic::{AtomicBool, Ordering};
 
-fn main() {
+pub fn main() {
     // pub fn fetch_and(&self, val: bool, order: Ordering) -> bool
     // Performs a logical "and" operation on the current value and
     // the argument val, and sets the new value to the result.

--- a/src/test/cbmc/Atomics/Stable/FetchOr/main.rs
+++ b/src/test/cbmc/Atomics/Stable/FetchOr/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::sync::atomic::{AtomicBool, Ordering};
 
-fn main() {
+pub fn main() {
     // pub fn fetch_or(&self, val: bool, order: Ordering) -> bool
     // Performs a logical "or" operation on the current value and
     // the argument val, and sets the new value to the result.

--- a/src/test/cbmc/Atomics/Stable/FetchSub/main.rs
+++ b/src/test/cbmc/Atomics/Stable/FetchSub/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::sync::atomic::{AtomicIsize, Ordering};
 
-fn main() {
+pub fn main() {
     // pub fn fetch_sub(&self, val: isize, order: Ordering) -> isize
     // Subtracts from the current value, returning the previous value.
     let a1 = AtomicIsize::new(1);

--- a/src/test/cbmc/Atomics/Stable/FetchXor/main.rs
+++ b/src/test/cbmc/Atomics/Stable/FetchXor/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::sync::atomic::{AtomicBool, Ordering};
 
-fn main() {
+pub fn main() {
     // pub fn fetch_xor(&self, val: bool, order: Ordering) -> bool
     // Performs a bitwise "xor" operation on the current value and
     // the argument val, and sets the new value to the result.

--- a/src/test/cbmc/Atomics/Stable/Load/main.rs
+++ b/src/test/cbmc/Atomics/Stable/Load/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::sync::atomic::{AtomicBool, Ordering};
 
-fn main() {
+pub fn main() {
     // pub fn load(&self, order: Ordering) -> bool
     // Loads a value from the bool.
     // load takes an Ordering argument which describes the memory ordering

--- a/src/test/cbmc/Atomics/Stable/Store/main.rs
+++ b/src/test/cbmc/Atomics/Stable/Store/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::sync::atomic::{AtomicBool, Ordering};
 
-fn main() {
+pub fn main() {
     // ppub fn store(&self, val: bool, order: Ordering)
     // Stores a value into the bool.
     // store takes an Ordering argument which describes the memory ordering

--- a/src/test/cbmc/Atomics/Unstable/AtomicAdd/main.rs
+++ b/src/test/cbmc/Atomics/Unstable/AtomicAdd/main.rs
@@ -5,7 +5,7 @@ use std::intrinsics::{
     atomic_xadd, atomic_xadd_acq, atomic_xadd_acqrel, atomic_xadd_rel, atomic_xadd_relaxed,
 };
 
-fn main() {
+pub fn main() {
     let mut a1 = 0 as u8;
     let mut a2 = 0 as u8;
     let mut a3 = 0 as u8;

--- a/src/test/cbmc/Atomics/Unstable/AtomicAnd/main.rs
+++ b/src/test/cbmc/Atomics/Unstable/AtomicAnd/main.rs
@@ -5,7 +5,7 @@ use std::intrinsics::{
     atomic_and, atomic_and_acq, atomic_and_acqrel, atomic_and_rel, atomic_and_relaxed,
 };
 
-fn main() {
+pub fn main() {
     let mut a1 = 1 as u8;
     let mut a2 = 1 as u8;
     let mut a3 = 1 as u8;

--- a/src/test/cbmc/Atomics/Unstable/AtomicCxchg/main.rs
+++ b/src/test/cbmc/Atomics/Unstable/AtomicCxchg/main.rs
@@ -7,7 +7,7 @@ use std::intrinsics::{
     atomic_cxchg_rel, atomic_cxchg_relaxed,
 };
 
-fn main() {
+pub fn main() {
     let mut a1 = 0 as u8;
     let mut a2 = 0 as u8;
     let mut a3 = 0 as u8;

--- a/src/test/cbmc/Atomics/Unstable/AtomicFence/main.rs
+++ b/src/test/cbmc/Atomics/Unstable/AtomicFence/main.rs
@@ -3,7 +3,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::{atomic_fence, atomic_fence_acq, atomic_fence_acqrel, atomic_fence_rel};
 
-fn main() {
+pub fn main() {
     unsafe {
         atomic_fence();
         atomic_fence_acq();

--- a/src/test/cbmc/Atomics/Unstable/AtomicLoad/main.rs
+++ b/src/test/cbmc/Atomics/Unstable/AtomicLoad/main.rs
@@ -3,7 +3,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::{atomic_load, atomic_load_acq, atomic_load_relaxed};
 
-fn main() {
+pub fn main() {
     let a1 = 1 as u8;
     let a2 = 1 as u8;
     let a3 = 1 as u8;

--- a/src/test/cbmc/Atomics/Unstable/AtomicOr/main.rs
+++ b/src/test/cbmc/Atomics/Unstable/AtomicOr/main.rs
@@ -5,7 +5,7 @@ use std::intrinsics::{
     atomic_or, atomic_or_acq, atomic_or_acqrel, atomic_or_rel, atomic_or_relaxed,
 };
 
-fn main() {
+pub fn main() {
     let mut a1 = 1 as u8;
     let mut a2 = 1 as u8;
     let mut a3 = 1 as u8;

--- a/src/test/cbmc/Atomics/Unstable/AtomicStore/main.rs
+++ b/src/test/cbmc/Atomics/Unstable/AtomicStore/main.rs
@@ -3,7 +3,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::{atomic_store, atomic_store_rel, atomic_store_relaxed};
 
-fn main() {
+pub fn main() {
     let mut a1 = 1 as u8;
     let mut a2 = 1 as u8;
     let mut a3 = 1 as u8;

--- a/src/test/cbmc/Atomics/Unstable/AtomicSub/main.rs
+++ b/src/test/cbmc/Atomics/Unstable/AtomicSub/main.rs
@@ -5,7 +5,7 @@ use std::intrinsics::{
     atomic_xsub, atomic_xsub_acq, atomic_xsub_acqrel, atomic_xsub_rel, atomic_xsub_relaxed,
 };
 
-fn main() {
+pub fn main() {
     let mut a1 = 1 as u8;
     let mut a2 = 1 as u8;
     let mut a3 = 1 as u8;

--- a/src/test/cbmc/Atomics/Unstable/AtomicXchg/main.rs
+++ b/src/test/cbmc/Atomics/Unstable/AtomicXchg/main.rs
@@ -5,7 +5,7 @@ use std::intrinsics::{
     atomic_xchg, atomic_xchg_acq, atomic_xchg_acqrel, atomic_xchg_rel, atomic_xchg_relaxed,
 };
 
-fn main() {
+pub fn main() {
     let mut a1 = 0 as u8;
     let mut a2 = 0 as u8;
     let mut a3 = 0 as u8;

--- a/src/test/cbmc/Atomics/Unstable/AtomicXor/main.rs
+++ b/src/test/cbmc/Atomics/Unstable/AtomicXor/main.rs
@@ -5,7 +5,7 @@ use std::intrinsics::{
     atomic_xor, atomic_xor_acq, atomic_xor_acqrel, atomic_xor_rel, atomic_xor_relaxed,
 };
 
-fn main() {
+pub fn main() {
     let mut a1 = 1 as u8;
     let mut a2 = 1 as u8;
     let mut a3 = 1 as u8;

--- a/src/test/cbmc/BitManipulation/Stable/fixme_main.rs
+++ b/src/test/cbmc/BitManipulation/Stable/fixme_main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // rmc-verify-fail
 
-fn main() {
+pub fn main() {
     // Intrinsics implemented as integer primitives
     // https://doc.rust-lang.org/core/intrinsics/fn.cttz.html
     // https://doc.rust-lang.org/core/intrinsics/fn.ctlz.html

--- a/src/test/cbmc/BitManipulation/Unstable/Rotate/main.rs
+++ b/src/test/cbmc/BitManipulation/Unstable/Rotate/main.rs
@@ -3,7 +3,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::{rotate_left, rotate_right};
 
-fn main() {
+pub fn main() {
     let vl8 = 0b0011_1000_u8;
     let vl16 = 0b0011_1000_0000_0000_u16;
     let vl32 = 0b0011_1000_0000_0000_0000_0000_0000_0000_u32;

--- a/src/test/cbmc/BitManipulation/Unstable/fixme_main.rs
+++ b/src/test/cbmc/BitManipulation/Unstable/fixme_main.rs
@@ -5,7 +5,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::{ctlz, cttz, cttz_nonzero};
 
-fn main() {
+pub fn main() {
     let v8 = 0b0011_1000_u8;
     let v16 = 0b0011_1000_0000_0000_u16;
     let v32 = 0b0011_1000_0000_0000_0000_0000_0000_0000_u32;

--- a/src/test/cbmc/BitwiseArithOperators/bool.rs
+++ b/src/test/cbmc/BitwiseArithOperators/bool.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let a: bool = __nondet();
     let b: bool = __nondet();
     let c = a ^ b;

--- a/src/test/cbmc/BitwiseArithOperators/main.rs
+++ b/src/test/cbmc/BitwiseArithOperators/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     assert!(3 | 5 == 7);
     assert!(7 & 9 == 1);
     assert!(9 ^ 7 == 14);

--- a/src/test/cbmc/BitwiseEqualOperators/main.rs
+++ b/src/test/cbmc/BitwiseEqualOperators/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let mut x = 0;
     x |= 1;
     assert!(x == 1);

--- a/src/test/cbmc/BitwiseShiftOperators/Usize/main.rs
+++ b/src/test/cbmc/BitwiseShiftOperators/Usize/main.rs
@@ -5,7 +5,7 @@ fn bitmap_new(byte_size: usize, page_size: usize) -> usize {
     let map_size = ((bit_size - 1) >> 6) + 1;
     map_size
 }
-fn main() {
+pub fn main() {
     let map_size = bitmap_new(1024, 128);
     assert!(map_size == 1);
 }

--- a/src/test/cbmc/BitwiseShiftOperators/main.rs
+++ b/src/test/cbmc/BitwiseShiftOperators/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     assert!(8 >> 4 == 0);
     assert!(1 << 4 == 16);
 

--- a/src/test/cbmc/Bool-BoolOperators/main.rs
+++ b/src/test/cbmc/Bool-BoolOperators/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     assert!(true);
     assert!(true || false);
     assert!(!false);

--- a/src/test/cbmc/Cast/cast_abstract_args_to_concrete.rs
+++ b/src/test/cbmc/Cast/cast_abstract_args_to_concrete.rs
@@ -19,7 +19,7 @@ extern crate libc;
 
 use std::mem;
 
-fn main() {
+pub fn main() {
     let _x32 = 1.0f32.powi(2);
     let _x64 = 1.0f64.powi(2);
 

--- a/src/test/cbmc/Cast/from_be_bytes.rs
+++ b/src/test/cbmc/Cast/from_be_bytes.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::convert::TryInto;
 include!("../../rmc-prelude.rs");
-fn main() {
+pub fn main() {
     let input: &[u8] = &vec![
         __nondet(),
         __nondet(),

--- a/src/test/cbmc/Cast/path.rs
+++ b/src/test/cbmc/Cast/path.rs
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::path::Path;
 
-fn main() {
+pub fn main() {
     let path = Path::new("./foo/bar.txt");
 }

--- a/src/test/cbmc/Closure/main.rs
+++ b/src/test/cbmc/Closure/main.rs
@@ -38,7 +38,7 @@ fn test_env() {
     assert!(r == 9);
 }
 
-fn main() {
+pub fn main() {
     closure_with_empty_args();
     closure_with_1_arg();
     test_three_args();

--- a/src/test/cbmc/CodegenConstValue/bigints.rs
+++ b/src/test/cbmc/CodegenConstValue/bigints.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-fn main() {
+pub fn main() {
     let x: u128 = u128::MAX;
     let x2: u128 = {
         // u128::MAX = 2^128 - 1;

--- a/src/test/cbmc/CodegenConstValue/main.rs
+++ b/src/test/cbmc/CodegenConstValue/main.rs
@@ -8,7 +8,7 @@
 // [main.pointer_dereference.5] line 16 dereference failure: pointer outside object bounds in *lut_ptr: FAILURE
 // Tracking issue: https://github.com/model-checking/rmc/issues/307
 const DEC_DIGITS_LUT: &'static [u8] = b"ab";
-fn main() {
+pub fn main() {
     // The next two assertions don't go through to CBMC
     // 'cos they're constant folded away
     assert!(DEC_DIGITS_LUT[0] == b'a');

--- a/src/test/cbmc/CodegenConstValue/u128.rs
+++ b/src/test/cbmc/CodegenConstValue/u128.rs
@@ -6,6 +6,6 @@ fn assert_bigger(a: u128, b: u128) {
     assert!(a > b);
 }
 
-fn main() {
+pub fn main() {
     assert_bigger(u128::MAX, 12);
 }

--- a/src/test/cbmc/CodegenMisc/main.rs
+++ b/src/test/cbmc/CodegenMisc/main.rs
@@ -12,7 +12,7 @@ pub type SignalHandler = extern "C" fn(num: c_int, _unused: *mut c_void) -> ();
 
 extern "C" fn handle_signal(_: c_int, _: *mut c_void) {}
 
-fn main() {
+pub fn main() {
     let x = handle_signal as *const () as usize;
     assert!(x != 0);
 }

--- a/src/test/cbmc/CodegenStatic/main.rs
+++ b/src/test/cbmc/CodegenStatic/main.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 static STATIC: [&str; 1] = ["FOO"];
-fn main() {
+pub fn main() {
     let x = STATIC[0];
     let bytes = x.as_bytes();
     assert!(bytes.len() == 3);

--- a/src/test/cbmc/CodegenStatic/struct.rs
+++ b/src/test/cbmc/CodegenStatic/struct.rs
@@ -7,6 +7,6 @@ pub struct Foo<const N: usize> {
 
 const x: Foo<3> = Foo { bytes: [1, 2, 3] };
 
-fn main() {
+pub fn main() {
     assert!(x.bytes[0] == 1);
 }

--- a/src/test/cbmc/CopyIntrinsics/main.rs
+++ b/src/test/cbmc/CopyIntrinsics/main.rs
@@ -87,7 +87,7 @@ fn test_swap() {
     assert!(y == 12);
 }
 
-fn main() {
+pub fn main() {
     test_copy();
     test_swap();
     test_append();

--- a/src/test/cbmc/Count/Unstable/Ctlz/bounds.rs
+++ b/src/test/cbmc/Count/Unstable/Ctlz/bounds.rs
@@ -6,7 +6,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::ctlz_nonzero;
 
-fn main() {
+pub fn main() {
     let uv8: u8 = 0;
     let uv16: u16 = 0;
     let uv32: u32 = 0;

--- a/src/test/cbmc/Count/Unstable/Ctlz/main.rs
+++ b/src/test/cbmc/Count/Unstable/Ctlz/main.rs
@@ -3,7 +3,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::{ctlz, ctlz_nonzero};
 
-fn main() {
+pub fn main() {
     let uv8 = 0b0011_1000_u8;
     let uv16 = uv8 as u16;
     let uv32 = uv8 as u32;

--- a/src/test/cbmc/Count/Unstable/Cttz/bounds.rs
+++ b/src/test/cbmc/Count/Unstable/Cttz/bounds.rs
@@ -6,7 +6,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::cttz_nonzero;
 
-fn main() {
+pub fn main() {
     let uv8: u8 = 0;
     let uv16: u16 = 0;
     let uv32: u32 = 0;

--- a/src/test/cbmc/Count/Unstable/Cttz/main.rs
+++ b/src/test/cbmc/Count/Unstable/Cttz/main.rs
@@ -3,7 +3,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::{cttz, cttz_nonzero};
 
-fn main() {
+pub fn main() {
     let uv8 = 0b0011_1000_u8;
     let uv16 = uv8 as u16;
     let uv32 = uv8 as u32;

--- a/src/test/cbmc/DynTrait/any_cast_int.rs
+++ b/src/test/cbmc/DynTrait/any_cast_int.rs
@@ -25,7 +25,7 @@ fn downcast_to_fewer_traits(s: &(dyn Any + Send)) {
     downcast_to_concrete(c);
 }
 
-fn main() {
+pub fn main() {
     let i: i32 = 7;
     downcast_to_fewer_traits(&i);
 }

--- a/src/test/cbmc/DynTrait/any_cast_int_fail.rs
+++ b/src/test/cbmc/DynTrait/any_cast_int_fail.rs
@@ -28,7 +28,7 @@ fn downcast_to_fewer_traits(s: &(dyn Any + Send)) {
     downcast_to_concrete(c);
 }
 
-fn main() {
+pub fn main() {
     let i: i32 = 7;
     downcast_to_fewer_traits(&i);
 }

--- a/src/test/cbmc/DynTrait/boxed_closure.rs
+++ b/src/test/cbmc/DynTrait/boxed_closure.rs
@@ -3,7 +3,7 @@
 
 // Check that we can codegen a boxed dyn closure
 
-fn main() {
+pub fn main() {
     // Create a boxed once-callable closure
     let f: Box<dyn FnOnce(f32, i32)> = Box::new(|x, y| {
         assert!(x == 1.0);

--- a/src/test/cbmc/DynTrait/boxed_closure_fail.rs
+++ b/src/test/cbmc/DynTrait/boxed_closure_fail.rs
@@ -5,7 +5,7 @@
 // Check that we can codegen a boxed dyn closure and fail an inner assertion
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     // Create a boxed once-callable closure
     let f: Box<dyn FnOnce(i32)> = Box::new(|x| {
         __VERIFIER_expect_fail(x == 2, "Wrong int");

--- a/src/test/cbmc/DynTrait/boxed_debug_cast.rs
+++ b/src/test/cbmc/DynTrait/boxed_debug_cast.rs
@@ -22,7 +22,7 @@ fn f<'a>(x: &'a &Box<dyn Error + Send + Sync>) -> Box<&'a dyn Debug> {
     Box::new(d)
 }
 
-fn main() {
+pub fn main() {
     let c = Concrete {};
     let x = Box::new(c) as Box<dyn Error + Send + Sync>;
     let d = f(&&x);

--- a/src/test/cbmc/DynTrait/boxed_trait.rs
+++ b/src/test/cbmc/DynTrait/boxed_trait.rs
@@ -43,7 +43,7 @@ fn do_area_box(x: Box<dyn Shape>) -> u32 {
     x.area()
 }
 
-fn main() {
+pub fn main() {
     let rec = Box::new(Rectangle { w: 10, h: 5 });
     assert!(rec.vol(3) == 150);
     assert!(do_vol(&*rec, 2) == 100);

--- a/src/test/cbmc/DynTrait/boxed_trait_fail.rs
+++ b/src/test/cbmc/DynTrait/boxed_trait_fail.rs
@@ -45,7 +45,7 @@ fn do_area_box(x: Box<dyn Shape>) -> u32 {
     x.area()
 }
 
-fn main() {
+pub fn main() {
     let rec = Box::new(Rectangle { w: 10, h: 5 });
     assert!(rec.vol(3) != 150);
     assert!(do_vol(&*rec, 2) != 100);

--- a/src/test/cbmc/DynTrait/different_crates.rs
+++ b/src/test/cbmc/DynTrait/different_crates.rs
@@ -42,7 +42,7 @@ fn weird_count(c: &mut dyn Iterator) -> usize {
     c.next().unwrap()
 }
 
-fn main() {
+pub fn main() {
     let counter: &mut Counter = &mut Counter { count: 0 };
     assert!(std_count(counter as &mut dyn std::iter::Iterator<Item = usize>) == 1);
     assert!(weird_count(counter as &mut dyn Iterator) == 42);

--- a/src/test/cbmc/DynTrait/different_crates_fail.rs
+++ b/src/test/cbmc/DynTrait/different_crates_fail.rs
@@ -43,7 +43,7 @@ fn weird_count(c: &mut dyn Iterator) -> usize {
     c.next().unwrap()
 }
 
-fn main() {
+pub fn main() {
     let counter: &mut Counter = &mut Counter { count: 0 };
     assert!(std_count(counter as &mut dyn std::iter::Iterator<Item = usize>) == 0); // Should be 1
     assert!(weird_count(counter as &mut dyn Iterator) == 0); // Should be 42

--- a/src/test/cbmc/DynTrait/drop_boxed_dyn.rs
+++ b/src/test/cbmc/DynTrait/drop_boxed_dyn.rs
@@ -35,7 +35,7 @@ impl Drop for Concrete2 {
     }
 }
 
-fn main() {
+pub fn main() {
     {
         let x: Box<dyn T>;
         if __nondet() {

--- a/src/test/cbmc/DynTrait/drop_concrete.rs
+++ b/src/test/cbmc/DynTrait/drop_concrete.rs
@@ -15,7 +15,7 @@ impl Drop for Concrete1 {
     }
 }
 
-fn main() {
+pub fn main() {
     {
         let _x1 = Concrete1 {};
     }

--- a/src/test/cbmc/DynTrait/drop_dyn_pointer.rs
+++ b/src/test/cbmc/DynTrait/drop_dyn_pointer.rs
@@ -33,7 +33,7 @@ impl Drop for Concrete2 {
     }
 }
 
-fn main() {
+pub fn main() {
     {
         let _x1: &dyn T = &Concrete1 {};
     }

--- a/src/test/cbmc/DynTrait/drop_nested_boxed_dyn.rs
+++ b/src/test/cbmc/DynTrait/drop_nested_boxed_dyn.rs
@@ -19,7 +19,7 @@ impl Drop for Concrete {
     }
 }
 
-fn main() {
+pub fn main() {
     // Check normal box
     {
         let _x: Box<dyn Send> = Box::new(Concrete {});

--- a/src/test/cbmc/DynTrait/drop_nested_boxed_dyn_fail.rs
+++ b/src/test/cbmc/DynTrait/drop_nested_boxed_dyn_fail.rs
@@ -18,7 +18,7 @@ impl Drop for Concrete {
     }
 }
 
-fn main() {
+pub fn main() {
     // Check normal box
     {
         let _x: Box<dyn Send> = Box::new(Concrete {});

--- a/src/test/cbmc/DynTrait/dyn_fn_mut.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_mut.rs
@@ -12,7 +12,7 @@ pub fn mut_i32_ptr(x: &mut i32) {
     *x = *x + 1;
 }
 
-fn main() {
+pub fn main() {
     let mut x = 1;
     takes_dyn_fun(Box::new(&mut_i32_ptr), &mut x);
     assert!(x == 2);

--- a/src/test/cbmc/DynTrait/dyn_fn_mut_fail.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_mut_fail.rs
@@ -15,7 +15,7 @@ pub fn mut_i32_ptr(x: &mut i32) {
     *x = *x + 1;
 }
 
-fn main() {
+pub fn main() {
     let mut x = 1;
     takes_dyn_fun(Box::new(&mut_i32_ptr), &mut x);
     __VERIFIER_expect_fail(x == 3, "Wrong x")

--- a/src/test/cbmc/DynTrait/dyn_fn_once.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_once.rs
@@ -12,6 +12,6 @@ pub fn unit_to_u32() -> u32 {
     5
 }
 
-fn main() {
+pub fn main() {
     assert!(takes_dyn_fun(Box::new(&unit_to_u32)) == 5)
 }

--- a/src/test/cbmc/DynTrait/dyn_fn_once_fail.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_once_fail.rs
@@ -15,6 +15,6 @@ pub fn unit_to_u32() -> u32 {
     5
 }
 
-fn main() {
+pub fn main() {
     __VERIFIER_expect_fail(takes_dyn_fun(Box::new(&unit_to_u32)) == 3, "Wrong u32")
 }

--- a/src/test/cbmc/DynTrait/dyn_fn_param.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param.rs
@@ -20,6 +20,6 @@ pub fn unit_to_u32() -> u32 {
     5 as u32
 }
 
-fn main() {
+pub fn main() {
     takes_dyn_fun(&unit_to_u32)
 }

--- a/src/test/cbmc/DynTrait/dyn_fn_param_closure.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_closure.rs
@@ -12,7 +12,7 @@ fn takes_dyn_fun(fun: &dyn Fn() -> i32) {
     /* The closure does not capture anything and thus has zero size */
     assert!(size_from_vtable(vtable!(fun)) == 0);
 }
-fn main() {
+pub fn main() {
     let closure = || 5;
     takes_dyn_fun(&closure)
 }

--- a/src/test/cbmc/DynTrait/dyn_fn_param_closure_capture.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_closure_capture.rs
@@ -14,7 +14,7 @@ fn takes_dyn_fun(fun: &dyn Fn() -> i32) {
     assert!(size_from_vtable(vtable!(fun)) == 8);
 }
 
-fn main() {
+pub fn main() {
     let a = vec![3];
     let closure = || a[0] + 2;
     takes_dyn_fun(&closure)

--- a/src/test/cbmc/DynTrait/dyn_fn_param_closure_capture_fail.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_closure_capture_fail.rs
@@ -15,7 +15,7 @@ fn takes_dyn_fun(fun: &dyn Fn() -> i32) {
     __VERIFIER_expect_fail(size_from_vtable(vtable!(fun)) != 8, "Wrong size");
 }
 
-fn main() {
+pub fn main() {
     let a = vec![3];
     let closure = || a[0] + 2;
     takes_dyn_fun(&closure)

--- a/src/test/cbmc/DynTrait/dyn_fn_param_closure_fail.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_closure_fail.rs
@@ -13,7 +13,7 @@ fn takes_dyn_fun(fun: &dyn Fn() -> i32) {
     /* The closure does not capture anything and thus has zero size */
     __VERIFIER_expect_fail(size_from_vtable(vtable!(fun)) != 0, "Wrong size");
 }
-fn main() {
+pub fn main() {
     let closure = || 5;
     takes_dyn_fun(&closure)
 }

--- a/src/test/cbmc/DynTrait/dyn_fn_param_fail.rs
+++ b/src/test/cbmc/DynTrait/dyn_fn_param_fail.rs
@@ -23,6 +23,6 @@ pub fn unit_to_u32() -> u32 {
     5 as u32
 }
 
-fn main() {
+pub fn main() {
     takes_dyn_fun(&unit_to_u32)
 }

--- a/src/test/cbmc/DynTrait/generic_duplicate_names.rs
+++ b/src/test/cbmc/DynTrait/generic_duplicate_names.rs
@@ -18,7 +18,7 @@ impl<T> Foo<T> for () {
 
 impl Bar for () {}
 
-fn main() {
+pub fn main() {
     let b: &dyn Bar = &();
     // The vtable for b will now have two Foo::method entries,
     // one for Foo<u32> and one for Foo<i32>.

--- a/src/test/cbmc/DynTrait/generic_duplicate_names_fail.rs
+++ b/src/test/cbmc/DynTrait/generic_duplicate_names_fail.rs
@@ -21,7 +21,7 @@ impl<T> Foo<T> for () {
 
 impl Bar for () {}
 
-fn main() {
+pub fn main() {
     let b: &dyn Bar = &();
     // The vtable for b will now have two Foo::method entries,
     // one for Foo<u32> and one for Foo<i32>.

--- a/src/test/cbmc/DynTrait/generic_duplicate_names_impl.rs
+++ b/src/test/cbmc/DynTrait/generic_duplicate_names_impl.rs
@@ -25,7 +25,7 @@ impl Foo<u32> for () {
 
 impl Bar for () {}
 
-fn main() {
+pub fn main() {
     let b: &dyn Bar = &();
     // The vtable for b will now have two Foo::method entries,
     // one for Foo<u32> and one for Foo<i32>.

--- a/src/test/cbmc/DynTrait/generic_duplicate_names_impl_fail.rs
+++ b/src/test/cbmc/DynTrait/generic_duplicate_names_impl_fail.rs
@@ -28,7 +28,7 @@ impl Foo<u32> for () {
 
 impl Bar for () {}
 
-fn main() {
+pub fn main() {
     let b: &dyn Bar = &();
     // The vtable for b will now have two Foo::method entries,
     // one for Foo<u32> and one for Foo<i32>.

--- a/src/test/cbmc/DynTrait/main.rs
+++ b/src/test/cbmc/DynTrait/main.rs
@@ -30,7 +30,7 @@ fn random_animal(random_number: i64) -> Box<dyn Animal> {
     if random_number < 5 { Box::new(Sheep {}) } else { Box::new(Cow {}) }
 }
 
-fn main() {
+pub fn main() {
     let random_number = __nondet();
     let animal = random_animal(random_number);
     let s = animal.noise();

--- a/src/test/cbmc/DynTrait/main_fail.rs
+++ b/src/test/cbmc/DynTrait/main_fail.rs
@@ -30,7 +30,7 @@ fn random_animal(random_number: i64) -> Box<dyn Animal> {
     if random_number < 5 { Box::new(Sheep {}) } else { Box::new(Cow {}) }
 }
 
-fn main() {
+pub fn main() {
     let random_number = __nondet();
     let animal = random_animal(random_number);
     let s = animal.noise();

--- a/src/test/cbmc/DynTrait/nested_boxes.rs
+++ b/src/test/cbmc/DynTrait/nested_boxes.rs
@@ -20,7 +20,7 @@ struct Foo {
     pub _b: i8,
 }
 
-fn main() {
+pub fn main() {
     let dyn_trait1: Box<dyn Send> = Box::new(Foo { _a: 1, _b: 2 });
     let dyn_trait2: Box<dyn Send> = Box::new(dyn_trait1);
     let dyn_trait3: Box<dyn Send> = Box::new(dyn_trait2);

--- a/src/test/cbmc/DynTrait/nested_boxes_fail.rs
+++ b/src/test/cbmc/DynTrait/nested_boxes_fail.rs
@@ -22,7 +22,7 @@ struct Foo {
     pub _b: i8,
 }
 
-fn main() {
+pub fn main() {
     let dyn_trait1: Box<dyn Send> = Box::new(Foo { _a: 1, _b: 2 });
     let dyn_trait2: Box<dyn Send> = Box::new(dyn_trait1);
     let dyn_trait3: Box<dyn Send> = Box::new(dyn_trait2);

--- a/src/test/cbmc/DynTrait/nested_closures.rs
+++ b/src/test/cbmc/DynTrait/nested_closures.rs
@@ -4,7 +4,7 @@
 // Check that we can codegen various nesting structures of boxes and
 // pointer to closures.
 
-fn main() {
+pub fn main() {
     // Create a nested boxed once-callable closure
     let f: Box<Box<dyn FnOnce(i32)>> = Box::new(Box::new(|x| assert!(x == 1)));
     f(1);

--- a/src/test/cbmc/DynTrait/nested_closures_fail.rs
+++ b/src/test/cbmc/DynTrait/nested_closures_fail.rs
@@ -8,7 +8,7 @@
 
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     // Create a nested boxed once-callable closure
     let f: Box<Box<dyn FnOnce(i32)>> =
         Box::new(Box::new(|x| __VERIFIER_expect_fail(x != 1, "wrong int")));

--- a/src/test/cbmc/DynTrait/object_safe_generics.rs
+++ b/src/test/cbmc/DynTrait/object_safe_generics.rs
@@ -30,7 +30,7 @@ impl<T> Foo<T> for () {
 
 impl Bar for () {}
 
-fn main() {
+pub fn main() {
     let b: &dyn Bar = &();
     // The vtable for b will now have two Foo::method entries,
     // one for Foo<u32> and one for Foo<i32>. Both follow the

--- a/src/test/cbmc/DynTrait/object_safe_trait.rs
+++ b/src/test/cbmc/DynTrait/object_safe_trait.rs
@@ -40,7 +40,7 @@ impl NonDispatchable for S {
     }
 }
 
-fn main() {
+pub fn main() {
     let s = S {};
     S::foo();
     let t = s.returns();

--- a/src/test/cbmc/DynTrait/std_lib_add_duplicate.rs
+++ b/src/test/cbmc/DynTrait/std_lib_add_duplicate.rs
@@ -18,7 +18,7 @@ fn weird_add(x: &dyn WeirdAdd, y: i32) -> i32 {
     x.add(y)
 }
 
-fn main() {
+pub fn main() {
     let x = 2;
     let y = 4;
 

--- a/src/test/cbmc/DynTrait/vtable_duplicate_field_override.rs
+++ b/src/test/cbmc/DynTrait/vtable_duplicate_field_override.rs
@@ -45,7 +45,7 @@ impl T for S {
     }
 }
 
-fn main() {
+pub fn main() {
     let t = S::new_box(1, 2, 3);
     let a = <dyn T as A>::foo(&*t);
     assert!(a == 1);

--- a/src/test/cbmc/DynTrait/vtable_duplicate_fields.rs
+++ b/src/test/cbmc/DynTrait/vtable_duplicate_fields.rs
@@ -38,7 +38,7 @@ impl B for S {
 
 impl T for S {}
 
-fn main() {
+pub fn main() {
     let t = S::new_box(1, 2);
     let a = <dyn T as A>::foo(&*t);
     assert!(a == 1);

--- a/src/test/cbmc/DynTrait/vtable_size_align_drop.rs
+++ b/src/test/cbmc/DynTrait/vtable_size_align_drop.rs
@@ -47,7 +47,7 @@ fn random_animal(random_number: i64) -> Box<dyn Animal> {
     if random_number < 5 { Box::new(Sheep { sheep_num: 7 }) } else { Box::new(Cow { cow_num: 9 }) }
 }
 
-fn main() {
+pub fn main() {
     // The vtable is laid out as the right hand side here:
     //
     // +-------+------------------+

--- a/src/test/cbmc/DynTrait/vtable_size_align_drop_fail.rs
+++ b/src/test/cbmc/DynTrait/vtable_size_align_drop_fail.rs
@@ -49,7 +49,7 @@ fn random_animal(random_number: i64) -> Box<dyn Animal> {
     if random_number < 5 { Box::new(Sheep { sheep_num: 7 }) } else { Box::new(Cow { cow_num: 9 }) }
 }
 
-fn main() {
+pub fn main() {
     let ptr_size = size_of::<&usize>() as isize;
 
     // The vtable is laid out as the right hand side here:

--- a/src/test/cbmc/EQ-NE/main.rs
+++ b/src/test/cbmc/EQ-NE/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let x: u32 = __nondet();
     if x < u32::MAX >> 1 {
         let y = x * 2;

--- a/src/test/cbmc/Enum/main.rs
+++ b/src/test/cbmc/Enum/main.rs
@@ -7,7 +7,7 @@ fn foo() -> Result<i64, MyInfallible> {
     Ok(1)
 }
 
-fn main() {
+pub fn main() {
     let v = foo().unwrap();
     assert!(v == 1);
 }

--- a/src/test/cbmc/Enum/min_offset.rs
+++ b/src/test/cbmc/Enum/min_offset.rs
@@ -12,7 +12,7 @@ enum E {
     Bar,
 }
 
-fn main() {
+pub fn main() {
     let e = E::Foo { a: 32, b: 100 };
     match e {
         E::Foo { a, b } => {

--- a/src/test/cbmc/Enum/variants_multiple_len_2.rs
+++ b/src/test/cbmc/Enum/variants_multiple_len_2.rs
@@ -6,6 +6,6 @@ pub enum EnumMultiple {
     Multiple2,
 }
 
-fn main() {
+pub fn main() {
     let e = EnumMultiple::Multiple1;
 }

--- a/src/test/cbmc/Enum/variants_single_len_1_fields_arbitrary_0.rs
+++ b/src/test/cbmc/Enum/variants_single_len_1_fields_arbitrary_0.rs
@@ -5,7 +5,7 @@ pub enum EnumSingle {
     MySingle,
 }
 
-fn main() {
+pub fn main() {
     let e = EnumSingle::MySingle;
     assert!(e == EnumSingle::MySingle);
 }

--- a/src/test/cbmc/Enum/variants_single_len_1_fields_arbitrary_1.rs
+++ b/src/test/cbmc/Enum/variants_single_len_1_fields_arbitrary_1.rs
@@ -5,7 +5,7 @@ pub enum EnumSingle {
     MySingle(u32),
 }
 
-fn main() {
+pub fn main() {
     let e = EnumSingle::MySingle(1);
     assert!(e == EnumSingle::MySingle(1));
 }

--- a/src/test/cbmc/Enum/variants_single_len_1_fields_arbitrary_2.rs
+++ b/src/test/cbmc/Enum/variants_single_len_1_fields_arbitrary_2.rs
@@ -5,7 +5,7 @@ pub enum EnumSingle {
     MySingle(u32, u32),
 }
 
-fn main() {
+pub fn main() {
     let e = EnumSingle::MySingle(1, 1);
     assert!(e == EnumSingle::MySingle(1, 1));
 }

--- a/src/test/cbmc/Enum/variants_single_len_2_fields_arbitrary_1.rs
+++ b/src/test/cbmc/Enum/variants_single_len_2_fields_arbitrary_1.rs
@@ -8,7 +8,7 @@ pub enum MyInfallible {}
 fn foo() -> Result<i64, MyInfallible> {
     Ok(1)
 }
-fn main() {
+pub fn main() {
     let v = foo().unwrap();
     assert!(v == 1);
 }

--- a/src/test/cbmc/ExactDiv/main.rs
+++ b/src/test/cbmc/ExactDiv/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 #![feature(core_intrinsics)]
 
-fn main() {
+pub fn main() {
     let a: u8 = 8;
     let b: u8 = 4;
     let i = unsafe { std::intrinsics::exact_div(a, b) };

--- a/src/test/cbmc/FatPointers/boxmuttrait.rs
+++ b/src/test/cbmc/FatPointers/boxmuttrait.rs
@@ -9,7 +9,7 @@ use std::ptr::DynMetadata;
 
 include!("../Helpers/vtable_utils_ignore.rs");
 
-fn main() {
+pub fn main() {
     let mut log: Box<dyn Write + Send> = Box::new(sink());
     let dest: Box<dyn Write + Send> = Box::new(log.as_mut());
 

--- a/src/test/cbmc/FatPointers/boxmuttrait_fail.rs
+++ b/src/test/cbmc/FatPointers/boxmuttrait_fail.rs
@@ -4,7 +4,7 @@
 
 use std::io::{sink, Write};
 
-fn main() {
+pub fn main() {
     let mut log: Box<dyn Write + Send> = Box::new(sink());
     let dest: Box<dyn Write + Send> = Box::new(log.as_mut());
 

--- a/src/test/cbmc/FatPointers/boxslice1.rs
+++ b/src/test/cbmc/FatPointers/boxslice1.rs
@@ -4,7 +4,7 @@
 // Casts boxed array to boxed slice (example taken from rust documentation)
 use std::str;
 
-fn main() {
+pub fn main() {
     // This vector of bytes is used to initialize a Box<[u8; 4]>
     let sparkle_heart_vec = vec![240, 159, 146, 150];
 

--- a/src/test/cbmc/FatPointers/boxslice2.rs
+++ b/src/test/cbmc/FatPointers/boxslice2.rs
@@ -5,7 +5,7 @@
 // Casts boxed array to boxed slice (example taken from rust documentation)
 use std::str;
 
-fn main() {
+pub fn main() {
     // This vector of bytes is used to initialize a Box<[u8; 4]>
     let sparkle_heart_vec = vec![240, 159, 146, 150];
 

--- a/src/test/cbmc/FatPointers/boxtrait.rs
+++ b/src/test/cbmc/FatPointers/boxtrait.rs
@@ -27,7 +27,7 @@ impl Trait for Concrete {
     }
 }
 
-fn main() {
+pub fn main() {
     let mut x: Box<dyn Trait> = Box::new(Concrete::new());
     x.increment();
     assert!(x.get() == 1);

--- a/src/test/cbmc/FatPointers/boxtrait_fail.rs
+++ b/src/test/cbmc/FatPointers/boxtrait_fail.rs
@@ -28,7 +28,7 @@ impl Trait for Concrete {
     }
 }
 
-fn main() {
+pub fn main() {
     let mut x: Box<dyn Trait> = Box::new(Concrete::new());
     x.increment();
     assert!(x.get() == 3); // Should be x.get() == 1

--- a/src/test/cbmc/FatPointers/fixme_slice2.rs
+++ b/src/test/cbmc/FatPointers/fixme_slice2.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-fn main() {
+pub fn main() {
     let array = [1, 2, 3, 4, 5, 6];
     let slice = &array[2..5];
     assert!(slice[0] == 3);

--- a/src/test/cbmc/FatPointers/slice1.rs
+++ b/src/test/cbmc/FatPointers/slice1.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-fn main() {
+pub fn main() {
     let array = [1, 2, 3, 4, 5, 6];
     let slice: &[u32] = &array;
     assert!(slice[0] == 1);

--- a/src/test/cbmc/FatPointers/slice3.rs
+++ b/src/test/cbmc/FatPointers/slice3.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-fn main() {
+pub fn main() {
     let array = [1, 2, 3, 4, 5, 6];
     let slice1 = &array[2..5];
     let slice2 = &slice1[1..2];

--- a/src/test/cbmc/FatPointers/structslice.rs
+++ b/src/test/cbmc/FatPointers/structslice.rs
@@ -9,7 +9,7 @@ struct Abstract<'a> {
     uints: &'a [u32],
 }
 
-fn main() {
+pub fn main() {
     let x = Concrete { array: [1, 2, 3, 4] };
     assert!(x.array[0] == 1);
     let y = Abstract { uints: &[10, 11, 12, 13] };

--- a/src/test/cbmc/FatPointers/trait1.rs
+++ b/src/test/cbmc/FatPointers/trait1.rs
@@ -24,7 +24,7 @@ impl Subscriber for DummySubscriber {
     }
 }
 
-fn main() {
+pub fn main() {
     let _d = DummySubscriber::new();
     let _s = &_d as &dyn Subscriber;
     assert!(_s.process() == 1);

--- a/src/test/cbmc/FatPointers/trait1_fail.rs
+++ b/src/test/cbmc/FatPointers/trait1_fail.rs
@@ -25,7 +25,7 @@ impl Subscriber for DummySubscriber {
     }
 }
 
-fn main() {
+pub fn main() {
     let _d = DummySubscriber::new();
     let _s = &_d as &dyn Subscriber;
     assert!(_s.process() == 3); // Should be _s.process() == 1

--- a/src/test/cbmc/FatPointers/trait2.rs
+++ b/src/test/cbmc/FatPointers/trait2.rs
@@ -24,7 +24,7 @@ impl Subscriber for DummySubscriber {
     }
 }
 
-fn main() {
+pub fn main() {
     let _d = DummySubscriber::new();
     let _s = &_d as *const dyn Subscriber;
     assert!(unsafe { _s.as_ref().unwrap().process() } == 1);

--- a/src/test/cbmc/FatPointers/trait2_fail.rs
+++ b/src/test/cbmc/FatPointers/trait2_fail.rs
@@ -25,7 +25,7 @@ impl Subscriber for DummySubscriber {
     }
 }
 
-fn main() {
+pub fn main() {
     let _d = DummySubscriber::new();
     let _s = &_d as *const dyn Subscriber;
     assert!(unsafe { _s.as_ref().unwrap().process() } == 3); // Should be == 1

--- a/src/test/cbmc/FatPointers/trait3.rs
+++ b/src/test/cbmc/FatPointers/trait3.rs
@@ -28,7 +28,7 @@ impl Subscriber for DummySubscriber {
     }
 }
 
-fn main() {
+pub fn main() {
     let d = DummySubscriber::new();
 
     let d1 = &d as *const DummySubscriber;

--- a/src/test/cbmc/FatPointers/trait3_fail.rs
+++ b/src/test/cbmc/FatPointers/trait3_fail.rs
@@ -29,7 +29,7 @@ impl Subscriber for DummySubscriber {
     }
 }
 
-fn main() {
+pub fn main() {
     let d = DummySubscriber::new();
 
     let d1 = &d as *const DummySubscriber;

--- a/src/test/cbmc/FloatingPoint/main.rs
+++ b/src/test/cbmc/FloatingPoint/main.rs
@@ -23,7 +23,7 @@ macro_rules! test_floats {
     };
 }
 
-fn main() {
+pub fn main() {
     assert!(1.1 == 1.1 * 1.0);
     assert!(1.1 != 1.11 / 1.0);
 

--- a/src/test/cbmc/ForeignItems/fixme_main.rs
+++ b/src/test/cbmc/ForeignItems/fixme_main.rs
@@ -48,7 +48,7 @@ extern "C" {
     fn takes_struct_ptr2(f: &Foo2) -> u32;
 }
 
-fn main() {
+pub fn main() {
     unsafe {
         assert!(S == 12);
         update_static();

--- a/src/test/cbmc/ForeignItems/fixme_varadic.rs
+++ b/src/test/cbmc/ForeignItems/fixme_varadic.rs
@@ -13,7 +13,7 @@ extern "C" {
 
 }
 
-fn main() {
+pub fn main() {
     unsafe {
         assert!(my_add(2 as usize, 3 as usize, 4 as usize) == 7); //works
         assert!(my_add(3, 3 as usize, 4 as usize, 5 as usize) == 12); //works

--- a/src/test/cbmc/ForeignItems/main.rs
+++ b/src/test/cbmc/ForeignItems/main.rs
@@ -36,7 +36,7 @@ extern "C" {
     fn takes_struct_ptr2(f: &Foo2) -> u32;
 }
 
-fn main() {
+pub fn main() {
     unsafe {
         assert!(S == 12);
         update_static();

--- a/src/test/cbmc/FunctionCall/FnPtr/main.rs
+++ b/src/test/cbmc/FunctionCall/FnPtr/main.rs
@@ -10,7 +10,7 @@ pub struct LocalKey {
 unsafe fn foo(x: i32) -> i32 {
     x + 1
 }
-fn main() {
+pub fn main() {
     let l = LocalKey { inner: foo };
     unsafe { assert!((l.inner)(3) == 4) }
 }

--- a/src/test/cbmc/FunctionCall/Variadic/fixme_main.rs
+++ b/src/test/cbmc/FunctionCall/Variadic/fixme_main.rs
@@ -14,7 +14,7 @@ pub unsafe extern "C" fn my_add(num: c_long, mut args: ...) -> c_long {
     accum
 }
 
-fn main() {
+pub fn main() {
     let arg0: c_long = 2;
     let arg1: c_long = 3;
     let arg1: c_long = 4;

--- a/src/test/cbmc/FunctionCall/Variadic/main.rs
+++ b/src/test/cbmc/FunctionCall/Variadic/main.rs
@@ -8,7 +8,7 @@ type c_long = i64;
 
 pub unsafe extern "C" fn syscall(_num: c_long, _: ...) {}
 
-fn main() {
+pub fn main() {
     let arg0: c_long = 0;
     let arg1: c_long = 1;
     let _x = unsafe { syscall(0, arg0, arg1) };

--- a/src/test/cbmc/FunctionCall_ImplicitReturn/main.rs
+++ b/src/test/cbmc/FunctionCall_ImplicitReturn/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     assert!(x_plus_two_1(0) == 2);
     assert!(x_plus_two_2(1) == 3);
     assert!(x_plus_two_1(x_plus_two_2(0) + 1) == 5);

--- a/src/test/cbmc/FunctionCall_NoRet-NoParam/main.rs
+++ b/src/test/cbmc/FunctionCall_NoRet-NoParam/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     assert!(true);
     trivial_function();
     assert!(1.0 == 1.0);

--- a/src/test/cbmc/FunctionCall_NoRet-Param/main.rs
+++ b/src/test/cbmc/FunctionCall_NoRet-Param/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     check_u32(4);
     check_u32(123);
     check_u32(119);

--- a/src/test/cbmc/FunctionCall_Ret-NoParam/main.rs
+++ b/src/test/cbmc/FunctionCall_Ret-NoParam/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let a = return_u32();
     assert!(a < 10);
     assert!(return_u32() < 10);

--- a/src/test/cbmc/FunctionCall_Ret-Param/main.rs
+++ b/src/test/cbmc/FunctionCall_Ret-Param/main.rs
@@ -10,7 +10,7 @@
 
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let x: u32 = __nondet();
     let pi = 3.14159265359;
 

--- a/src/test/cbmc/Generator/main.rs
+++ b/src/test/cbmc/Generator/main.rs
@@ -21,6 +21,6 @@ fn maybe_call(call: bool) {
     }
 }
 
-fn main() {
+pub fn main() {
     maybe_call(false);
 }

--- a/src/test/cbmc/IfElseifElse_NonReturning/main.rs
+++ b/src/test/cbmc/IfElseifElse_NonReturning/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let a: u32 = __nondet();
 
     if a % 3 == 0 {

--- a/src/test/cbmc/IfElseifElse_Returning/main.rs
+++ b/src/test/cbmc/IfElseifElse_Returning/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let a: u32 = __nondet();
 
     let b = if a % 3 == 0 {

--- a/src/test/cbmc/Intrinsics/abort.rs
+++ b/src/test/cbmc/Intrinsics/abort.rs
@@ -4,6 +4,6 @@
 
 #![feature(core_intrinsics)]
 use std::intrinsics;
-fn main() {
+pub fn main() {
     intrinsics::abort();
 }

--- a/src/test/cbmc/Intrinsics/black_box.rs
+++ b/src/test/cbmc/Intrinsics/black_box.rs
@@ -4,7 +4,7 @@
 #![feature(bench_black_box)]
 use std::hint::black_box;
 
-fn main() {
+pub fn main() {
     // black_box is an identity function that limits compiler optimizations
     let a = 10;
     let b = black_box(a);

--- a/src/test/cbmc/Intrinsics/fixme_catch_unwind.rs
+++ b/src/test/cbmc/Intrinsics/fixme_catch_unwind.rs
@@ -5,7 +5,7 @@
 // Stable way of calling the `try` intrinsic.
 use std::panic;
 
-fn main() {
+pub fn main() {
     let result = panic::catch_unwind(|| {
         println!("hello!");
     });

--- a/src/test/cbmc/Intrinsics/fixme_try.rs
+++ b/src/test/cbmc/Intrinsics/fixme_try.rs
@@ -5,7 +5,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::r#try;
 
-fn main() {
+pub fn main() {
     unsafe {
         // Rust will make a best-effort to swallow the panic, and then execute the cleanup function.
         // However, my understanding is that failure is still possible, since its just a best-effort

--- a/src/test/cbmc/Intrinsics/needs_drop.rs
+++ b/src/test/cbmc/Intrinsics/needs_drop.rs
@@ -15,7 +15,7 @@ impl<T> Foo<T> {
     }
 }
 
-fn main() {
+pub fn main() {
     // Integers don't need to be dropped
     let int_foo = Foo::<i32> { _foo: 0 };
     assert!(!int_foo.call_needs_drop());

--- a/src/test/cbmc/LT-GT-LE-GE/main.rs
+++ b/src/test/cbmc/LT-GT-LE-GE/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let a: u32 = __nondet();
     let b = a / 2;
     assert!(b <= a);

--- a/src/test/cbmc/LoopLoop_NonReturning/main.rs
+++ b/src/test/cbmc/LoopLoop_NonReturning/main.rs
@@ -5,7 +5,7 @@
 
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let mut a: u32 = __nondet();
 
     if a < 1024 {

--- a/src/test/cbmc/LoopLoop_NonReturning/main_no_unwind_asserts.rs
+++ b/src/test/cbmc/LoopLoop_NonReturning/main_no_unwind_asserts.rs
@@ -23,7 +23,7 @@ include!("../../rmc-prelude.rs");
 //
 // ** 0 of 1 failed (1 iterations)
 // VERIFICATION SUCCESSFUL
-fn main() {
+pub fn main() {
     let mut a: u32 = __nondet();
 
     if a < 1024 {

--- a/src/test/cbmc/LoopWhile_NonReturning/main.rs
+++ b/src/test/cbmc/LoopWhile_NonReturning/main.rs
@@ -5,7 +5,7 @@
 
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let mut a: u32 = __nondet();
 
     if a < 1024 {

--- a/src/test/cbmc/LoopWhile_NonReturning/main_no_unwind_asserts.rs
+++ b/src/test/cbmc/LoopWhile_NonReturning/main_no_unwind_asserts.rs
@@ -24,7 +24,7 @@ include!("../../rmc-prelude.rs");
 //
 // ** 0 of 1 failed (1 iterations)
 // VERIFICATION SUCCESSFUL
-fn main() {
+pub fn main() {
     let mut a: u32 = __nondet();
 
     if a < 1024 {

--- a/src/test/cbmc/MemReplace/main.rs
+++ b/src/test/cbmc/MemReplace/main.rs
@@ -4,7 +4,7 @@ enum Dummy {
     Dumb,
 }
 
-fn main() {
+pub fn main() {
     // invoke replace on a zero-sized type
     let mut value: Dummy = Dummy::Dumb;
     let dst: &mut Dummy = &mut value;

--- a/src/test/cbmc/NondetVectors/bytes.rs
+++ b/src/test/cbmc/NondetVectors/bytes.rs
@@ -4,7 +4,7 @@ use std::convert::TryInto;
 
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let input: &[u8] = &vec![
         __nondet(),
         __nondet(),

--- a/src/test/cbmc/NondetVectors/fixme_main.rs
+++ b/src/test/cbmc/NondetVectors/fixme_main.rs
@@ -3,7 +3,7 @@
 const FIFO_SIZE: usize = 2;
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let len: usize = __nondet();
     if !(len <= FIFO_SIZE) {
         return;

--- a/src/test/cbmc/Parenths/main.rs
+++ b/src/test/cbmc/Parenths/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let a = 10;
     let b = (a + 6) / 2;
     assert!(b == 8);

--- a/src/test/cbmc/PointerOffset/Stable/main.rs
+++ b/src/test/cbmc/PointerOffset/Stable/main.rs
@@ -9,7 +9,7 @@
 // [overflow.2] arithmetic overflow on signed - in var_11 - var_12: FAILURE
 // Tracking issue: https://github.com/model-checking/rmc/issues/307
 
-fn main() {
+pub fn main() {
     // pub unsafe fn offset_from(self, origin: *const T) -> isize
     // Calculates the distance between two pointers. The returned value
     // is in units of T: the distance in bytes is divided by mem::size_of::<T>().

--- a/src/test/cbmc/PointerOffset/Unstable/main.rs
+++ b/src/test/cbmc/PointerOffset/Unstable/main.rs
@@ -12,7 +12,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::ptr_offset_from;
 
-fn main() {
+pub fn main() {
     let a = [0; 5];
     let b = [0; 5];
     let ptr1: *const i32 = &a[1];

--- a/src/test/cbmc/PointerOffset/Unstable/main_fail.rs
+++ b/src/test/cbmc/PointerOffset/Unstable/main_fail.rs
@@ -5,7 +5,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::ptr_offset_from;
 
-fn main() {
+pub fn main() {
     let a = [0; 5];
     let b = [0; 5];
     let ptr1: *const i32 = &a[1];

--- a/src/test/cbmc/Pointers_Basic/fixme_from_raw.rs
+++ b/src/test/cbmc/Pointers_Basic/fixme_from_raw.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // rmc-verify-fail
 
-fn main() {
+pub fn main() {
     let address = 0x01234usize;
     let ptr = address as *mut i32;
     // pointers can only be dereferenced inside unsafe blocks

--- a/src/test/cbmc/Pointers_Basic/main.rs
+++ b/src/test/cbmc/Pointers_Basic/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let x = 3;
     let y = &x;
     let mut z = *y;

--- a/src/test/cbmc/Pointers_Functions/main.rs
+++ b/src/test/cbmc/Pointers_Functions/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let mut x = 1;
     add_two(&mut x);
     assert!(x == 3);

--- a/src/test/cbmc/Pointers_InAssert/main.rs
+++ b/src/test/cbmc/Pointers_InAssert/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let mut a = 5;
     let mut c = &mut a;
     add_two(c);

--- a/src/test/cbmc/Pointers_OtherTypes/main.rs
+++ b/src/test/cbmc/Pointers_OtherTypes/main.rs
@@ -10,7 +10,7 @@
 
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let mut x = 1;
     add_two(&mut x);
     assert!(x == 3);

--- a/src/test/cbmc/Pointers_OutOfScopeFail/fixme_main.rs
+++ b/src/test/cbmc/Pointers_OutOfScopeFail/fixme_main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // rmc-verify-fail
 
-fn main() {
+pub fn main() {
     // declare pointer to integer
     let p_subscoped: *const u32;
 

--- a/src/test/cbmc/ProjectionElem/ConstantIndex/main.rs
+++ b/src/test/cbmc/ProjectionElem/ConstantIndex/main.rs
@@ -96,7 +96,7 @@ fn test4() {
     assert!(encode_utf8_raw(code, dst) == 0);
 }
 
-fn main() {
+pub fn main() {
     test1();
     test2();
     test3(&[1, 2, 3, 4]);

--- a/src/test/cbmc/Refs/fixme_main.rs
+++ b/src/test/cbmc/Refs/fixme_main.rs
@@ -79,7 +79,7 @@ impl<'a> ArgParser<'a> {
     }
 }
 
-fn main() {
+pub fn main() {
     let a: ArgParser = ArgParser { arguments: BTreeMap::new() };
     a.format_arguments();
 }

--- a/src/test/cbmc/Repr/main.rs
+++ b/src/test/cbmc/Repr/main.rs
@@ -13,7 +13,7 @@ fn mmap() -> *mut MyCVoid {
     0 as *mut MyCVoid
 }
 
-fn main() {
+pub fn main() {
     let v = mmap();
     assert!(v != MAP_FAILED);
     assert!(v.is_null());

--- a/src/test/cbmc/SIMD/Compare/main.rs
+++ b/src/test/cbmc/SIMD/Compare/main.rs
@@ -31,7 +31,7 @@ macro_rules! assert_cmp {
 // Vectors are compared element-wise producing:
 //  * 0 when comparison is false
 //  * -1 (all bits set) otherwise
-fn main() {
+pub fn main() {
     let x = i64x2(0, 0);
     let y = i64x2(0, 1);
 

--- a/src/test/cbmc/SIMD/Construction/main.rs
+++ b/src/test/cbmc/SIMD/Construction/main.rs
@@ -12,7 +12,7 @@ extern "platform-intrinsic" {
     fn simd_insert<T, U>(x: T, idx: u32, b: U) -> T;
 }
 
-fn main() {
+pub fn main() {
     let y = i64x2(0, 1);
     let z = i64x2(1, 2);
 

--- a/src/test/cbmc/SIMD/Operators/main.rs
+++ b/src/test/cbmc/SIMD/Operators/main.rs
@@ -29,7 +29,7 @@ macro_rules! assert_op {
 
 // Tests inspired by Rust's examples in
 // https://github.com/rust-lang/rust/blob/0d97f7a96877a96015d70ece41ad08bb7af12377/src/test/ui/simd-intrinsic/simd-intrinsic-generic-arithmetic.rs
-fn main() {
+pub fn main() {
     let x = i64x2(0, 0);
     let y = i64x2(0, 1);
     let z = i64x2(1, 2);

--- a/src/test/cbmc/SIMD/Shuffle/main.rs
+++ b/src/test/cbmc/SIMD/Shuffle/main.rs
@@ -17,7 +17,7 @@ extern "platform-intrinsic" {
     fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
 }
 
-fn main() {
+pub fn main() {
     {
         let y = i64x2(0, 1);
         let z = i64x2(1, 2);

--- a/src/test/cbmc/SaturatingIntrinsics/fixme_128.rs
+++ b/src/test/cbmc/SaturatingIntrinsics/fixme_128.rs
@@ -7,7 +7,7 @@ use std::intrinsics;
 
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let v: u128 = __nondet();
     let w: u128 = __nondet();
     intrinsics::saturating_add(v, w);

--- a/src/test/cbmc/SaturatingIntrinsics/main.rs
+++ b/src/test/cbmc/SaturatingIntrinsics/main.rs
@@ -51,7 +51,7 @@ macro_rules! test_saturating_intrinsics {
     };
 }
 
-fn main() {
+pub fn main() {
     test_saturating_intrinsics!(u8);
     test_saturating_intrinsics!(u16);
     test_saturating_intrinsics!(u32);

--- a/src/test/cbmc/Scopes_NonReturning/main.rs
+++ b/src/test/cbmc/Scopes_NonReturning/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let a: u32 = __nondet();
     let b = a / 2;
     let c = a / 2;

--- a/src/test/cbmc/Scopes_Returning/main.rs
+++ b/src/test/cbmc/Scopes_Returning/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let x = { 5 };
     assert!(x == 5);
 

--- a/src/test/cbmc/Serde/main.rs
+++ b/src/test/cbmc/Serde/main.rs
@@ -17,7 +17,7 @@ impl fmt::Display for OneOf {
     }
 }
 
-fn main() {
+pub fn main() {
     let v = OneOf { names: &["one"] };
     println!("{}", v);
 }

--- a/src/test/cbmc/SizeAndAlignOfDst/main_assert_fixme.rs
+++ b/src/test/cbmc/SizeAndAlignOfDst/main_assert_fixme.rs
@@ -60,7 +60,7 @@ impl Subscriber for DummySubscriber {
     }
 }
 
-fn main() {
+pub fn main() {
     let s: Arc<Mutex<dyn Subscriber>> = Arc::new(Mutex::new(DummySubscriber::new()));
     let mut data = s.lock().unwrap();
     data.increment();

--- a/src/test/cbmc/SizeAndAlignOfDst/main_fixme.rs
+++ b/src/test/cbmc/SizeAndAlignOfDst/main_fixme.rs
@@ -53,6 +53,6 @@ impl Subscriber for DummySubscriber {
     fn interest_list(&self) {}
 }
 
-fn main() {
+pub fn main() {
     let s: Arc<Mutex<dyn Subscriber>> = Arc::new(Mutex::new(DummySubscriber::new()));
 }

--- a/src/test/cbmc/Slice/codegen.rs
+++ b/src/test/cbmc/Slice/codegen.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let name = String::from("Mark");
     let name_str = name.as_str();
     assert!(name_str.len() > 0);

--- a/src/test/cbmc/Slice/main.rs
+++ b/src/test/cbmc/Slice/main.rs
@@ -3,7 +3,7 @@
 
 // cbmc-flags: --unwind 6
 
-fn main() {
+pub fn main() {
     let name: &str = "hello";
     assert!(name == "hello");
 }

--- a/src/test/cbmc/Slice/slice.rs
+++ b/src/test/cbmc/Slice/slice.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let list = [1, 2, 3];
     let slice = &list[1..2];
     assert!(slice.len() > 0);

--- a/src/test/cbmc/Slice/slice_from_raw.rs
+++ b/src/test/cbmc/Slice/slice_from_raw.rs
@@ -7,7 +7,7 @@ use std::slice;
 include!("../../rmc-prelude.rs");
 
 // From Listing 19-7: Creating a slice from an arbitrary memory location. https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html
-fn main() {
+pub fn main() {
     let address = 0x01234usize;
     let r = address as *mut i32;
     let slice: &mut [i32] = unsafe { slice::from_raw_parts_mut(r, 10000) };

--- a/src/test/cbmc/Static/main.rs
+++ b/src/test/cbmc/Static/main.rs
@@ -11,7 +11,7 @@ pub enum MyEnum {
     ChoiceC,
 }
 
-fn main() {
+pub fn main() {
     assert!(!X);
     unsafe {
         Y = true;

--- a/src/test/cbmc/Static/table_of_pairs.rs
+++ b/src/test/cbmc/Static/table_of_pairs.rs
@@ -7,7 +7,7 @@ fn test_equal(a: u64, b: u64) -> bool {
     a == b
 }
 
-fn main() {
+pub fn main() {
     let x = TABLE[0];
     assert!(test_equal(x.1, 2));
 }

--- a/src/test/cbmc/Static/table_of_pairs2.rs
+++ b/src/test/cbmc/Static/table_of_pairs2.rs
@@ -12,7 +12,7 @@ fn test_equal(a: u64, b: u64) -> bool {
     a == b
 }
 
-fn main() {
+pub fn main() {
     let x = TABLE1[0];
     assert!(test_equal(x.1, 1));
     let y = TABLE2[0];

--- a/src/test/cbmc/Strings/copy_empty_string_by_intrinsic.rs
+++ b/src/test/cbmc/Strings/copy_empty_string_by_intrinsic.rs
@@ -24,7 +24,7 @@ fn copy_string(s: &str, l: usize) {
     }
 }
 
-fn main() {
+pub fn main() {
     copy_string("x", 1);
     copy_string("", 0);
 }

--- a/src/test/cbmc/Strings/copy_empty_string_by_intrinsic_fixme.rs
+++ b/src/test/cbmc/Strings/copy_empty_string_by_intrinsic_fixme.rs
@@ -37,7 +37,7 @@ fn copy_string(s: &str, l: usize) {
     }
 }
 
-fn main() {
+pub fn main() {
     // Verification fails for both of these cases.
     copy_string("x", 1);
     copy_string("", 0);

--- a/src/test/cbmc/Strings/copy_empty_string_by_ref.rs
+++ b/src/test/cbmc/Strings/copy_empty_string_by_ref.rs
@@ -7,7 +7,7 @@ fn take_string_ref(s: &str, l: usize) {
     assert!(s.len() == l)
 }
 
-fn main() {
+pub fn main() {
     take_string_ref(&"x".to_string(), 1);
     take_string_ref(&"".to_string(), 0);
 }

--- a/src/test/cbmc/Strings/fixme_boxed_str.rs
+++ b/src/test/cbmc/Strings/fixme_boxed_str.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Fails with a type safety error - see TODO in rvalue.rs::codegen_misc_cast()
-fn main() {
+pub fn main() {
     let s = String::from("hello");
     let _b = s.into_boxed_str();
 }

--- a/src/test/cbmc/Strings/fixme_main.rs
+++ b/src/test/cbmc/Strings/fixme_main.rs
@@ -23,7 +23,7 @@ fn test4() {
         //assert!(*ptr.offset(1) as char == '2'); // u8 to char not handled yet
     }
 }
-fn main() {
+pub fn main() {
     //  test2();
     //  test3();
     test4();

--- a/src/test/cbmc/Strings/fixme_os_str.rs
+++ b/src/test/cbmc/Strings/fixme_os_str.rs
@@ -44,7 +44,7 @@ impl OsStr {
     }
 }
 
-fn main() {
+pub fn main() {
     let x = OsStr::new("hi");
     x.as_bytes();
 }

--- a/src/test/cbmc/Strings/main.rs
+++ b/src/test/cbmc/Strings/main.rs
@@ -20,6 +20,6 @@ fn test1() {
     assert!(string.len() == 3);
 }
 
-fn main() {
+pub fn main() {
     test1();
 }

--- a/src/test/cbmc/Strings/os_str_reduced.rs
+++ b/src/test/cbmc/Strings/os_str_reduced.rs
@@ -28,7 +28,7 @@ fn test2() {
     assert!(inner.inner[1] == 'i' as u8);
 }
 
-fn main() {
+pub fn main() {
     test1();
     test2();
 }

--- a/src/test/cbmc/SubSlice/subslice1.rs
+++ b/src/test/cbmc/SubSlice/subslice1.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let arr = [1, 2, 3];
     // s is a slice (&[i32])
     let [s @ ..] = &arr[..];

--- a/src/test/cbmc/SubSlice/subslice2_fixme.rs
+++ b/src/test/cbmc/SubSlice/subslice2_fixme.rs
@@ -30,7 +30,7 @@
 // Full support for subslice projection to be added in
 // https://github.com/model-checking/rmc/issues/357
 
-fn main() {
+pub fn main() {
     let arr = [1, 2, 3];
     // s is a slice (&[i32])
     let [s @ ..] = &arr[1..];

--- a/src/test/cbmc/SwitchInt/main.rs
+++ b/src/test/cbmc/SwitchInt/main.rs
@@ -36,7 +36,7 @@ fn doswitch_bytes() -> i32 {
     return 2;
 }
 
-fn main() {
+pub fn main() {
     let v = doswitch_int();
     assert!(v == 1);
     let v = doswitch_chars();

--- a/src/test/cbmc/Transparent/transparent1.rs
+++ b/src/test/cbmc/Transparent/transparent1.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-fn main() {
+pub fn main() {
     let mut x: u32 = 4;
     let pointer0: std::ptr::NonNull<u32> = std::ptr::NonNull::new(&mut x).unwrap();
     let y = unsafe { *pointer0.as_ptr() };

--- a/src/test/cbmc/Transparent/transparent2.rs
+++ b/src/test/cbmc/Transparent/transparent2.rs
@@ -23,7 +23,7 @@ where
     }
 }
 
-fn main() {
+pub fn main() {
     let mut x: u32 = 4;
     let container = Container::new(&mut x);
     let _y = container.get();

--- a/src/test/cbmc/Transparent/transparent3.rs
+++ b/src/test/cbmc/Transparent/transparent3.rs
@@ -10,7 +10,7 @@ pub struct Container<T> {
     container: Pointer<T>,
 }
 
-fn main() {
+pub fn main() {
     let x: u32 = 4;
     let my_pointer = Pointer { pointer: &x };
     let my_container = Container { container: my_pointer };

--- a/src/test/cbmc/Transparent/transparent4.rs
+++ b/src/test/cbmc/Transparent/transparent4.rs
@@ -13,7 +13,7 @@ pub struct Container<T> {
     container: Pointer<T>,
 }
 
-fn main() {
+pub fn main() {
     let x: u32 = 4;
     let my_container = Container { container: Pointer { pointer: &x } };
 

--- a/src/test/cbmc/Unit/main.rs
+++ b/src/test/cbmc/Unit/main.rs
@@ -18,7 +18,7 @@ fn ret_unit() {
     ()
 }
 
-fn main() {
+pub fn main() {
     assert!(() == ());
     let u = ret_unit();
     assert!(u == ());

--- a/src/test/cbmc/UnsafeBlocks_Useless/main.rs
+++ b/src/test/cbmc/UnsafeBlocks_Useless/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let x = unsafe {
         assert!(true);
         5

--- a/src/test/cbmc/Vectors/fixme_main.rs
+++ b/src/test/cbmc/Vectors/fixme_main.rs
@@ -9,7 +9,7 @@ pub struct GuestRegionMmap {
 }
 
 // TODO: running this with --unwrap 2 causes CBMC to hang in propositional reduction.
-fn main() {
+pub fn main() {
     let r = GuestRegionMmap { guest_base: GuestAddress(0) };
     let mut regions: Vec<GuestRegionMmap> = vec![];
     regions.push(r);

--- a/src/test/cbmc/Vectors/vector_extend.rs
+++ b/src/test/cbmc/Vectors/vector_extend.rs
@@ -4,7 +4,7 @@
 // Check that we can handle set len on drop. If drop_in_place is not
 // called correctly, this will fail to actually extend the vector.
 
-fn main() {
+pub fn main() {
     let mut v: Vec<u32> = Vec::new();
     v.extend(42..=42);
     assert!(v[0] == 42);

--- a/src/test/cbmc/Vectors/vector_extend_fail.rs
+++ b/src/test/cbmc/Vectors/vector_extend_fail.rs
@@ -5,7 +5,7 @@
 
 // rmc-verify-fail
 
-fn main() {
+pub fn main() {
     let mut v: Vec<u32> = Vec::new();
     v.extend(42..=42);
     assert!(v[0] == 41); // Incorrect value

--- a/src/test/cbmc/Vectors/vector_extend_in_new.rs
+++ b/src/test/cbmc/Vectors/vector_extend_in_new.rs
@@ -7,7 +7,7 @@
 // There is an implicit loop, so we need an explicit unwind
 // cbmc-flags: --unwind 3 --unwinding-assertions
 
-fn main() {
+pub fn main() {
     let a: Vec<Vec<i32>> = vec![vec![0; 2]; 1];
     assert!(a.len() == 1);
 }

--- a/src/test/cbmc/VolatileIntrinsics/main.rs
+++ b/src/test/cbmc/VolatileIntrinsics/main.rs
@@ -114,7 +114,7 @@ fn test_copy_volatile_nonoverlapping() {
     }
 }
 
-fn main() {
+pub fn main() {
     test_volatile_store();
     test_copy_volatile();
     test_copy_volatile_nonoverlapping();

--- a/src/test/cbmc/Whitespace/main.rs
+++ b/src/test/cbmc/Whitespace/main.rs
@@ -10,7 +10,7 @@
 // [_RNvXs5_NtNtCs9Odk7Lrvgnw_4core3str7patternINtB5_19MultiCharEqSearcherNtB7_12IsWhitespaceENtB5_8Searcher4nextCs21hi0yVfW1J_4main.overflow.1] line 641 arithmetic overflow on unsigned - in *((unsigned int *)((unsigned char *)&var_5 + 8)) - 1114112: FAILURE
 // Tracking issue: https://github.com/model-checking/rmc/issues/307
 
-fn main() {
+pub fn main() {
     let mut iter = "A few words".split_whitespace();
     match iter.next() {
         None => assert!(false),

--- a/src/test/cbmc/i32-Unary-/main.rs
+++ b/src/test/cbmc/i32-Unary-/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let a: i32 = __nondet();
     if -100000 < a && a < 100000 {
         let b = -a;

--- a/src/test/expected/allocation/main.rs
+++ b/src/test/expected/allocation/main.rs
@@ -4,7 +4,7 @@ fn foo() -> Option<i32> {
     None
 }
 
-fn main() {
+pub fn main() {
     assert!(foo() == None);
     let x = foo();
     let y: Option<i32> = None;

--- a/src/test/expected/array/main.rs
+++ b/src/test/expected/array/main.rs
@@ -5,7 +5,7 @@ fn foo(x: [i32; 5]) -> [i32; 2] {
     [x[0], x[1]]
 }
 
-fn main() {
+pub fn main() {
     let x = [1, 2, 3, 4, 5];
     let y = foo(x);
     let z = 2;

--- a/src/test/expected/assert-eq/main.rs
+++ b/src/test/expected/assert-eq/main.rs
@@ -9,7 +9,7 @@
 ///     "library/std/src/macros.rs line 17 a panicking function core::panicking::panic_fmt is invoked: SUCCESS"
 ///     https://github.com/model-checking/rmc/issues/13
 
-fn main() {
+pub fn main() {
     let x = 1;
     let y = 2;
     assert_eq!(x + 1, y);

--- a/src/test/expected/binop/main.rs
+++ b/src/test/expected/binop/main.rs
@@ -55,7 +55,7 @@ fn ibxor_test(a: i32, b: i32, correct: i32, wrong: i32) {
     assert!(a ^ b == wrong);
 }
 
-fn main() {
+pub fn main() {
     iadd_test(1, 2, 3, 4);
     isub_test(3, 4, -1, 0);
     imul_test(5, 6, 30, 60);

--- a/src/test/expected/closure2/main.rs
+++ b/src/test/expected/closure2/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let x = 2;
     let f = |y| x + y;
     let z = f(100);

--- a/src/test/expected/comp/main.rs
+++ b/src/test/expected/comp/main.rs
@@ -14,7 +14,7 @@ fn eq2(a: i32, b: i32) {
 
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let a = __nondet();
     let b = __nondet();
     if a > -400 && a < 100 && b < 200 && b > 0 {

--- a/src/test/expected/copy/main.rs
+++ b/src/test/expected/copy/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use std::ptr;
 
-fn main() {
+pub fn main() {
     // TODO: make an overlapping set of locations, and check that it does the right thing for the overlapping region too.
     // https://github.com/model-checking/rmc/issues/12
     let expected_val = 42;

--- a/src/test/expected/dry-run/expected
+++ b/src/test/expected/dry-run/expected
@@ -1,4 +1,4 @@
-rmc-rustc -Z codegen-backend=gotoc -Z trim-diagnostic-paths=no -Z symbol-mangling-version=v0 -Z symbol_table_passes= --cfg=rmc
+rmc-rustc -Z codegen-backend=gotoc -Z trim-diagnostic-paths=no -Z symbol-mangling-version=v0 -Z symbol_table_passes= --crate-type=lib -Z human_readable_cgu_names --cfg=rmc
 symtab2gb
 goto-cc --function main
 cbmc --bounds-check --pointer-check --pointer-primitive-check --conversion-check --div-by-zero-check --float-overflow-check --nan-check --pointer-overflow-check --signed-overflow-check --undefined-shift-check --unsigned-overflow-check --unwinding-assertions --function main

--- a/src/test/expected/dry-run/main.rs
+++ b/src/test/expected/dry-run/main.rs
@@ -6,4 +6,4 @@
 // `--dry-run` causes RMC to print out commands instead of running them
 // In `expected` you will find substrings of these commands because the
 // concrete paths depend on your working directory.
-fn main() {}
+pub fn main() {}

--- a/src/test/expected/dynamic-error-trait/main.rs
+++ b/src/test/expected/dynamic-error-trait/main.rs
@@ -25,7 +25,7 @@ impl MemoryMapping {
     }
 }
 
-fn main() {
+pub fn main() {
     let mm = MemoryMapping::new(2);
     if mm.is_ok() {
         let mm = mm.expect("foo");

--- a/src/test/expected/dynamic-trait-static-dispatch/main.rs
+++ b/src/test/expected/dynamic-trait-static-dispatch/main.rs
@@ -20,7 +20,7 @@ impl Foo for Bar {
 }
 
 // this example works with static dispatch, so should work also while dynamic dispatch is not yet resolved
-fn main() {
+pub fn main() {
     let bar = Bar {};
     assert!(bar.a() == 3);
     assert!(bar.b() == 5);

--- a/src/test/expected/dynamic-trait/main.rs
+++ b/src/test/expected/dynamic-trait/main.rs
@@ -47,7 +47,7 @@ fn impl_area(a: impl Shape) -> u32 {
     a.area()
 }
 
-fn main() {
+pub fn main() {
     let rec = Rectangle { w: 10, h: 5 };
     assert!(rec.vol(3) == 150);
     assert!(impl_area(rec.clone()) == 50);

--- a/src/test/expected/enum/main.rs
+++ b/src/test/expected/enum/main.rs
@@ -13,7 +13,7 @@ fn b() -> Foo {
     Foo::B { x: 30, y: 60.0 }
 }
 
-fn main() {
+pub fn main() {
     let x = a();
     match x {
         Foo::A(x) => assert!(x == 10),

--- a/src/test/expected/float-nan/main.rs
+++ b/src/test/expected/float-nan/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let mut f: f32 = 2.0;
     while f != 0.0 {
         f -= 1.0;

--- a/src/test/expected/generics/main.rs
+++ b/src/test/expected/generics/main.rs
@@ -13,7 +13,7 @@ fn wrapped<T>(x: T) -> Foo<T> {
     Foo { data: ident(x), i: 0 }
 }
 
-fn main() {
+pub fn main() {
     let x = 10;
     let y = wrapped(x);
     let z = 20.0;

--- a/src/test/expected/iterator/main.rs
+++ b/src/test/expected/iterator/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let mut z = 1;
     for i in 1..4 {
         z *= i;

--- a/src/test/expected/niche/main.rs
+++ b/src/test/expected/niche/main.rs
@@ -15,7 +15,7 @@ fn get_some<'a>(a: &'a i8) -> T<'a> {
     Option2::Some((*a, a))
 }
 
-fn main() {
+pub fn main() {
     let x = get_opt();
     match x {
         Option2::None => {}

--- a/src/test/expected/niche2/main.rs
+++ b/src/test/expected/niche2/main.rs
@@ -17,7 +17,7 @@ fn get_b() -> Option<Foo> {
     Some(Foo::B([]))
 }
 
-fn main() {
+pub fn main() {
     match get_none() {
         None => {}
         Some(_) => assert!(false),

--- a/src/test/expected/nondet/main.rs
+++ b/src/test/expected/nondet/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let x: i32 = __nondet();
     if (x > -500 && x < 500) {
         // x * x - 2 * x + 1 == 4 -> x == -1 || x == 3

--- a/src/test/expected/references/main.rs
+++ b/src/test/expected/references/main.rs
@@ -11,7 +11,7 @@ impl Foo {
     }
 }
 
-fn main() {
+pub fn main() {
     let foo = Foo { a: 2, _b: 3.0 };
     let z = foo.get_a();
     assert!(z == 2);

--- a/src/test/expected/replace-hashmap/main.rs
+++ b/src/test/expected/replace-hashmap/main.rs
@@ -60,6 +60,6 @@ fn test_actual_map<K: Eq + Copy + Hash, V: Copy>(key: K, value: V) {
     assert!(b.is_none());
 }
 
-fn main() {
+pub fn main() {
     test_actual_map::<i32, i32>(1, 3);
 }

--- a/src/test/expected/replace-vec/main.rs
+++ b/src/test/expected/replace-vec/main.rs
@@ -59,7 +59,7 @@ fn test_actual_vec<T: PartialEq + Copy>(to_push: T, not_pushed: T) {
     assert!(p == Some(not_pushed));
 }
 
-fn main() {
+pub fn main() {
     test_actual_vec::<char>('a', 'b');
     test_actual_vec::<bool>(true, false);
     test_actual_vec::<i8>(1, 3);

--- a/src/test/expected/slice/main.rs
+++ b/src/test/expected/slice/main.rs
@@ -8,7 +8,7 @@ fn bar(x: &[i32; 5]) -> &[i32] {
     &x[1..4]
 }
 
-fn main() {
+pub fn main() {
     let x = [1, 2, 3, 4, 5];
     let y = foo(&x);
     let z = bar(&x);

--- a/src/test/expected/static-mutable-struct/main.rs
+++ b/src/test/expected/static-mutable-struct/main.rs
@@ -19,7 +19,7 @@ fn mutate_the_thing(nx: i64, ny: i32) {
     }
 }
 
-fn main() {
+pub fn main() {
     assert!(foo().x == 12);
     assert!(foo().y == 12);
     assert!(foo().x == 14);

--- a/src/test/expected/static-mutable/main.rs
+++ b/src/test/expected/static-mutable/main.rs
@@ -12,7 +12,7 @@ fn mutate_the_thing(new: i32) {
     }
 }
 
-fn main() {
+pub fn main() {
     assert!(10 == foo());
     assert!(12 == foo());
     mutate_the_thing(10);

--- a/src/test/expected/static/main.rs
+++ b/src/test/expected/static/main.rs
@@ -6,7 +6,7 @@ fn foo() -> i32 {
     X
 }
 
-fn main() {
+pub fn main() {
     assert!(10 == foo());
     assert!(12 == foo());
 }

--- a/src/test/expected/test1/main.rs
+++ b/src/test/expected/test1/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let mut a: i32 = 0;
     let mut i: i32 = 10;
     while i != 0 {

--- a/src/test/expected/test2/main.rs
+++ b/src/test/expected/test2/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let mut a: i32 = 4;
     let mut i = 0;
     while a != 1 {

--- a/src/test/expected/test3/main.rs
+++ b/src/test/expected/test3/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let mut a: f32 = 0.0;
     let mut i = 10;
 

--- a/src/test/expected/test4/main.rs
+++ b/src/test/expected/test4/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let mut a = 4;
     let mut i = 0;
     while a != 1 {

--- a/src/test/expected/test5/main.rs
+++ b/src/test/expected/test5/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     // should succeed
     assert!(div(4, 2) == 2);
     // should fail

--- a/src/test/expected/test6/main.rs
+++ b/src/test/expected/test6/main.rs
@@ -4,7 +4,7 @@ fn add2(a: i32, b: i32) -> f32 {
     add(a, b as f32)
 }
 
-fn main() {
+pub fn main() {
     // should succeed: 1 + 1 = 2
     assert!(add2(1, 1) == 2.0);
     // should fail: 2 + 1 = 3

--- a/src/test/expected/transmute/main.rs
+++ b/src/test/expected/transmute/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let bitpattern = unsafe { std::mem::transmute::<f32, u32>(1.0) };
     assert!(bitpattern == 0x3F800000);
 

--- a/src/test/expected/unwind_tip/main.rs
+++ b/src/test/expected/unwind_tip/main.rs
@@ -12,7 +12,7 @@ include!("../../rmc-prelude.rs");
 //
 // In this test, we check that RMC warns the user about unwinding failures
 // and makes a recommendation to fix the issue.
-fn main() {
+pub fn main() {
     let mut a: u32 = __nondet();
 
     if a < 1024 {

--- a/src/test/expected/vec/main.rs
+++ b/src/test/expected/vec/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let mut x: Vec<i32> = Vec::new();
     x.push(10);
     assert!(x[0] == 10);

--- a/src/test/expected/vecdq/main.rs
+++ b/src/test/expected/vecdq/main.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 
 include!("../../rmc-prelude.rs");
 
-fn main() {
+pub fn main() {
     let x = __nondet();
     let y = __nondet();
     let mut q: VecDeque<i32> = VecDeque::new();

--- a/src/test/firecracker/virtio-block-parse/main.rs
+++ b/src/test/firecracker/virtio-block-parse/main.rs
@@ -324,7 +324,7 @@ fn is_nonzero_pow2(x: u16) -> bool {
     unsafe { (x != 0) && ((x & (x - 1)) == 0) }
 }
 
-fn main() {
+pub fn main() {
     let mem = GuestMemoryMmap {};
     let queue_size: u16 = __nondet();
     if !is_nonzero_pow2(queue_size) {

--- a/src/test/prusti/100_doors.rs
+++ b/src/test/prusti/100_doors.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let mut door_open = [false; 10];
     for pass in 1..11 {
         let mut door = pass;

--- a/src/test/prusti/Ackermann_function.rs
+++ b/src/test/prusti/Ackermann_function.rs
@@ -8,7 +8,7 @@ fn ack(m: u64, n: u64) -> u64 {
     }
 }
 
-fn main() {
+pub fn main() {
     let a = ack(2, 4);
     assert!(a == 11);
 }

--- a/src/test/prusti/Binary_search.rs
+++ b/src/test/prusti/Binary_search.rs
@@ -49,7 +49,7 @@ fn get() -> [i32; 11] {
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 }
 
-fn main() {
+pub fn main() {
     let x = get();
     let y = __nondet();
     if 1 <= y && y <= 11 {

--- a/src/test/prusti/Fibonacci_sequence.rs
+++ b/src/test/prusti/Fibonacci_sequence.rs
@@ -21,7 +21,7 @@ impl Iterator for Fib {
     }
 }
 
-fn main() {
+pub fn main() {
     let mut fib = Fib::new();
     assert!(fib.nth(10).unwrap() == 55);
 }

--- a/src/test/prusti/Heapsort.rs
+++ b/src/test/prusti/Heapsort.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-fn main() {
+pub fn main() {
     let mut v = [3, 0, 1, 2];
     create_heap(&mut v, |x, y| x < y);
     assert!(v == [3, 2, 1, 0]);

--- a/src/test/prusti/Selection_sort.rs
+++ b/src/test/prusti/Selection_sort.rs
@@ -18,7 +18,7 @@ fn selection_sort(array: &mut [i32]) {
     }
 }
 
-fn main() {
+pub fn main() {
     let mut array = [9, 4, 8, 3];
     selection_sort(&mut array);
     assert!(array == [3, 4, 8, 9]);

--- a/src/test/prusti/Tower_of_Hanoi.rs
+++ b/src/test/prusti/Tower_of_Hanoi.rs
@@ -7,6 +7,6 @@ fn move_(n: i32, from: i32, to: i32, via: i32) {
     }
 }
 
-fn main() {
+pub fn main() {
     move_(4, 1, 2, 3);
 }

--- a/src/test/prusti/borrow_first.rs
+++ b/src/test/prusti/borrow_first.rs
@@ -14,7 +14,7 @@ fn foo(vec: &mut Vec<i32>) -> &i32 {
     &vec[last]
 }
 
-fn main() {
+pub fn main() {
     let mut v = vec![-1, 2, 3];
     let r = foo(&mut v);
     assert!(*r > 0);

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2442,7 +2442,10 @@ impl<'test> TestCx<'test> {
                 "codegen-backend=gotoc",
                 "-Z",
                 "trim-diagnostic-paths=no",
+                "-Z",
+                "human_readable_cgu_names",
                 "--cfg=rmc",
+                "--crate-type=lib",
                 "--out-dir",
             ])
             .arg(self.output_base_dir())

--- a/src/tools/dashboard/src/util.rs
+++ b/src/tools/dashboard/src/util.rs
@@ -193,7 +193,7 @@ pub fn add_codegen_job(litani: &mut Litani, test_props: &TestProps) {
             "build/tmp",
             "-Z",
             "human_readable_cgu_names",
-            "-crate-type=lib",
+            "--crate-type=lib",
         ])
         .arg(&test_props.path);
     // TODO: replace `test` with `codegen` when Litani adds support for custom

--- a/src/tools/dashboard/src/util.rs
+++ b/src/tools/dashboard/src/util.rs
@@ -185,7 +185,16 @@ pub fn add_codegen_job(litani: &mut Litani, test_props: &TestProps) {
     let mut rmc_rustc = Command::new("rmc-rustc");
     rmc_rustc
         .args(&test_props.rustc_args)
-        .args(["-Z", "codegen-backend=gotoc", "--cfg=rmc", "--out-dir", "build/tmp"])
+        .args([
+            "-Z",
+            "codegen-backend=gotoc",
+            "--cfg=rmc",
+            "--out-dir",
+            "build/tmp",
+            "-Z",
+            "human_readable_cgu_names",
+            "-crate-type=lib",
+        ])
         .arg(&test_props.path);
     // TODO: replace `test` with `codegen` when Litani adds support for custom
     // stages (see https://github.com/model-checking/rmc/issues/391).


### PR DESCRIPTION
This changes the compilation to use crate type lib instead of binary when
we are running rmc on a single .rs file. This allow us to use
any public function as a verification target.

We have also changed the tests to use pub main so it is exported and it
can be used as the entry point of the proof.

Fix cargo-rmc and the current testcase to support library build.


### Description of changes: 

1- RMC users will need to ensure their main function is public in order to use them as verification harness. Note that this not affect proof harness with attribute `#[no_mangle]` since this attribute actually exports the function.
2- Users can now invoke rmc with the `--function` attribute. They can select any public function as their starting point. Note that the function still has to have the `#[no_mangle]` attribute.

### Resolved issues:

Resolves #169 


### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
