### PR TITLE
optimize checkouts, and time and clean up scripts used in CI

### DIFF
--- a/.github/workflows/rmc.yml
+++ b/.github/workflows/rmc.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: Checkout RMC
         uses: actions/checkout@v2
+        # https://github.com/rust-lang/rust/issues/87890
+        # A non-shallow clone is unfortunately necessary, as bootstrap.py searches commit history
+        # to find the correct LLVM artifacts to download. (0 below indicates non-shallow)
         with:
           fetch-depth: 0
 
@@ -29,10 +32,6 @@ jobs:
       - name: Install Rust toolchain
         run: ./scripts/setup/install_rustup.sh
 
-      - name: Install dashboard dependencies
-        if: ${{ matrix.os == 'ubuntu-20.04' && github.event_name == 'push' && startsWith('refs/heads/main', github.ref) }}
-        run: ./scripts/setup/install_dashboard_deps.sh
-
       - name: Set config.toml file
         run: |
           ./configure \
@@ -42,16 +41,23 @@ jobs:
             --set=rust.deny-warnings=false
 
       - name: Update submodules
-        run: git submodule update --init
-
-      - name: Export backtrace flags
-        run: export RUST_BACKTRACE=1
+        run: |
+          # Since we download cached artifacts, we can skip checking out llvm locally in CI
+          git config submodule."src/llvm-project".update=none
+          git submodule update --init --depth 1
 
       - name: Build RMC
-        run: ./x.py build -i --stage 1 library/std
+        run: |
+          export RUST_BACKTRACE=1
+          ./x.py build -i --stage 1 library/std
 
       - name: Execute RMC regression
         run: ./scripts/rmc-regression.sh
+
+
+      - name: Install dashboard dependencies
+        if: ${{ matrix.os == 'ubuntu-20.04' && github.event_name == 'push' && startsWith('refs/heads/main', github.ref) }}
+        run: ./scripts/setup/install_dashboard_deps.sh
 
       - name: Generate RMC dashboard
         if: ${{ matrix.os == 'ubuntu-20.04' && github.event_name == 'push' && startsWith('refs/heads/main', github.ref) }}

--- a/.github/workflows/rmc.yml
+++ b/.github/workflows/rmc.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Update submodules
         run: |
           # Since we download cached artifacts, we can skip checking out llvm locally in CI
-          git config submodule."src/llvm-project".update=none
+          git config submodule."src/llvm-project".update none
           git submodule update --init --depth 1
 
       - name: Build RMC

--- a/scripts/codegen-firecracker.sh
+++ b/scripts/codegen-firecracker.sh
@@ -2,10 +2,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
+set -eu
+
 # Test for platform
-platform=`uname -sp`
-if [[ $platform != "Linux x86_64" ]]; then
-  echo "Codegen script only works on Linux x86 platform"
+PLATFORM=$(uname -sp)
+if [[ $PLATFORM != "Linux x86_64" ]]; then
+  echo
+  echo "Firecracker codegen regression only works on Linux x86 platform, skipping..."
+  echo
   exit 0
 fi
 
@@ -13,7 +17,14 @@ fi
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 RMC_DIR=$SCRIPT_DIR/..
 
+echo
+echo "Starting Firecracker codegen regression..."
+echo
+
 # At the moment, we only test codegen for the virtio module
-git submodule update --init --recursive
 cd $RMC_DIR/firecracker/src/devices/src/virtio/
 RUST_BACKTRACE=1 RUSTFLAGS="-Z trim-diagnostic-paths=no -Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo build --target x86_64-unknown-linux-gnu
+
+echo
+echo "Finished Firefracker codegen regression successfully..."
+echo

--- a/scripts/rmc-regression.sh
+++ b/scripts/rmc-regression.sh
@@ -26,10 +26,10 @@ check-cbmc-viewer-version.py --major 2 --minor 5
 ./x.py test -i --stage 0 compiler/cbmc
 
 # Check codegen for the standard library
-$SCRIPT_DIR/std-lib-regression.sh
+time "$SCRIPT_DIR"/std-lib-regression.sh
 
 # Check codegen of firecracker
-$SCRIPT_DIR/codegen-firecracker.sh
+time "$SCRIPT_DIR"/codegen-firecracker.sh
 
 # Check that we can use RMC on crates with a diamond dependency graph,
 # with two different versions of the same crate.
@@ -39,10 +39,10 @@ $SCRIPT_DIR/codegen-firecracker.sh
 #   main             dependency3
 #        \           / v0.1.1
 #         dependency2
-./src/test/rmc-dependency-test/diamond-dependency/run-dependency-test.sh
+time "$RMC_DIR"/src/test/rmc-dependency-test/diamond-dependency/run-dependency-test.sh
 
 # Check that we don't have type mismatches across different crates
-./src/test/rmc-multicrate/type-mismatch/run-mismatch-test.sh
+time "$RMC_DIR"/src/test/rmc-multicrate/type-mismatch/run-mismatch-test.sh
 
 echo
 echo "All RMC regression tests completed successfully."

--- a/scripts/std-lib-regression.sh
+++ b/scripts/std-lib-regression.sh
@@ -2,10 +2,15 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
+# Deliberately not enabling this, since we expect a failure currently and are failing based on 'grep' later
+#set -eu
+
 # Test for platform
