### PR TITLE
Break min/max_int into their own util functions, and have them return BigInt to avoid any arbitrary width constraints

### DIFF
--- a/compiler/cbmc/src/utils.rs
+++ b/compiler/cbmc/src/utils.rs
@@ -45,23 +45,6 @@ macro_rules! btree_string_map {
     }}
 }
 
-#[test]
-fn test_max_int() {
-    // Unsigned
-    assert_eq!(max_int(8, false), BigInt::from(u8::MAX));
-    assert_eq!(max_int(16, false), BigInt::from(u16::MAX));
-    assert_eq!(max_int(32, false), BigInt::from(u32::MAX));
-    assert_eq!(max_int(64, false), BigInt::from(u64::MAX));
-    assert_eq!(max_int(128, false), BigInt::from(u128::MAX));
-
-    //Signed
-    assert_eq!(max_int(8, true), BigInt::from(i8::MAX));
-    assert_eq!(max_int(16, true), BigInt::from(i16::MAX));
-    assert_eq!(max_int(32, true), BigInt::from(i32::MAX));
-    assert_eq!(max_int(64, true), BigInt::from(i64::MAX));
-    assert_eq!(max_int(128, true), BigInt::from(i128::MAX));
-}
-
 pub fn max_int(width: u64, signed: bool) -> BigInt {
     let mut bi = BigInt::from(0);
     if signed {
@@ -72,22 +55,6 @@ pub fn max_int(width: u64, signed: bool) -> BigInt {
     bi - 1
 }
 
-#[test]
-fn test_min_int() {
-    // Unsigned
-    assert_eq!(min_int(8, false), BigInt::from(u8::MIN));
-    assert_eq!(min_int(16, false), BigInt::from(u16::MIN));
-    assert_eq!(min_int(32, false), BigInt::from(u32::MIN));
-    assert_eq!(min_int(64, false), BigInt::from(u64::MIN));
-    assert_eq!(min_int(128, false), BigInt::from(u128::MIN));
-
-    //Signed
-    assert_eq!(min_int(8, true), BigInt::from(i8::MIN));
-    assert_eq!(min_int(16, true), BigInt::from(i16::MIN));
-    assert_eq!(min_int(32, true), BigInt::from(i32::MIN));
-    assert_eq!(min_int(64, true), BigInt::from(i64::MIN));
-    assert_eq!(min_int(128, true), BigInt::from(i128::MIN));
-}
 pub fn min_int(width: u64, signed: bool) -> BigInt {
     if signed {
         let max = max_int(width, true);
@@ -95,5 +62,44 @@ pub fn min_int(width: u64, signed: bool) -> BigInt {
         min
     } else {
         BigInt::from(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::{max_int, min_int};
+    use num::BigInt;
+    #[test]
+    fn test_max_int() {
+        // Unsigned
+        assert_eq!(max_int(8, false), BigInt::from(u8::MAX));
+        assert_eq!(max_int(16, false), BigInt::from(u16::MAX));
+        assert_eq!(max_int(32, false), BigInt::from(u32::MAX));
+        assert_eq!(max_int(64, false), BigInt::from(u64::MAX));
+        assert_eq!(max_int(128, false), BigInt::from(u128::MAX));
+
+        //Signed
+        assert_eq!(max_int(8, true), BigInt::from(i8::MAX));
+        assert_eq!(max_int(16, true), BigInt::from(i16::MAX));
+        assert_eq!(max_int(32, true), BigInt::from(i32::MAX));
+        assert_eq!(max_int(64, true), BigInt::from(i64::MAX));
+        assert_eq!(max_int(128, true), BigInt::from(i128::MAX));
+    }
+
+    #[test]
+    fn test_min_int() {
+        // Unsigned
+        assert_eq!(min_int(8, false), BigInt::from(u8::MIN));
+        assert_eq!(min_int(16, false), BigInt::from(u16::MIN));
+        assert_eq!(min_int(32, false), BigInt::from(u32::MIN));
+        assert_eq!(min_int(64, false), BigInt::from(u64::MIN));
+        assert_eq!(min_int(128, false), BigInt::from(u128::MIN));
+
+        //Signed
+        assert_eq!(min_int(8, true), BigInt::from(i8::MIN));
+        assert_eq!(min_int(16, true), BigInt::from(i16::MIN));
+        assert_eq!(min_int(32, true), BigInt::from(i32::MIN));
+        assert_eq!(min_int(64, true), BigInt::from(i64::MIN));
+        assert_eq!(min_int(128, true), BigInt::from(i128::MIN));
     }
 }

--- a/compiler/cbmc/src/utils.rs
+++ b/compiler/cbmc/src/utils.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Useful utilities for CBMC
 
+use num::bigint::BigInt;
+
 /// RMC bug report URL, for asserts/errors
 pub const BUG_REPORT_URL: &str =
     "https://github.com/model-checking/rmc/issues/new?template=bug_report.md";
@@ -41,4 +43,57 @@ macro_rules! btree_string_map {
         use std::iter::FromIterator;
         (BTreeMap::from_iter(vec![$($x),*].into_iter().map(|(k,v)|(k.to_string(),v))))
     }}
+}
+
+#[test]
+fn test_max_int() {
+    // Unsigned
+    assert_eq!(max_int(8, false), BigInt::from(u8::MAX));
+    assert_eq!(max_int(16, false), BigInt::from(u16::MAX));
+    assert_eq!(max_int(32, false), BigInt::from(u32::MAX));
+    assert_eq!(max_int(64, false), BigInt::from(u64::MAX));
+    assert_eq!(max_int(128, false), BigInt::from(u128::MAX));
+
+    //Signed
+    assert_eq!(max_int(8, true), BigInt::from(i8::MAX));
+    assert_eq!(max_int(16, true), BigInt::from(i16::MAX));
+    assert_eq!(max_int(32, true), BigInt::from(i32::MAX));
+    assert_eq!(max_int(64, true), BigInt::from(i64::MAX));
+    assert_eq!(max_int(128, true), BigInt::from(i128::MAX));
+}
+
+pub fn max_int(width: u64, signed: bool) -> BigInt {
+    let mut bi = BigInt::from(0);
+    if signed {
+        bi.set_bit(width - 1, true);
+    } else {
+        bi.set_bit(width, true);
+    }
+    bi - 1
+}
+
+#[test]
+fn test_min_int() {
+    // Unsigned
+    assert_eq!(min_int(8, false), BigInt::from(u8::MIN));
+    assert_eq!(min_int(16, false), BigInt::from(u16::MIN));
+    assert_eq!(min_int(32, false), BigInt::from(u32::MIN));
+    assert_eq!(min_int(64, false), BigInt::from(u64::MIN));
+    assert_eq!(min_int(128, false), BigInt::from(u128::MIN));
+
+    //Signed
+    assert_eq!(min_int(8, true), BigInt::from(i8::MIN));
+    assert_eq!(min_int(16, true), BigInt::from(i16::MIN));
+    assert_eq!(min_int(32, true), BigInt::from(i32::MIN));
+    assert_eq!(min_int(64, true), BigInt::from(i64::MIN));
+    assert_eq!(min_int(128, true), BigInt::from(i128::MIN));
+}
+pub fn min_int(width: u64, signed: bool) -> BigInt {
+    if signed {
+        let max = max_int(width, true);
+        let min = -max - 1;
+        min
+    } else {
+        BigInt::from(0)
+    }
 }


### PR DESCRIPTION
### Description of changes: 

Currently, `min_int` and `max_int` work on 128 bit representations, which means we can't calculate them for larger sizes. This was causing unnecessary codegen failures. Instead, use BigInt so we have no width constraints (until Rust runs out of memory, anyway)

### Resolved issues:

Resolves #414 

### Call-outs:

* Moved the code into utils, where it belongs

### Testing:

* How is this change tested? Additional unit tests

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
