### PR TITLE
Fix rmc codegen to check for no-codegen option

### DIFF
--- a/compiler/rustc_codegen_rmc/src/compiler_interface.rs
+++ b/compiler/rustc_codegen_rmc/src/compiler_interface.rs
@@ -147,7 +147,7 @@ impl CodegenBackend for GotocCodegenBackend {
 
     fn link(
         &self,
-        _sess: &Session,
+        sess: &Session,
         codegen_results: Box<dyn Any>,
         outputs: &OutputFilenames,
     ) -> Result<(), ErrorReported> {
@@ -157,18 +157,21 @@ impl CodegenBackend for GotocCodegenBackend {
             .downcast::<GotocCodegenResult>()
             .expect("in link: codegen_results is not a GotocCodegenResult");
 
-        // "path.o"
-        let base_filename = outputs.path(OutputType::Object);
+        // No output should be generated if user selected no_codegen.
+        if !sess.opts.debugging_opts.no_codegen && sess.opts.output_types.should_codegen() {
+            // "path.o"
+            let base_filename = outputs.path(OutputType::Object);
 
-        let symtab_filename = base_filename.with_extension("symtab.json");
-        debug!("output to {:?}", symtab_filename);
-        let mut out_file = ::std::fs::File::create(&symtab_filename).unwrap();
-        write!(out_file, "{}", result.symtab.to_irep().to_json().pretty().to_string()).unwrap();
+            let symtab_filename = base_filename.with_extension("symtab.json");
+            debug!("output to {:?}", symtab_filename);
+            let mut out_file = ::std::fs::File::create(&symtab_filename).unwrap();
+            write!(out_file, "{}", result.symtab.to_irep().to_json().pretty().to_string()).unwrap();
 
-        let type_map_filename = base_filename.with_extension("type_map.json");
-        debug!("type_map to {:?}", type_map_filename);
-        let mut out_file = ::std::fs::File::create(&type_map_filename).unwrap();
-        write!(out_file, "{}", result.type_map.to_json().pretty().to_string()).unwrap();
+            let type_map_filename = base_filename.with_extension("type_map.json");
+            debug!("type_map to {:?}", type_map_filename);
+            let mut out_file = ::std::fs::File::create(&type_map_filename).unwrap();
+            write!(out_file, "{}", result.type_map.to_json().pretty().to_string()).unwrap();
+        }
 
         Ok(())
     }


### PR DESCRIPTION
### Description of changes: 

RMC code generation was creating artifacts even if rustc was run with
-Z no-codegen. I changed the codegen to check for this option before
writing the json files.

This issue was uncovered by my change to move the rmc flags to
rmc-rustc. This script is used during compiletest. In the check stage,
the test runs rustc with --no-codegen.

### Call-outs:

This code will be tested once we merge #597 PR.

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