-platform=`uname -sp`
-if [[ $platform != "Linux x86_64" ]]; then
-  echo "Codegen script only works on Linux x86 platform"
+PLATFORM=$(uname -sp)
+if [[ $PLATFORM != "Linux x86_64" ]]; then
+  echo
+  echo "Std-Lib codegen regression only works on Linux x86 platform, skipping..."
+  echo
   exit 0
 fi
 
@@ -13,9 +18,10 @@ fi
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 RMC_DIR=$SCRIPT_DIR/..
 
-# Log output
-STD_LIB_LOG="/tmp/StdLibTest/log.txt"
-echo "Starting RMC codegen for the Rust standard library"
+echo
+echo "Starting RMC codegen for the Rust standard library..."
+echo
+
 cd /tmp
 if [ -d StdLibTest ]; then rm -rf StdLibTest; fi
 cargo new StdLibTest
@@ -27,8 +33,10 @@ if ! rustup toolchain list | grep -q nightly; then
   rustup toolchain install nightly
 fi
 
+STD_LIB_LOG="/tmp/StdLibTest/log.txt"
+
 echo "Starting cargo build with RMC"
-RUSTFLAGS="-Z trim-diagnostic-paths=no -Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo +nightly build -Z build-std --target x86_64-unknown-linux-gnu &> $STD_LIB_LOG
+RUSTFLAGS="-Z trim-diagnostic-paths=no -Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo +nightly build -Z build-std --target x86_64-unknown-linux-gnu 2>&1 | tee $STD_LIB_LOG
 
 # For now, we expect a linker error, but no modules should fail with a compiler
 # panic. 
@@ -40,9 +48,12 @@ RUSTFLAGS="-Z trim-diagnostic-paths=no -Z codegen-backend=gotoc --cfg=rmc" RUSTC
 # TODO: this check is insufficient if the failure is before codegen
 # https://github.com/model-checking/rmc/issues/375
 if grep -q "error: internal compiler error: unexpected panic" $STD_LIB_LOG; then
+  echo
   echo "Panic on building standard library"
-  cat $STD_LIB_LOG
+  echo
   exit 1
-else 
-echo "Successful RMC codegen for the Rust standard library"
 fi
+
+echo
+echo "Finished RMC codegen for the Rust standard library successfully..."
+echo

--- a/src/test/rmc-dependency-test/diamond-dependency/run-dependency-test.sh
+++ b/src/test/rmc-dependency-test/diamond-dependency/run-dependency-test.sh
@@ -2,6 +2,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
+# We're explicitly checking output rather than failing if the test fails
+#set -eu
+
+echo
+echo "Starting Diamond Dependency Test..."
+echo
+
 # Compile crates with RMC backend
 cd $(dirname $0)
 rm -rf build
@@ -18,12 +25,14 @@ goto-instrument --drop-unused-functions a.out b.out
 # Run the solver
 RESULT="/tmp/dependency_test_result.txt"
 cbmc b.out &> $RESULT
-if grep -q "VERIFICATION SUCCESSFUL" $RESULT; then
+if ! grep -q "VERIFICATION SUCCESSFUL" $RESULT; then
   cat $RESULT
-  echo "Successful dependency test"
-  exit 0
-else 
-  cat $RESULT
+  echo
   echo "Failed dependency test"
+  echo
   exit 1
 fi
+
+echo
+echo "Finished Diamond Dependency Test successfully..."
+echo

--- a/src/test/rmc-multicrate/type-mismatch/run-mismatch-test.sh
+++ b/src/test/rmc-multicrate/type-mismatch/run-mismatch-test.sh
@@ -2,6 +2,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
+# We're explicitly checking output rather than failing if the test fails
+#set -eu
+
+echo
+echo "Starting type mismatch test..."
+echo
+
 # Compile crates with RMC backend
 cd $(dirname $0)
 rm -rf build
@@ -19,12 +26,14 @@ goto-instrument --drop-unused-functions a.out b.out
 # Run the solver
 RESULT="/tmp/dependency_test_result.txt"
 cbmc b.out &> $RESULT
-if grep -q "VERIFICATION SUCCESSFUL" $RESULT; then
+if ! grep -q "VERIFICATION SUCCESSFUL" $RESULT; then
   cat $RESULT
-  echo "Successful dependency test"
-  exit 0
-else 
-  cat $RESULT
-  echo "Failed dependency test"
+  echo
+  echo "Failed type mismatch test"
+  echo
   exit 1
 fi
+
+echo
+echo "Finished type mismatch test successfully..."
+echo


### PR DESCRIPTION
### Description of changes: 

1. We can't shallow checkout our repo, because bootstrap expects commit history, but I added a comment because upstream rust seems to consider this a bug?
2. Don't checkout LLVM in CI, saves a good amount of download time.
3. Shallow checkouts of other submodules. Seems harmless... may save some time?
4. Avoid (seemingly unnecessary?) submodule update in the firecracker regression
5. I got mad at the regression testing scripts and tried to clean them up
6. Among other things, I discovered we weren't failing CI if the firecracker build failed. Resolved that with `set -eu`
7. Added timing and clear "start" "stop" log messages for various sub-components of rmc-regression

Let's see if any CI times are noticably shorter in this PR...

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [n/a] Methods or procedures are documented
- [n/a] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
