### PR TITLE
Enable codegen for `core::slice::<impl [T]>::split_first`

### DIFF
--- a/compiler/rustc_codegen_rmc/src/codegen/function.rs
+++ b/compiler/rustc_codegen_rmc/src/codegen/function.rs
@@ -19,8 +19,6 @@ impl<'tcx> GotocCtx<'tcx> {
             name if name.ends_with("__getit") => true,
             // https://github.com/model-checking/rmc/issues/205
             "panic::Location::<'a>::caller" => true,
-            // https://github.com/model-checking/rmc/issues/207
-            "core::slice::<impl [T]>::split_first" => true,
             // https://github.com/model-checking/rmc/issues/281
             name if name.starts_with("bridge::client") => true,
             // https://github.com/model-checking/rmc/issues/282


### PR DESCRIPTION
### Description of changes: 

Removes `core::slice::<impl [T]>::split_first` from the list of functions to be skipped during codegen. This can be done since `ProjectionElem::Subslice` was partially implemented (for slices) some time ago.

### Resolved issues:

Resolves #207 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Running existing regression.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
