### PR TITLE
Skip repo updates in CI

### DIFF
--- a/scripts/codegen-firecracker.sh
+++ b/scripts/codegen-firecracker.sh
@@ -26,5 +26,5 @@ cd $RMC_DIR/firecracker/src/devices/src/virtio/
 RUST_BACKTRACE=1 RUSTFLAGS="-Z trim-diagnostic-paths=no -Z codegen-backend=gotoc --cfg=rmc" RUSTC=rmc-rustc cargo build --target x86_64-unknown-linux-gnu
 
 echo
-echo "Finished Firefracker codegen regression successfully..."
+echo "Finished Firecracker codegen regression successfully..."
 echo

--- a/scripts/setup/macos-10.15/install_deps.sh
+++ b/scripts/setup/macos-10.15/install_deps.sh
@@ -4,8 +4,12 @@
 
 set -eux
 
-# Update tools in macOS 10.15 via `brew`
-brew update
+# Github promises weekly build image updates, so we can skip the update step and
+# worst case we should only be 1-2 weeks behind upstream brew.
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
+#brew update
+
+# Install dependencies via `brew`
 brew install ctags
 
 # Add Python package dependencies

--- a/scripts/setup/ubuntu/install_deps.sh
+++ b/scripts/setup/ubuntu/install_deps.sh
@@ -34,18 +34,17 @@ declare -A VERSION_DEPS
 VERSION_DEPS["20.04"]="python-is-python3"
 VERSION_DEPS["18.04"]=""
 
-set -x
-
-sudo apt-get --yes update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes "${DEPS[@]}"
-
 UBUNTU_VERSION=$(lsb_release -rs)
 OTHER_DEPS="${VERSION_DEPS[${UBUNTU_VERSION}]:-""}"
-if [[ ! -z ${OTHER_DEPS} ]]
-then
-    # This package was added on ubuntu 20.04.
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes "${OTHER_DEPS[@]}"
-fi
+
+set -x
+
+# Github promises weekly build image updates, so we can skip the update step and
+# worst case we should only be 1-2 weeks behind upstream repos.
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
+#sudo apt-get --yes update
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes "${DEPS[@]}" "${OTHER_DEPS[@]}"
 
 # Add Python package dependencies
 PYTHON_DEPS=(


### PR DESCRIPTION
### Description of changes: 

This is a minor tweak:

1. Skip repo updates in CI. Github updates images every week, so worst case we're 2 weeks behind. Saves between 11 and 90 seconds from each build.
2. Fix typo
3. Install all apt dependencies at once, rather than with two separate calls.

### Call-outs:

We're now looking at:

* 25-30 min builds
* 7-10 min regressions
* 20 min dashboard builds, but only for the main branch

Seems the only thing left is the "hard work" of figuring out how to make the rustc/rmc builds faster.

### Testing:

* How is this change tested? CI

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [n/a] Methods or procedures are documented
- [n/a] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
