### PR TITLE
Fix panic due to wrong intrinsic arguments (#533)

### DIFF
--- a/compiler/rustc_codegen_rmc/src/codegen/statement.rs
+++ b/compiler/rustc_codegen_rmc/src/codegen/statement.rs
@@ -271,18 +271,14 @@ impl<'tcx> GotocCtx<'tcx> {
         // Therefore, we have to project out the corresponding fields when we detect
         // an invocation of a closure.
         //
-        // Note: In some cases, the enviroment struct has type FnDef, so we skip it in
+        // Note: In some cases, the environment struct has type FnDef, so we skip it in
         // ignore_var_ty. So the tuple is always the last arg, but it might be in the
         // first or the second position.
+        // Note 2: For empty closures, the only argument needed is the environment struct.
         if fargs.len() > 0 {
             let tupe = fargs.remove(fargs.len() - 1);
             let tupled_args: Vec<Type> = match self.operand_ty(last_mir_arg.unwrap()).kind() {
                 ty::Tuple(tupled_args) => {
-                    // The tuple needs to be added back for type checking even if empty
-                    if tupled_args.is_empty() {
-                        fargs.push(tupe);
-                        return;
-                    }
                     tupled_args.iter().map(|s| self.codegen_ty(s.expect_ty())).collect()
                 }
                 _ => unreachable!("Argument to function with Abi::RustCall is not a tuple"),
@@ -290,11 +286,9 @@ impl<'tcx> GotocCtx<'tcx> {
 
             // Unwrap as needed
             for (i, t) in tupled_args.iter().enumerate() {
-                if !t.is_unit() {
-                    // Access the tupled parameters through the `member` operation
-                    let index_param = tupe.clone().member(&i.to_string(), &self.symbol_table);
-                    fargs.push(index_param);
-                }
+                // Access the tupled parameters through the `member` operation
+                let index_param = tupe.clone().member(&i.to_string(), &self.symbol_table);
+                fargs.push(index_param);
             }
         }
     }

--- a/compiler/rustc_codegen_rmc/src/codegen/typ.rs
+++ b/compiler/rustc_codegen_rmc/src/codegen/typ.rs
@@ -1238,7 +1238,6 @@ impl<'tcx> GotocCtx<'tcx> {
     /// Whether a variable of type ty should be ignored as a parameter to a function
     pub fn ignore_var_ty(&self, ty: Ty<'tcx>) -> bool {
         match ty.kind() {
-            ty::Tuple(substs) if substs.is_empty() => true,
             ty::FnDef(_, _) => true,
             _ => false,
         }

--- a/src/test/rmc/Iterator/try_fold.rs
+++ b/src/test/rmc/Iterator/try_fold.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// cbmc-flags: --unwind 20
+// cbmc-flags: --unwind 3
 
 pub fn main() {
     let arr = [(1, 2), (2, 2)];

--- a/src/test/rmc/Iterator/try_fold.rs
+++ b/src/test/rmc/Iterator/try_fold.rs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// cbmc-flags: --unwind 20
+
+pub fn main() {
+    let arr = [(1, 2), (2, 2)];
+    let result = arr.iter().try_fold((), |acc, &i| Some(()));
+    assert_ne!(result, None, "This should succeed");
+}


### PR DESCRIPTION
During codegen of function calls, we were ignoring argument of Unit
type. This was causing a failure due to missing arguments when an
intrinsic or closure was being called with an '()' as an argument.

This change modifies how we deal with Unit types during function
definition and function call.


### Description of changes: 

Describe RMC's current behavior and how your code changes that behavior. If there are no issues this PR is resolving, explain why this change is necessary.

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
