### PR TITLE
Use interned strings to reduce memory usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom 0.2.0",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +492,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "cstr",
+ "lazy_static",
  "libc",
  "measureme 9.1.2",
  "num",
@@ -505,6 +517,7 @@ dependencies = [
  "serde_test",
  "smallvec",
  "snap",
+ "string-interner",
  "tracing",
  "vector-map",
 ]
@@ -1599,6 +1612,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "362385356d610bd1e5a408ddf8d022041774b683f345a1d2cfcb4f60f8ae2db5"
 dependencies = [
+ "ahash",
  "compiler_builtins",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
@@ -5197,6 +5211,17 @@ dependencies = [
  "libc",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
+]
+
+[[package]]
+name = "string-interner"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e2531d8525b29b514d25e275a43581320d587b86db302b9a7e464bac579648"
+dependencies = [
+ "cfg-if 1.0.0",
+ "hashbrown",
+ "serde",
 ]
 
 [[package]]

--- a/compiler/cbmc/Cargo.toml
+++ b/compiler/cbmc/Cargo.toml
@@ -12,12 +12,14 @@ doctest = false
 
 [dependencies]
 bitflags = "1.0"
+lazy_static = "1.4.0"
 cstr = "0.2"
 libc = "0.2"
 measureme = "9.1.0"
 num = "0.4.0"
 serde = {version = "1", features = ["derive"]}
 snap = "1"
+string-interner = "0.14.0"
 tracing = "0.1"
 vector-map = "1.0.1"
 rustc_middle = { path = "../rustc_middle" }

--- a/compiler/cbmc/src/cbmc_string.rs
+++ b/compiler/cbmc/src/cbmc_string.rs
@@ -1,0 +1,118 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use lazy_static::lazy_static;
+use std::sync::Mutex;
+use string_interner::symbol::SymbolU32;
+use string_interner::StringInterner;
+
+/// This class implements an interner for Strings.
+/// CBMC objects to have a large number of strings which refer to names: symbols, files, etc.
+/// These tend to be reused many times, which causes signifcant memory usage.
+/// If we intern the strings, each unique string is only allocated once, saving memory.
+/// On the stdlib test, interning led to a 15% savings in peak memory usage.
+/// Since they're referred to by index, InternedStrings become `Copy`, which simplifies APIs.
+/// The downside is that interned strings live the lifetime of the execution.
+/// So you should only intern strings that will be used in long-lived data-structures, not temps.
+///
+/// We use a single global string interner, which is protected by a Mutex (i.e. threadsafe).
+/// To create an interned string, either do
+/// `let i : InternedString = s.into();` or
+/// `let i = s.intern();`
+#[derive(Debug, Clone, Hash, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct InternedString(SymbolU32);
+
+// Use a `Mutex` to make this thread safe.
+lazy_static! {
+    static ref INTERNER: Mutex<StringInterner> = Mutex::new(StringInterner::default());
+}
+
+impl InternedString {
+    pub fn is_empty(&self) -> bool {
+        self.map(|s| s.is_empty())
+    }
+
+    pub fn len(&self) -> usize {
+        self.map(|s| s.len())
+    }
+
+    /// Apply the function `f` to the interned string, represented as an &str.
+    /// Needed because exporting the &str backing the InternedString is blocked by lifetime rules.
+    /// Instead, this allows users to operate on the &str when needed.
+    pub fn map<T, F: FnOnce(&str) -> T>(&self, f: F) -> T {
+        f(INTERNER.lock().unwrap().resolve(self.0).unwrap())
+    }
+
+    pub fn starts_with(&self, pattern: &str) -> bool {
+        self.map(|s| s.starts_with(pattern))
+    }
+}
+
+impl std::fmt::Display for InternedString {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(fmt, "{}", INTERNER.lock().unwrap().resolve(self.0).unwrap())
+    }
+}
+
+impl<T> From<T> for InternedString
+where
+    T: AsRef<str>,
+{
+    fn from(s: T) -> InternedString {
+        InternedString(INTERNER.lock().unwrap().get_or_intern(s))
+    }
+}
+
+impl<T> PartialEq<T> for InternedString
+where
+    T: AsRef<str>,
+{
+    fn eq(&self, other: &T) -> bool {
+        INTERNER.lock().unwrap().resolve(self.0).unwrap() == other.as_ref()
+    }
+}
+
+pub trait InternString {
+    fn intern(self) -> InternedString;
+}
+
+impl<T> InternString for T
+where
+    T: Into<InternedString>,
+{
+    fn intern(self) -> InternedString {
+        self.into()
+    }
+}
+pub trait InternStringOption {
+    fn intern(self) -> Option<InternedString>;
+}
+
+impl<T> InternStringOption for Option<T>
+where
+    T: Into<InternedString>,
+{
+    fn intern(self) -> Option<InternedString> {
+        self.map(|s| s.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cbmc_string::InternedString;
+
+    #[test]
+    fn test_string_interner() {
+        let a: InternedString = "A".into();
+        let b: InternedString = "B".into();
+        let aa: InternedString = "A".into();
+
+        assert_eq!(a, aa);
+        assert_ne!(a, b);
+        assert_ne!(aa, b);
+
+        assert_eq!(a, "A");
+        assert_eq!(b, "B");
+        assert_eq!(aa, "A");
+    }
+}

--- a/compiler/cbmc/src/env.rs
+++ b/compiler/cbmc/src/env.rs
@@ -70,8 +70,8 @@ pub fn additional_env_symbols() -> Vec<Symbol> {
         int_constant("__CPROVER_malloc_failure_mode_return_null", 1),
         Symbol::typedef("__CPROVER_size_t", "__CPROVER_size_t", Type::size_t(), Location::none()),
         Symbol::static_variable(
-            "__CPROVER_memory".to_string(),
-            "__CPROVER_memory".to_string(),
+            "__CPROVER_memory",
+            "__CPROVER_memory",
             Type::unsigned_int(8).infinite_array_of(),
             Location::none(),
         )

--- a/compiler/cbmc/src/goto_program/location.rs
+++ b/compiler/cbmc/src/goto_program/location.rs
@@ -1,19 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+use crate::cbmc_string::{InternStringOption, InternedString};
 use std::convert::TryInto;
 use std::fmt::Debug;
-
 /// A `Location` represents a source location.
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum Location {
     /// Unknown source location
     None,
     /// Code is in a builtin function
-    BuiltinFunction { function_name: String, line: Option<u64> },
+    BuiltinFunction { function_name: InternedString, line: Option<u64> },
     /// Location in user code.
     /// `function` is `None` for global, `Some(function_name)` for function local.
-    Loc { file: String, function: Option<String>, line: u64, col: Option<u64> },
+    Loc { file: InternedString, function: Option<InternedString>, line: u64, col: Option<u64> },
 }
 
 /// Getters and predicates
@@ -35,13 +35,20 @@ impl Location {
 
 /// Constructors
 impl Location {
-    pub fn new<T>(file: String, function: Option<String>, line: T, col: Option<T>) -> Location
+    pub fn new<T, U: Into<InternedString>, V: Into<InternedString>>(
+        file: U,
+        function: Option<V>,
+        line: T,
+        col: Option<T>,
+    ) -> Location
     where
         T: TryInto<u64>,
         T::Error: Debug,
     {
+        let file = file.into();
         let line = line.try_into().unwrap();
         let col = col.map(|x| x.try_into().unwrap());
+        let function = function.intern();
         Location::Loc { file, function, line, col }
     }
 
@@ -49,7 +56,8 @@ impl Location {
         Location::None
     }
 
-    pub fn builtin_function(name: &str, line: Option<u64>) -> Location {
-        Location::BuiltinFunction { line, function_name: name.to_string() }
+    pub fn builtin_function<T: Into<InternedString>>(name: T, line: Option<u64>) -> Location {
+        let function_name = name.into();
+        Location::BuiltinFunction { line, function_name }
     }
 }

--- a/compiler/cbmc/src/goto_program/stmt.rs
+++ b/compiler/cbmc/src/goto_program/stmt.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use self::StmtBody::*;
 use super::{BuiltinFn, Expr, Location};
+use crate::InternedString;
 use std::fmt::Debug;
 use tracing::debug;
 
@@ -72,7 +73,7 @@ pub enum StmtBody {
         arguments: Vec<Expr>,
     },
     /// `goto dest;`
-    Goto(String),
+    Goto(InternedString),
     /// `if (i) { t } else { e }`
     Ifthenelse {
         i: Expr,
@@ -81,7 +82,7 @@ pub enum StmtBody {
     },
     /// `label: body;`
     Label {
-        label: String,
+        label: InternedString,
         body: Stmt,
     },
     /// `return e;` or `return;`
@@ -270,7 +271,8 @@ impl Stmt {
     }
 
     /// `goto dest;`
-    pub fn goto(dest: String, loc: Location) -> Self {
+    pub fn goto<T: Into<InternedString>>(dest: T, loc: Location) -> Self {
+        let dest = dest.into();
         assert!(!dest.is_empty());
         stmt!(Goto(dest), loc)
     }
@@ -309,7 +311,8 @@ impl Stmt {
     }
 
     /// `label: self;`
-    pub fn with_label(self, label: String) -> Self {
+    pub fn with_label<T: Into<InternedString>>(self, label: T) -> Self {
+        let label = label.into();
         assert!(!label.is_empty());
         stmt!(Label { label, body: self }, self.location().clone())
     }

--- a/compiler/cbmc/src/goto_program/symbol.rs
+++ b/compiler/cbmc/src/goto_program/symbol.rs
@@ -1,14 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-use super::super::utils::aggr_name;
+use super::super::utils::aggr_tag;
 use super::{DatatypeComponent, Expr, Location, Parameter, Stmt, Type};
+use crate::{InternStringOption, InternedString};
 
 /// Based off the CBMC symbol implementation here:
 /// https://github.com/diffblue/cbmc/blob/develop/src/util/symbol.h
 #[derive(Clone, Debug)]
 pub struct Symbol {
     /// Unique identifier. Mangled name from compiler `foo12_bar17_x@1`
-    pub name: String,
+    pub name: InternedString,
     pub location: Location,
     pub typ: Type,
     pub value: SymbolValues,
@@ -16,11 +17,11 @@ pub struct Symbol {
     /// Optional debugging information
 
     /// Local name `x`
-    pub base_name: Option<String>,
+    pub base_name: Option<InternedString>,
     /// Fully qualifier name `foo::bar::x`
-    pub pretty_name: Option<String>,
+    pub pretty_name: Option<InternedString>,
     /// Only used by verilog
-    pub module: Option<String>,
+    pub module: Option<InternedString>,
     pub mode: SymbolModes,
     // global properties
     pub is_exported: bool,
@@ -59,14 +60,17 @@ pub enum SymbolValues {
 }
 /// Constructors
 impl Symbol {
-    fn new(
-        name: String,
+    fn new<T: Into<InternedString>, U: Into<InternedString>, V: Into<InternedString>>(
+        name: T,
         location: Location,
         typ: Type,
         value: SymbolValues,
-        base_name: Option<String>,
-        pretty_name: Option<String>,
+        base_name: Option<U>,
+        pretty_name: Option<V>,
     ) -> Self {
+        let name = name.into();
+        let base_name = base_name.intern();
+        let pretty_name = pretty_name.intern();
         Symbol {
             name,
             location,
@@ -100,20 +104,26 @@ impl Symbol {
 
     /// The symbol that defines the type of the struct or union.
     /// For a struct foo this is the symbol "tag-foo" that maps to the type struct foo.
-    pub fn aggr_ty(t: Type, pretty_name: Option<String>) -> Symbol {
+    pub fn aggr_ty<T: Into<InternedString>>(t: Type, pretty_name: Option<T>) -> Symbol {
         //TODO take location
-        let base_name = t.tag().unwrap().to_string();
-        let name = aggr_name(&base_name);
+        let pretty_name = pretty_name.intern();
+        let base_name = t.tag().unwrap();
+        let name = aggr_tag(base_name);
         Symbol::new(name, Location::none(), t, SymbolValues::None, Some(base_name), pretty_name)
             .with_is_type(true)
     }
 
-    pub fn builtin_function(name: &str, param_types: Vec<Type>, return_type: Type) -> Symbol {
+    pub fn builtin_function<T: Into<InternedString>>(
+        name: T,
+        param_types: Vec<Type>,
+        return_type: Type,
+    ) -> Symbol {
+        let name = name.into();
         Symbol::function(
             name,
             Type::code_with_unnamed_parameters(param_types, return_type),
             None,
-            None,
+            None::<InternedString>,
             Location::builtin_function(name, None),
         )
     }
@@ -136,19 +146,21 @@ impl Symbol {
         .with_is_static_lifetime(true) //TODO with thread local was also true??
     }
 
-    pub fn function(
-        name: &str,
+    pub fn function<T: Into<InternedString>, U: Into<InternedString>>(
+        name: T,
         typ: Type,
         body: Option<Stmt>,
-        pretty_name: Option<String>,
+        pretty_name: Option<U>,
         loc: Location,
     ) -> Symbol {
+        let name = name.into();
+        let pretty_name = pretty_name.intern();
         Symbol::new(
             name.to_string(),
             loc,
             typ,
             body.map_or(SymbolValues::None, |x| SymbolValues::Stmt(x)),
-            Some(name.to_string()),
+            Some(name),
             pretty_name,
         )
         .with_is_lvalue(true)
@@ -168,48 +180,73 @@ impl Symbol {
         .with_is_static_lifetime(true)
     }
 
-    pub fn variable(name: String, base_name: String, t: Type, l: Location) -> Symbol {
-        Symbol::new(name, l, t, SymbolValues::None, Some(base_name), None)
+    pub fn variable<T: Into<InternedString>, U: Into<InternedString>>(
+        name: T,
+        base_name: U,
+        t: Type,
+        l: Location,
+    ) -> Symbol {
+        let name = name.into();
+        let base_name: InternedString = base_name.into();
+        Symbol::new(name, l, t, SymbolValues::None, Some(base_name), None::<InternedString>)
             .with_is_thread_local(true)
             .with_is_lvalue(true)
             .with_is_state_var(true)
     }
 
-    pub fn static_variable(name: String, base_name: String, t: Type, l: Location) -> Symbol {
+    pub fn static_variable<T: Into<InternedString>, U: Into<InternedString>>(
+        name: T,
+        base_name: U,
+        t: Type,
+        l: Location,
+    ) -> Symbol {
+        let name = name.into();
+        let base_name: InternedString = base_name.into();
         Symbol::variable(name, base_name, t, l)
             .with_is_thread_local(false)
             .with_is_static_lifetime(true)
     }
 
-    pub fn struct_type(
-        name: &str,
-        pretty_name: Option<String>,
+    pub fn struct_type<T: Into<InternedString>>(
+        name: T,
+        pretty_name: Option<InternedString>,
         components: Vec<DatatypeComponent>,
     ) -> Symbol {
+        let name = name.into();
         Symbol::aggr_ty(Type::struct_type(name, components), pretty_name)
     }
 
-    pub fn union_type(
-        name: &str,
-        pretty_name: Option<String>,
+    pub fn union_type<T: Into<InternedString>, U: Into<InternedString>>(
+        name: T,
+        pretty_name: Option<U>,
         components: Vec<DatatypeComponent>,
     ) -> Symbol {
+        let name = name.into();
+        let pretty_name = pretty_name.intern();
         Symbol::aggr_ty(Type::union_type(name, components), pretty_name)
     }
 
-    pub fn empty_struct(name: &str, pretty_name: Option<String>) -> Symbol {
+    pub fn empty_struct(name: InternedString, pretty_name: Option<InternedString>) -> Symbol {
         Symbol::aggr_ty(Type::empty_struct(name), pretty_name)
     }
 
-    pub fn empty_union(name: &str, pretty_name: Option<String>) -> Symbol {
+    pub fn empty_union(name: InternedString, pretty_name: Option<InternedString>) -> Symbol {
         Symbol::aggr_ty(Type::empty_union(name), pretty_name)
     }
 
-    pub fn incomplete_struct(name: &str, pretty_name: Option<String>) -> Symbol {
+    pub fn incomplete_struct<T: Into<InternedString>, U: Into<InternedString>>(
+        name: T,
+        pretty_name: Option<U>,
+    ) -> Symbol {
         Symbol::aggr_ty(Type::incomplete_struct(name), pretty_name)
     }
 
-    pub fn incomplete_union(name: &str, pretty_name: Option<String>) -> Symbol {
+    pub fn incomplete_union<T: Into<InternedString>, U: Into<InternedString>>(
+        name: T,
+        pretty_name: Option<U>,
+    ) -> Symbol {
+        let name = name.into();
+        let pretty_name = pretty_name.intern();
         Symbol::aggr_ty(Type::incomplete_union(name), pretty_name)
     }
 }
@@ -256,8 +293,8 @@ impl Symbol {
         self
     }
 
-    pub fn with_pretty_name(mut self, pretty_name: &str) -> Symbol {
-        self.pretty_name = Some(pretty_name.to_string());
+    pub fn with_pretty_name<T: Into<InternedString>>(mut self, pretty_name: T) -> Symbol {
+        self.pretty_name = Some(pretty_name.into());
         self
     }
 }
@@ -289,12 +326,12 @@ impl Symbol {
 impl Symbol {
     /// Makes a formal function parameter from a symbol.
     pub fn to_function_parameter(&self) -> Parameter {
-        self.typ.clone().as_parameter(Some(self.name.to_string()), self.base_name.clone())
+        self.typ.clone().as_parameter(Some(self.name), self.base_name)
     }
 
     /// Makes an expression from a symbol.
     pub fn to_expr(&self) -> Expr {
-        Expr::symbol_expression(self.name.clone(), self.typ.clone())
+        Expr::symbol_expression(self.name, self.typ.clone())
     }
 }
 

--- a/compiler/cbmc/src/goto_program/symtab_transformer/gen_c_transformer/name_transformer.rs
+++ b/compiler/cbmc/src/goto_program/symtab_transformer/gen_c_transformer/name_transformer.rs
@@ -5,6 +5,7 @@ use super::super::Transformer;
 use crate::goto_program::{
     DatatypeComponent, Expr, Location, Parameter, Stmt, Symbol, SymbolTable, Type,
 };
+use crate::InternedString;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 
 /// Struct for replacing names with valid C identifiers for --gen-c-runnable.
@@ -15,6 +16,7 @@ pub struct NameTransformer {
     /// injective (two distinct Rust names map to two distinct C names).
     /// To do this, `mapped_names` remembers what each Rust name gets transformed to,
     /// and `used_names` keeps track of what C names have been used.
+    // TODO: use InternedString to save memory.
     mapped_names: FxHashMap<String, String>,
     used_names: FxHashSet<String>,
 }
@@ -31,8 +33,12 @@ impl NameTransformer {
         .transform_symbol_table(original_symbol_table)
     }
 
+    fn normalize_identifier(&mut self, orig_name: InternedString) -> InternedString {
+        self.normalize_identifier_inner(&orig_name.to_string()).into()
+    }
+
     /// Converts an arbitrary identifier into a valid C identifier.
-    fn normalize_identifier(&mut self, orig_name: &str) -> String {
+    fn normalize_identifier_inner(&mut self, orig_name: &str) -> String {
         assert!(!orig_name.is_empty(), "Received empty identifier.");
 
         // If name already encountered, return same result;
@@ -151,87 +157,94 @@ impl Transformer for NameTransformer {
     }
 
     /// Normalize field names.
-    fn transform_expr_member(&mut self, _typ: &Type, lhs: &Expr, field: &str) -> Expr {
+    fn transform_expr_member(&mut self, _typ: &Type, lhs: &Expr, field: InternedString) -> Expr {
         let transformed_lhs = self.transform_expr(lhs);
-        transformed_lhs.member(&self.normalize_identifier(field), self.symbol_table())
+        transformed_lhs.member(self.normalize_identifier(field), self.symbol_table())
     }
 
     /// Normalize name in identifier expression.
-    fn transform_expr_symbol(&mut self, typ: &Type, identifier: &str) -> Expr {
+    fn transform_expr_symbol(&mut self, typ: &Type, identifier: InternedString) -> Expr {
         let transformed_typ = self.transform_type(typ);
         Expr::symbol_expression(self.normalize_identifier(identifier), transformed_typ)
     }
 
     /// Normalize union field names.
-    fn transform_expr_union(&mut self, typ: &Type, value: &Expr, field: &str) -> Expr {
+    fn transform_expr_union(&mut self, typ: &Type, value: &Expr, field: InternedString) -> Expr {
         let transformed_typ = self.transform_type(typ);
         let transformed_value = self.transform_expr(value);
         Expr::union_expr(
             transformed_typ,
-            &self.normalize_identifier(field),
+            self.normalize_identifier(field),
             transformed_value,
             self.symbol_table(),
         )
     }
 
     /// Normalize incomplete struct tag name.
-    fn transform_type_incomplete_struct(&mut self, tag: &str) -> Type {
-        Type::incomplete_struct(&self.normalize_identifier(tag))
+    fn transform_type_incomplete_struct(&mut self, tag: InternedString) -> Type {
+        Type::incomplete_struct(self.normalize_identifier(tag))
     }
 
     /// Normalize incomplete union tag name.
-    fn transform_type_incomplete_union(&mut self, tag: &str) -> Type {
-        Type::incomplete_union(&self.normalize_identifier(tag))
+    fn transform_type_incomplete_union(&mut self, tag: InternedString) -> Type {
+        Type::incomplete_union(self.normalize_identifier(tag))
     }
 
     /// Normalize union/struct component name.
     fn transform_datatype_component(&mut self, component: &DatatypeComponent) -> DatatypeComponent {
         match component {
-            DatatypeComponent::Field { name, typ } => DatatypeComponent::Field {
-                name: self.normalize_identifier(name),
-                typ: self.transform_type(typ),
-            },
+            DatatypeComponent::Field { name, typ } => {
+                DatatypeComponent::field(self.normalize_identifier(*name), self.transform_type(typ))
+            }
             DatatypeComponent::Padding { name, bits } => {
-                DatatypeComponent::Padding { name: self.normalize_identifier(name), bits: *bits }
+                DatatypeComponent::padding(self.normalize_identifier(*name), *bits)
             }
         }
     }
 
     /// Normalize struct type name.
-    fn transform_type_struct(&mut self, tag: &str, components: &[DatatypeComponent]) -> Type {
+    fn transform_type_struct(
+        &mut self,
+        tag: InternedString,
+        components: &[DatatypeComponent],
+    ) -> Type {
         let transformed_components = components
             .iter()
             .map(|component| self.transform_datatype_component(component))
             .collect();
-        Type::struct_type(&self.normalize_identifier(tag), transformed_components)
+        Type::struct_type(self.normalize_identifier(tag), transformed_components)
     }
 
     /// Normalize struct tag name.
-    fn transform_type_struct_tag(&mut self, tag: &str) -> Type {
-        Type::struct_tag_raw(&self.normalize_identifier(tag))
+    fn transform_type_struct_tag(&mut self, tag: InternedString) -> Type {
+        Type::struct_tag_raw(self.normalize_identifier(tag))
     }
 
     /// Normalize union type name.
-    fn transform_type_union(&mut self, tag: &str, components: &[DatatypeComponent]) -> Type {
+    fn transform_type_union(
+        &mut self,
+        tag: InternedString,
+        components: &[DatatypeComponent],
+    ) -> Type {
         let transformed_components = components
             .iter()
             .map(|component| self.transform_datatype_component(component))
             .collect();
-        Type::union_type(&self.normalize_identifier(tag), transformed_components)
+        Type::union_type(self.normalize_identifier(tag), transformed_components)
     }
 
     /// Normalize union tag name.
-    fn transform_type_union_tag(&mut self, tag: &str) -> Type {
-        Type::union_tag_raw(&self.normalize_identifier(tag))
+    fn transform_type_union_tag(&mut self, tag: InternedString) -> Type {
+        Type::union_tag_raw(self.normalize_identifier(tag))
     }
 
     /// Normalize goto label name.
-    fn transform_stmt_goto(&mut self, label: &str) -> Stmt {
+    fn transform_stmt_goto(&mut self, label: InternedString) -> Stmt {
         Stmt::goto(self.normalize_identifier(label), Location::none())
     }
 
     /// Normalize label name.
-    fn transform_stmt_label(&mut self, label: &str, body: &Stmt) -> Stmt {
+    fn transform_stmt_label(&mut self, label: InternedString, body: &Stmt) -> Stmt {
         let transformed_body = self.transform_stmt(body);
         transformed_body.with_label(self.normalize_identifier(label))
     }
@@ -242,10 +255,9 @@ impl Transformer for NameTransformer {
         new_symbol.typ = self.transform_type(&symbol.typ);
         new_symbol.value = self.transform_value(&symbol.value);
 
-        new_symbol.name = self.normalize_identifier(&new_symbol.name);
-        new_symbol.base_name = new_symbol.base_name.map(|name| self.normalize_identifier(&name));
-        new_symbol.pretty_name =
-            new_symbol.pretty_name.map(|name| self.normalize_identifier(&name));
+        new_symbol.name = self.normalize_identifier(new_symbol.name);
+        new_symbol.base_name = new_symbol.base_name.map(|name| self.normalize_identifier(name));
+        new_symbol.pretty_name = new_symbol.pretty_name.map(|name| self.normalize_identifier(name));
 
         new_symbol
     }

--- a/compiler/cbmc/src/goto_program/symtab_transformer/gen_c_transformer/nondet_transformer.rs
+++ b/compiler/cbmc/src/goto_program/symtab_transformer/gen_c_transformer/nondet_transformer.rs
@@ -109,7 +109,7 @@ impl Transformer for NondetTransformer {
             let ret_type = typ.return_type().unwrap();
             assert!(!ret_type.is_empty(), "Cannot generate nondet of type `void`.");
             let ret_name = format!("{}_ret", &identifier);
-            let ret_expr = Expr::symbol_expression(ret_name.clone(), ret_type.clone());
+            let ret_expr = Expr::symbol_expression(&ret_name, ret_type.clone());
             let body = Stmt::block(
                 vec![
                     // <ret_type> var_ret;
@@ -126,13 +126,8 @@ impl Transformer for NondetTransformer {
             self.mut_symbol_table().insert(ret_sym);
 
             // Add function to symbol table
-            let func_sym = Symbol::function(
-                &identifier,
-                typ,
-                Some(body),
-                Some(identifier.clone()),
-                Location::none(),
-            );
+            let func_sym =
+                Symbol::function(&identifier, typ, Some(body), Some(&identifier), Location::none());
             self.mut_symbol_table().insert(func_sym);
         }
     }

--- a/compiler/cbmc/src/goto_program/symtab_transformer/identity_transformer.rs
+++ b/compiler/cbmc/src/goto_program/symtab_transformer/identity_transformer.rs
@@ -3,7 +3,6 @@
 
 use super::Transformer;
 use crate::goto_program::SymbolTable;
-
 /// Struct for performing the identity transformation on a symbol table.
 /// Mainly used as a demo/for testing.
 pub struct IdentityTransformer {
@@ -151,12 +150,12 @@ mod tests {
             let struct_type = Type::struct_type(
                 "s",
                 vec![
-                    DatatypeComponent::Field { name: "a".to_string(), typ: Type::float() },
-                    DatatypeComponent::Padding { name: "b".to_string(), bits: 4 },
-                    DatatypeComponent::Field { name: "c".to_string(), typ: Type::double() },
-                    DatatypeComponent::Padding { name: "d".to_string(), bits: 5 },
-                    DatatypeComponent::Field { name: "e".to_string(), typ: Type::c_int() },
-                    DatatypeComponent::Padding { name: "f".to_string(), bits: 6 },
+                    DatatypeComponent::field("a", Type::float()),
+                    DatatypeComponent::padding("b", 4),
+                    DatatypeComponent::field("c", Type::double()),
+                    DatatypeComponent::padding("d", 5),
+                    DatatypeComponent::field("e", Type::c_int()),
+                    DatatypeComponent::padding("f", 6),
                 ],
             );
             add_sym(struct_type);
@@ -185,9 +184,9 @@ mod tests {
             let union_type = Type::union_type(
                 "u",
                 vec![
-                    DatatypeComponent::Field { name: "a".to_string(), typ: Type::float() },
-                    DatatypeComponent::Field { name: "c".to_string(), typ: Type::double() },
-                    DatatypeComponent::Field { name: "e".to_string(), typ: Type::c_int() },
+                    DatatypeComponent::field("a", Type::float()),
+                    DatatypeComponent::field("c", Type::double()),
+                    DatatypeComponent::field("e", Type::c_int()),
                 ],
             );
             add_sym(union_type);
@@ -275,12 +274,12 @@ mod tests {
             "s",
             None,
             vec![
-                DatatypeComponent::Field { name: "a".to_string(), typ: Type::float() },
-                DatatypeComponent::Padding { name: "b".to_string(), bits: 4 },
-                DatatypeComponent::Field { name: "c".to_string(), typ: Type::double() },
-                DatatypeComponent::Padding { name: "d".to_string(), bits: 5 },
-                DatatypeComponent::Field { name: "e".to_string(), typ: Type::c_int() },
-                DatatypeComponent::Padding { name: "f".to_string(), bits: 6 },
+                DatatypeComponent::field("a", Type::float()),
+                DatatypeComponent::padding("b", 4),
+                DatatypeComponent::field("c", Type::double()),
+                DatatypeComponent::padding("d", 5),
+                DatatypeComponent::field("e", Type::c_int()),
+                DatatypeComponent::padding("f", 6),
             ],
         );
         original.insert(struct_type);
@@ -309,11 +308,11 @@ mod tests {
 
         let union_type = Symbol::union_type(
             "u",
-            None,
+            crate::NO_PRETTY_NAME,
             vec![
-                DatatypeComponent::Field { name: "a".to_string(), typ: Type::float() },
-                DatatypeComponent::Field { name: "c".to_string(), typ: Type::double() },
-                DatatypeComponent::Field { name: "e".to_string(), typ: Type::c_int() },
+                DatatypeComponent::field("a", Type::float()),
+                DatatypeComponent::field("c", Type::double()),
+                DatatypeComponent::field("e", Type::c_int()),
             ],
         );
         original.insert(union_type);
@@ -356,7 +355,7 @@ mod tests {
                     &name,
                     Type::code_with_unnamed_parameters(vec![], Type::empty()),
                     Some(body),
-                    None,
+                    crate::NO_PRETTY_NAME,
                     Location::none(),
                 ));
                 curr_var += 1;

--- a/compiler/cbmc/src/irep/irep.rs
+++ b/compiler/cbmc/src/irep/irep.rs
@@ -5,6 +5,7 @@
 use super::super::goto_program::{Location, Type};
 use super::super::MachineModel;
 use super::{IrepId, ToIrep};
+use crate::cbmc_string::InternedString;
 use num::BigInt;
 use std::fmt::Debug;
 use vector_map::VecMap;
@@ -121,7 +122,7 @@ impl Irep {
         Irep { id: IrepId::EmptyString, sub: vec![], named_sub: named_sub }
     }
 
-    pub fn just_string_id(s: String) -> Irep {
+    pub fn just_string_id<T: Into<InternedString>>(s: T) -> Irep {
         Irep::just_id(IrepId::from_string(s))
     }
 

--- a/compiler/cbmc/src/irep/irep_id.rs
+++ b/compiler/cbmc/src/irep/irep_id.rs
@@ -4,12 +4,14 @@
 //!
 //! This file contains [IrepId] which is the id's used in CBMC.
 //! c.f. CBMC source code [src/util/irep_ids.def]
+use crate::cbmc_string::InternedString;
 use num::bigint::BigInt;
+
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub enum IrepId {
     /// In addition to the standard enums defined below, CBMC also allows ids to be strings.
     /// For e.g, to store the id of a variable. This enum variant captures those strings.
-    FreeformString(String),
+    FreeformString(InternedString),
     /// An integer, encoded as a decimal string
     FreeformInteger(BigInt),
     /// An integer, encoded as a hex string
@@ -833,9 +835,9 @@ impl IrepId {
         IrepId::FreeformHexInteger(i.into())
     }
 
-    pub fn from_string(s: String) -> IrepId {
-        //TODO assert that s is not the string produced by any other IrepId
-        IrepId::FreeformString(s)
+    //TODO assert that s is not the string produced by any other IrepId
+    pub fn from_string<T: Into<InternedString>>(s: T) -> IrepId {
+        IrepId::FreeformString(s.into())
     }
 }
 

--- a/compiler/cbmc/src/irep/serialize.rs
+++ b/compiler/cbmc/src/irep/serialize.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! This crate implements irep serialization using serde Serializer.
 use crate::irep::{Irep, IrepId, Symbol, SymbolTable};
+use crate::InternedString;
 use serde::ser::{SerializeMap, Serializer};
 use serde::Serialize;
 use vector_map::VecMap;
@@ -88,6 +89,15 @@ impl<'a> Serialize for StreamingSymbols<'a> {
     }
 }
 
+impl Serialize for InternedString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.to_string().serialize(serializer)
+    }
+}
+
 impl Serialize for Symbol {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -143,11 +153,11 @@ mod test {
             typ: Irep::empty(),
             value: Irep::empty(),
             location: Irep::empty(),
-            name: String::from("my_name"),
-            module: String::new(),
-            base_name: String::new(),
-            pretty_name: String::new(),
-            mode: String::new(),
+            name: "my_name".into(),
+            module: "".into(),
+            base_name: "".into(),
+            pretty_name: "".into(),
+            mode: "".into(),
             is_type: false,
             is_macro: false,
             is_exported: false,

--- a/compiler/cbmc/src/irep/symbol.rs
+++ b/compiler/cbmc/src/irep/symbol.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use super::Irep;
-
+use crate::InternedString;
 /// A direct implementation of the CBMC serilization format for symbols implemented in
 /// https://github.com/diffblue/cbmc/blob/develop/src/util/symbol.h
 // TODO: do we want these members to be public?
@@ -11,16 +11,16 @@ pub struct Symbol {
     pub value: Irep,
     pub location: Irep,
     /// Unique identifier, same as key in symbol table `foo::x`
-    pub name: String,
+    pub name: InternedString,
     /// Only used by verilog
-    pub module: String,
+    pub module: InternedString,
     /// Local identifier `x`
-    pub base_name: String,
+    pub base_name: InternedString,
     /// Almost always the same as base_name, but with name mangling can be relevant
-    pub pretty_name: String,
+    pub pretty_name: InternedString,
     /// Currently set to C. Consider creating a "rust" mode and using it in cbmc
     /// https://github.com/model-checking/rmc/issues/1
-    pub mode: String,
+    pub mode: InternedString,
 
     // global properties
     pub is_type: bool,

--- a/compiler/cbmc/src/irep/symbol_table.rs
+++ b/compiler/cbmc/src/irep/symbol_table.rs
@@ -1,13 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use super::Symbol;
+use crate::InternedString;
 use std::collections::BTreeMap;
 
 /// A direct implementation of the CBMC serilization format for symbol tables implemented in
 /// https://github.com/diffblue/cbmc/blob/develop/src/util/symbol_table.h
 #[derive(Debug, PartialEq)]
 pub struct SymbolTable {
-    pub symbol_table: BTreeMap<String, Symbol>,
+    pub symbol_table: BTreeMap<InternedString, Symbol>,
 }
 
 /// Constructors
@@ -20,6 +21,6 @@ impl SymbolTable {
 /// Setters
 impl SymbolTable {
     pub fn insert(&mut self, symbol: Symbol) {
-        self.symbol_table.insert(symbol.name.clone(), symbol);
+        self.symbol_table.insert(symbol.name, symbol);
     }
 }

--- a/compiler/cbmc/src/irep/to_irep.rs
+++ b/compiler/cbmc/src/irep/to_irep.rs
@@ -317,7 +317,7 @@ impl ToIrep for Location {
                 (IrepId::Line, Irep::just_int_id(*line)),
             ])
             .with_named_sub_option(IrepId::Column, col.map(Irep::just_int_id))
-            .with_named_sub_option(IrepId::Function, function.clone().map(Irep::just_string_id)),
+            .with_named_sub_option(IrepId::Function, function.map(Irep::just_string_id)),
         }
     }
 }
@@ -329,14 +329,8 @@ impl ToIrep for Parameter {
             sub: vec![],
             named_sub: vector_map![(IrepId::Type, self.typ().to_irep(mm))],
         }
-        .with_named_sub_option(
-            IrepId::CIdentifier,
-            self.identifier().cloned().map(Irep::just_string_id),
-        )
-        .with_named_sub_option(
-            IrepId::CBaseName,
-            self.base_name().cloned().map(Irep::just_string_id),
-        )
+        .with_named_sub_option(IrepId::CIdentifier, self.identifier().map(Irep::just_string_id))
+        .with_named_sub_option(IrepId::CBaseName, self.base_name().map(Irep::just_string_id))
     }
 }
 
@@ -439,16 +433,16 @@ impl goto_program::Symbol {
             },
             location: self.location.to_irep(mm),
             /// Unique identifier, same as key in symbol table `foo::x`
-            name: self.name.to_string(),
+            name: self.name,
             /// Only used by verilog
-            module: self.module.clone().unwrap_or_default(),
+            module: self.module.unwrap_or("".into()),
             /// Local identifier `x`
-            base_name: self.base_name.clone().unwrap_or_default(),
+            base_name: self.base_name.unwrap_or("".into()),
             /// Almost always the same as base_name, but with name mangling can be relevant
-            pretty_name: self.pretty_name.clone().unwrap_or_default(),
+            pretty_name: self.pretty_name.unwrap_or("".into()),
             /// Currently set to C. Consider creating a "rust" mode and using it in cbmc
             /// https://github.com/model-checking/rmc/issues/1
-            mode: self.mode.to_string(),
+            mode: self.mode.to_string().into(),
 
             // global properties
             is_type: self.is_type,

--- a/compiler/cbmc/src/lib.rs
+++ b/compiler/cbmc/src/lib.rs
@@ -32,3 +32,8 @@ mod machine_model;
 pub mod utils;
 pub use irep::serialize;
 pub use machine_model::{MachineModel, RoundingMode};
+mod cbmc_string;
+pub use cbmc_string::{InternString, InternStringOption, InternedString};
+
+// Rust has difficulty resolving types for None option values: this gives rustc a hint.
+pub const NO_PRETTY_NAME: Option<InternedString> = None;

--- a/compiler/cbmc/src/utils.rs
+++ b/compiler/cbmc/src/utils.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Useful utilities for CBMC
 
+use crate::InternedString;
 use num::bigint::BigInt;
 
 /// RMC bug report URL, for asserts/errors
@@ -9,8 +10,9 @@ pub const BUG_REPORT_URL: &str =
     "https://github.com/model-checking/rmc/issues/new?template=bug_report.md";
 
 /// The aggregate name used in CBMC for aggregates of type `n`.
-pub fn aggr_name(n: &str) -> String {
-    format!("tag-{}", n)
+pub fn aggr_tag<T: Into<InternedString>>(n: T) -> InternedString {
+    let n = n.into();
+    format!("tag-{}", n.to_string()).into()
 }
 
 /// Provides a useful shortcut for making BTreeMaps.
@@ -51,13 +53,14 @@ macro_rules! btree_string_map {
     ($($x:expr),*) => {{
         use std::collections::BTreeMap;
         use std::iter::FromIterator;
-        (BTreeMap::from_iter(vec![$($x),*].into_iter().map(|(k,v)|(k.to_string(),v))))
+        (BTreeMap::from_iter(vec![$($x),*].into_iter().map(|(k,v)|(k.into(),v))))
     }};
     ($($x:expr,)*) => {{
         use std::collections::BTreeMap;
         use std::iter::FromIterator;
-        (BTreeMap::from_iter(vec![$($x),*].into_iter().map(|(k,v)|(k.to_string(),v))))
+        (BTreeMap::from_iter(vec![$($x),*].into_iter().map(|(k,v)|(k.into(),v))))
     }}
+
 }
 
 pub fn max_int(width: u64, signed: bool) -> BigInt {

--- a/compiler/rustc_codegen_rmc/src/codegen/assumptions.rs
+++ b/compiler/rustc_codegen_rmc/src/codegen/assumptions.rs
@@ -4,6 +4,7 @@
 
 use crate::GotocCtx;
 use cbmc::goto_program::{Expr, Location, Stmt, Symbol, Type};
+use cbmc::NO_PRETTY_NAME;
 use rustc_middle::mir::interpret::{ConstValue, Scalar};
 use rustc_middle::ty;
 use rustc_middle::ty::layout::LayoutOf;
@@ -586,7 +587,7 @@ impl<'tcx> GotocCtx<'tcx> {
             fname,
             Type::code(vec![var.to_function_parameter()], Type::bool()),
             Some(body),
-            None,
+            NO_PRETTY_NAME,
             Location::none(),
         )
     }

--- a/compiler/rustc_codegen_rmc/src/codegen/function.rs
+++ b/compiler/rustc_codegen_rmc/src/codegen/function.rs
@@ -193,7 +193,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 fname,
                 ctx.fn_typ(),
                 None,
-                Some(ctx.current_fn().readable_name().to_string()),
+                Some(ctx.current_fn().readable_name()),
                 ctx.codegen_span(&mir.span),
             )
         });

--- a/compiler/rustc_codegen_rmc/src/codegen/rvalue.rs
+++ b/compiler/rustc_codegen_rmc/src/codegen/rvalue.rs
@@ -3,10 +3,11 @@
 use super::typ::{is_pointer, pointee_type, TypeExt};
 use crate::utils::{dynamic_fat_ptr, slice_fat_ptr};
 use crate::GotocCtx;
-use cbmc::btree_string_map;
 use cbmc::goto_program::{BuiltinFn, Expr, Location, Stmt, Symbol, Type};
-use cbmc::utils::{aggr_name, BUG_REPORT_URL};
+use cbmc::utils::{aggr_tag, BUG_REPORT_URL};
 use cbmc::MachineModel;
+use cbmc::NO_PRETTY_NAME;
+use cbmc::{btree_string_map, InternString, InternedString};
 use num::bigint::BigInt;
 use rustc_middle::mir::{AggregateKind, BinOp, CastKind, NullOp, Operand, Place, Rvalue, UnOp};
 use rustc_middle::ty::adjustment::PointerCast;
@@ -191,7 +192,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 &func_name,
                 Type::code(vec![inp.to_function_parameter()], res_t),
                 Some(Stmt::block(body, Location::none())),
-                None,
+                NO_PRETTY_NAME,
                 Location::none(),
             )
         });
@@ -711,10 +712,10 @@ impl<'tcx> GotocCtx<'tcx> {
         idx: usize,
     ) -> Expr {
         let vtable_field_name = self.vtable_field_name(instance.def_id(), idx);
-        let vtable_type_name = aggr_name(&self.vtable_name(t));
+        let vtable_type_name = aggr_tag(self.vtable_name(t));
         let field_type = self
             .symbol_table
-            .lookup_field_type(&vtable_type_name, &vtable_field_name)
+            .lookup_field_type(vtable_type_name, vtable_field_name)
             .cloned()
             .unwrap();
 
@@ -724,7 +725,7 @@ impl<'tcx> GotocCtx<'tcx> {
             // Create a pointer to the method
             // Note that the method takes a self* as the first argument, but the vtable field type has a void* as the first arg.
             // So we need to cast it at the end.
-            Expr::symbol_expression(fn_symbol.name.clone(), fn_symbol.typ.clone())
+            Expr::symbol_expression(fn_symbol.name, fn_symbol.typ.clone())
                 .address_of()
                 .cast_to(field_type)
         } else {
@@ -785,7 +786,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 &drop_sym_name,
                 Type::code(vec![param_sym.to_function_parameter()], Type::empty()),
                 Some(Stmt::block(vec![unimplemented], Location::none())),
-                None,
+                NO_PRETTY_NAME,
                 Location::none(),
             );
             self.symbol_table.insert(sym.clone());
@@ -863,13 +864,13 @@ impl<'tcx> GotocCtx<'tcx> {
 
         let src_name = self.ty_mangled_name(src_mir_type);
         // The name needs to be the same as inserted in typ.rs
-        let vtable_name = self.vtable_name(trait_type);
+        let vtable_name = self.vtable_name(trait_type).intern();
         let vtable_impl_name = format!("{}_impl_for_{}", vtable_name, src_name);
 
         self.ensure_global_var(
-            &vtable_impl_name,
+            vtable_impl_name,
             true,
-            Type::struct_tag(&vtable_name),
+            Type::struct_tag(vtable_name),
             Location::none(),
             |ctx, var| {
                 // Build the vtable, using Rust's vtable_entries to determine field order
@@ -905,7 +906,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     .collect();
 
                 let vtable = Expr::struct_expr_from_values(
-                    Type::struct_tag(&vtable_name),
+                    Type::struct_tag(vtable_name),
                     vtable_fields,
                     &ctx.symbol_table,
                 );
@@ -949,7 +950,7 @@ impl<'tcx> GotocCtx<'tcx> {
         let dst_goto_type = self.codegen_ty(dst_mir_type);
         let data = src_goto_expr.to_owned().member("data", &self.symbol_table);
         let vtable_name = self.vtable_name(dst_mir_dyn_ty);
-        let vtable_ty = Type::struct_tag(&vtable_name).to_pointer();
+        let vtable_ty = Type::struct_tag(vtable_name).to_pointer();
 
         let vtable = src_goto_expr.member("vtable", &self.symbol_table).cast_to(vtable_ty);
 
@@ -1123,14 +1124,14 @@ impl<'tcx> GotocCtx<'tcx> {
         assert!(src_goto_field_values.keys().eq(dst_mir_field_types.keys()));
 
         // Cast each field and collect the fields for which a cast was required
-        let mut cast_required: Vec<(String, Expr)> = vec![];
+        let mut cast_required: Vec<(InternedString, Expr)> = vec![];
         for field in src_goto_field_values.keys() {
             if let Some(expr) = self.cast_to_unsized_expr(
                 src_goto_field_values.get(field).unwrap().clone(),
                 src_mir_field_types.get(field).unwrap(),
                 dst_mir_field_types.get(field).unwrap(),
             ) {
-                cast_required.push((field.to_string(), expr));
+                cast_required.push((*field, expr));
             }
         }
         // Return None for a struct with fields if none of the fields require a cast.

--- a/compiler/rustc_codegen_rmc/src/codegen/statement.rs
+++ b/compiler/rustc_codegen_rmc/src/codegen/statement.rs
@@ -20,10 +20,15 @@ use tracing::debug;
 
 impl<'tcx> GotocCtx<'tcx> {
     fn codegen_ret_unit(&mut self) -> Stmt {
-        let name = &FN_RETURN_VOID_VAR_NAME.to_string();
         let is_file_local = false;
         let ty = self.codegen_ty_unit();
-        let var = self.ensure_global_var(name, is_file_local, ty, Location::none(), |_, _| None);
+        let var = self.ensure_global_var(
+            FN_RETURN_VOID_VAR_NAME,
+            is_file_local,
+            ty,
+            Location::none(),
+            |_, _| None,
+        );
         Stmt::ret(Some(var), Location::none())
     }
 
@@ -430,7 +435,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // arg0.vtable->f(arg0.data,arg1);
         let vtable_ref = trait_fat_ptr.to_owned().member("vtable", &self.symbol_table);
         let vtable = vtable_ref.dereference();
-        let fn_ptr = vtable.member(&vtable_field_name, &self.symbol_table);
+        let fn_ptr = vtable.member(vtable_field_name, &self.symbol_table);
 
         // Update the argument from arg0 to arg0.data
         fargs[0] = trait_fat_ptr.to_owned().member("data", &self.symbol_table);

--- a/compiler/rustc_codegen_rmc/src/codegen/typ.rs
+++ b/compiler/rustc_codegen_rmc/src/codegen/typ.rs
@@ -1,9 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use crate::GotocCtx;
-use cbmc::btree_map;
 use cbmc::goto_program::{DatatypeComponent, Expr, Parameter, Symbol, SymbolTable, Type};
-use cbmc::utils::aggr_name;
+use cbmc::utils::aggr_tag;
+use cbmc::{btree_map, NO_PRETTY_NAME};
+use cbmc::{InternString, InternedString};
 use rustc_ast::ast::Mutability;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::{HasLocalDecls, Local, Operand, Place, Rvalue};
@@ -25,9 +26,9 @@ use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::iter;
+use std::iter::FromIterator;
 use tracing::debug;
 use ty::layout::HasParamEnv;
-
 /// Map the unit type to an empty struct
 ///
 /// Mapping unit to `void` works for functions with no return type but not for variables with type
@@ -57,7 +58,7 @@ impl TypeExt for Type {
                     && components.iter().any(|x| x.name() == "data" && x.typ().is_pointer())
                     && components.iter().any(|x| x.name() == "len" && x.typ().is_integer())
             }
-            Type::StructTag(tag) => st.lookup(tag).unwrap().typ.is_rust_slice_fat_ptr(st),
+            Type::StructTag(tag) => st.lookup(*tag).unwrap().typ.is_rust_slice_fat_ptr(st),
             _ => false,
         }
     }
@@ -69,7 +70,9 @@ impl TypeExt for Type {
                     && components.iter().any(|x| x.name() == "data" && x.typ().is_pointer())
                     && components.iter().any(|x| x.name() == "vtable" && x.typ().is_pointer())
             }
-            Type::StructTag(tag) => st.lookup(tag).unwrap().typ.is_rust_trait_fat_ptr(st),
+            Type::StructTag(tag) => {
+                st.lookup(&tag.to_string()).unwrap().typ.is_rust_trait_fat_ptr(st)
+            }
             _ => false,
         }
     }
@@ -86,7 +89,7 @@ impl TypeExt for Type {
 
     fn is_unit(&self) -> bool {
         match self {
-            Type::StructTag(name) => *name == aggr_name(UNIT_TYPE_EMPTY_STRUCT_NAME),
+            Type::StructTag(name) => *name == aggr_tag(UNIT_TYPE_EMPTY_STRUCT_NAME),
             _ => false,
         }
     }
@@ -299,7 +302,7 @@ impl<'tcx> GotocCtx<'tcx> {
         // vtable field name, i.e., 3_vol (idx_method)
         let vtable_field_name = self.vtable_field_name(instance.def_id(), idx);
 
-        Type::datatype_component(&vtable_field_name, fn_ptr)
+        Type::datatype_component(vtable_field_name, fn_ptr)
     }
 
     /// Generates a vtable that looks like this:
@@ -312,7 +315,9 @@ impl<'tcx> GotocCtx<'tcx> {
     ///   }
     /// Ensures that the vtable is added to the symbol table.
     fn codegen_trait_vtable_type(&mut self, t: &'tcx ty::TyS<'tcx>) -> Type {
-        self.ensure_struct(&self.vtable_name(t), None, |ctx, _| ctx.trait_vtable_field_types(t))
+        self.ensure_struct(self.vtable_name(t), NO_PRETTY_NAME, |ctx, _| {
+            ctx.trait_vtable_field_types(t)
+        })
     }
 
     /// a trait dyn Trait is translated to
@@ -321,14 +326,14 @@ impl<'tcx> GotocCtx<'tcx> {
     ///     void* vtable;
     /// }
     fn codegen_trait_fat_ptr_type(&mut self, t: &'tcx ty::TyS<'tcx>) -> Type {
-        self.ensure_struct(&self.normalized_trait_name(t), None, |ctx, _| {
+        self.ensure_struct(&self.normalized_trait_name(t), NO_PRETTY_NAME, |ctx, _| {
             // At this point in time, the vtable hasn't been codegen yet.
             // However, all we need to know is its name, which we do know.
             // See the comment on codegen_ty_ref.
             let vtable_name = ctx.vtable_name(t);
             vec![
                 Type::datatype_component("data", Type::void_pointer()),
-                Type::datatype_component("vtable", Type::struct_tag(&vtable_name).to_pointer()),
+                Type::datatype_component("vtable", Type::struct_tag(vtable_name).to_pointer()),
             ]
         })
     }
@@ -399,10 +404,10 @@ impl<'tcx> GotocCtx<'tcx> {
     /// See compiler/rustc_middle/src/ty/vtable.rs
     /// https://github.com/model-checking/rmc/issues/358
     pub fn vtable_name(&self, t: Ty<'tcx>) -> String {
-        self.normalized_trait_name(t) + "::vtable"
+        format!("{}::vtable", self.normalized_trait_name(t))
     }
 
-    pub fn ty_pretty_name(&self, t: Ty<'tcx>) -> String {
+    pub fn ty_pretty_name(&self, t: Ty<'tcx>) -> InternedString {
         use rustc_hir::def::Namespace;
         use rustc_middle::ty::print::Printer;
         let mut name = String::new();
@@ -414,10 +419,10 @@ impl<'tcx> GotocCtx<'tcx> {
         //   StructTag("tag-std::boxed::Box<dyn std::error::Error + std::marker::Send + std::marker::Sync>") }
         let t = self.monomorphize(t);
         with_no_trimmed_paths(|| printer.print_type(t).unwrap());
-        name
+        name.intern()
     }
 
-    pub fn ty_mangled_name(&self, t: Ty<'tcx>) -> String {
+    pub fn ty_mangled_name(&self, t: Ty<'tcx>) -> InternedString {
         // Crate resolution: mangled names need to be distinct across different versions
         // of the same crate that could be pulled in by dependencies. However, RMC's
         // treatment of FFI C calls asssumes that we generate the same name for structs
@@ -430,7 +435,7 @@ impl<'tcx> GotocCtx<'tcx> {
         } else {
             // This hash is documented to be the same no matter the crate context
             let id_u64 = self.tcx.type_id_hash(t);
-            format!("_{}", id_u64)
+            format!("_{}", id_u64).intern()
         }
     }
 
@@ -459,16 +464,16 @@ impl<'tcx> GotocCtx<'tcx> {
     /// We handle this by treating it as an incomplete struct.
     fn codegen_foreign(&mut self, ty: Ty<'tcx>, defid: DefId) -> Type {
         debug!("codegen_foreign {:?} {:?}", ty, defid);
-        let name = self.ty_mangled_name(ty);
-        self.ensure(&aggr_name(&name), |ctx, _| {
-            Symbol::incomplete_struct(&name, Some(ctx.ty_pretty_name(ty)))
+        let name = self.ty_mangled_name(ty).intern();
+        self.ensure(aggr_tag(name), |ctx, _| {
+            Symbol::incomplete_struct(name, Some(ctx.ty_pretty_name(ty)))
         });
-        Type::struct_tag(&name)
+        Type::struct_tag(name)
     }
 
     /// The unit type in Rust is an empty struct in gotoc
     pub fn codegen_ty_unit(&mut self) -> Type {
-        self.ensure_struct(UNIT_TYPE_EMPTY_STRUCT_NAME, None, |_, _| vec![])
+        self.ensure_struct(UNIT_TYPE_EMPTY_STRUCT_NAME, NO_PRETTY_NAME, |_, _| vec![])
     }
 
     /// codegen for types. it finds a C type which corresponds to a rust type.
@@ -481,7 +486,7 @@ impl<'tcx> GotocCtx<'tcx> {
     pub fn codegen_ty(&mut self, ty: Ty<'tcx>) -> Type {
         let goto_typ = self.codegen_ty_inner(ty);
         if let Some(tag) = goto_typ.tag() {
-            if !self.type_map.contains_key(tag) {
+            if !self.type_map.contains_key(&tag.to_string()) {
                 self.type_map.insert(tag.to_string(), ty);
             }
         }
@@ -521,7 +526,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 // struct [T; n] {
                 //   T _0[n];
                 // }
-                self.ensure_struct(&array_name, None, |ctx, _| {
+                self.ensure_struct(&array_name, NO_PRETTY_NAME, |ctx, _| {
                     if et.is_unit() {
                         // we do not generate a struct with an array of units
                         vec![]
@@ -544,7 +549,9 @@ impl<'tcx> GotocCtx<'tcx> {
             ty::FnPtr(sig) => self.codegen_function_sig(*sig).to_pointer(),
             ty::Closure(_, subst) => self.codegen_ty_closure(ty, subst),
             ty::Generator(_, subst, _) => self.codegen_ty_generator(subst),
-            ty::Never => self.ensure_struct(NEVER_TYPE_EMPTY_STRUCT_NAME, None, |_, _| vec![]),
+            ty::Never => {
+                self.ensure_struct(NEVER_TYPE_EMPTY_STRUCT_NAME, NO_PRETTY_NAME, |_, _| vec![])
+            }
             ty::Tuple(ts) => {
                 if ts.is_empty() {
                     self.codegen_ty_unit()
@@ -552,7 +559,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     // we do not have to do two insertions for tuple because it is impossible for
                     // finite tuples to loop.
                     self.ensure_struct(
-                        &self.ty_mangled_name(ty),
+                        self.ty_mangled_name(ty),
                         Some(self.ty_pretty_name(ty)),
                         |tcx, _| tcx.codegen_ty_tuple_fields(ty, ts),
                     )
@@ -724,7 +731,7 @@ impl<'tcx> GotocCtx<'tcx> {
     /// just a tuple with a unique type identifier, so that Fn related traits
     /// can find its impl.
     fn codegen_ty_closure(&mut self, t: Ty<'tcx>, substs: ty::subst::SubstsRef<'tcx>) -> Type {
-        self.ensure_struct(&self.ty_mangled_name(t), Some(self.ty_pretty_name(t)), |ctx, _| {
+        self.ensure_struct(self.ty_mangled_name(t), Some(self.ty_pretty_name(t)), |ctx, _| {
             ctx.codegen_ty_tuple_like(t, substs.as_closure().upvar_tys().collect())
         })
     }
@@ -747,8 +754,8 @@ impl<'tcx> GotocCtx<'tcx> {
         if self.use_slice_fat_pointer(mir_type) {
             let pointer_name = match mir_type.kind() {
                 ty::Slice(..) => self.ty_mangled_name(mir_type),
-                ty::Str => "str".to_string(),
-                ty::Adt(..) => format!("&{}", self.ty_mangled_name(mir_type)),
+                ty::Str => "str".intern(),
+                ty::Adt(..) => format!("&{}", self.ty_mangled_name(mir_type)).intern(),
                 kind => unreachable!("Generating a slice fat pointer to {:?}", kind),
             };
             let element_type = match mir_type.kind() {
@@ -758,7 +765,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 ty::Adt(..) => self.codegen_ty(mir_type),
                 kind => unreachable!("Generating a slice fat pointer to {:?}", kind),
             };
-            self.ensure_struct(&pointer_name, None, |_, _| {
+            self.ensure_struct(pointer_name, NO_PRETTY_NAME, |_, _| {
                 vec![
                     Type::datatype_component("data", element_type.to_pointer()),
                     Type::datatype_component("len", Type::size_t()),
@@ -891,7 +898,7 @@ impl<'tcx> GotocCtx<'tcx> {
         def: &'tcx AdtDef,
         subst: &'tcx InternalSubsts<'tcx>,
     ) -> Type {
-        self.ensure_struct(&self.ty_mangled_name(ty), Some(self.ty_pretty_name(ty)), |ctx, _| {
+        self.ensure_struct(self.ty_mangled_name(ty), Some(self.ty_pretty_name(ty)), |ctx, _| {
             let variant = &def.variants.raw[0];
             let layout = ctx.layout_of(ty);
             ctx.codegen_variant_struct_fields(variant, subst, layout.layout, 0)
@@ -921,7 +928,7 @@ impl<'tcx> GotocCtx<'tcx> {
         def: &'tcx AdtDef,
         subst: &'tcx InternalSubsts<'tcx>,
     ) -> Type {
-        self.ensure_union(&self.ty_mangled_name(ty), Some(self.ty_pretty_name(ty)), |ctx, _| {
+        self.ensure_union(self.ty_mangled_name(ty), Some(self.ty_pretty_name(ty)), |ctx, _| {
             def.variants.raw[0]
                 .fields
                 .iter()
@@ -973,7 +980,7 @@ impl<'tcx> GotocCtx<'tcx> {
         adtdef: &'tcx AdtDef,
         subst: &'tcx InternalSubsts<'tcx>,
     ) -> Type {
-        self.ensure_struct(&self.ty_mangled_name(ty), Some(self.ty_pretty_name(ty)), |ctx, name| {
+        self.ensure_struct(self.ty_mangled_name(ty), Some(self.ty_pretty_name(ty)), |ctx, name| {
             // variants appearing in source code (in source code order)
             let source_variants = &adtdef.variants;
             // variants appearing in mir code
@@ -1123,14 +1130,14 @@ impl<'tcx> GotocCtx<'tcx> {
 
     fn codegen_enum_cases_union(
         &mut self,
-        name: &str,
+        name: InternedString,
         def: &'tcx AdtDef,
         subst: &'tcx InternalSubsts<'tcx>,
         layouts: &IndexVec<VariantIdx, Layout>,
         initial_offset: usize,
     ) -> Type {
         // TODO Should we have a pretty name here?
-        self.ensure_union(&format!("{}-union", name), None, |ctx, name| {
+        self.ensure_union(&format!("{}-union", name.to_string()), NO_PRETTY_NAME, |ctx, name| {
             def.variants
                 .iter_enumerated()
                 .map(|(i, case)| {
@@ -1151,15 +1158,15 @@ impl<'tcx> GotocCtx<'tcx> {
 
     fn codegen_enum_case_struct(
         &mut self,
-        name: &str,
+        name: InternedString,
         case: &VariantDef,
         subst: &'tcx InternalSubsts<'tcx>,
         variant: &Layout,
         initial_offset: usize,
     ) -> Type {
-        let case_name = format!("{}::{}", name, case.ident.name);
+        let case_name = format!("{}::{}", name.to_string(), case.ident.name);
         debug!("handling variant {}: {:?}", case_name, case);
-        self.ensure_struct(&case_name, None, |tcx, _| {
+        self.ensure_struct(&case_name, NO_PRETTY_NAME, |tcx, _| {
             tcx.codegen_variant_struct_fields(case, subst, variant, initial_offset)
         })
     }
@@ -1208,7 +1215,10 @@ impl<'tcx> GotocCtx<'tcx> {
                             ident = name;
                         }
                     }
-                    Some(self.codegen_ty(*t).as_parameter(Some(ident.to_string()), Some(ident)))
+                    Some(
+                        self.codegen_ty(*t)
+                            .as_parameter(Some(ident.clone().into()), Some(ident.into())),
+                    )
                 }
             })
             .collect();
@@ -1218,9 +1228,9 @@ impl<'tcx> GotocCtx<'tcx> {
         // and similar code in compiler/rustc_mir/src/shim.rs.
         if let ty::InstanceDef::VtableShim(..) = self.current_fn().instance().def {
             if let Some(self_param) = params.first() {
-                let ident = self_param.identifier().map(|i| i.to_string());
+                let ident = self_param.identifier();
                 let ty = self_param.typ().clone();
-                params[0] = ty.to_pointer().as_parameter(ident.clone(), ident);
+                params[0] = ty.to_pointer().as_parameter(ident, ident);
             }
         }
 
@@ -1243,17 +1253,16 @@ impl<'tcx> GotocCtx<'tcx> {
 /// Use maps instead of lists to manage mir struct components.
 impl<'tcx> GotocCtx<'tcx> {
     /// A mapping from mir field names to mir field types for a mir struct (for a single-variant adt)
-    pub fn mir_struct_field_types(&self, struct_type: Ty<'tcx>) -> BTreeMap<String, Ty<'tcx>> {
+    pub fn mir_struct_field_types(
+        &self,
+        struct_type: Ty<'tcx>,
+    ) -> BTreeMap<InternedString, Ty<'tcx>> {
         match struct_type.kind() {
             ty::Adt(adt_def, adt_substs) if adt_def.variants.len() == 1 => {
                 let fields = &adt_def.variants.get(VariantIdx::from_u32(0)).unwrap().fields;
-                let mut map: BTreeMap<String, Ty<'tcx>> = BTreeMap::new();
-                map.extend(
-                    fields.iter().map(|field| {
-                        (field.ident.name.to_string(), field.ty(self.tcx, adt_substs))
-                    }),
-                );
-                map
+                BTreeMap::from_iter(fields.iter().map(|field| {
+                    (field.ident.name.to_string().into(), field.ty(self.tcx, adt_substs))
+                }))
             }
             _ => unreachable!("Expected a single-variant ADT. Found {:?}", struct_type),
         }

--- a/compiler/rustc_codegen_rmc/src/context/goto_ctx.rs
+++ b/compiler/rustc_codegen_rmc/src/context/goto_ctx.rs
@@ -13,12 +13,12 @@
 //!   2. Provides constructors, getters and setters for the context.
 //! Any MIR specific functionality (e.g. codegen etc) should live in specialized files that use
 //! this structure as input.
-
 use super::current_fn::CurrentFnCtx;
 use crate::overrides::{fn_hooks, GotocHooks};
 use crate::utils::full_crate_name;
 use cbmc::goto_program::{DatatypeComponent, Expr, Location, Stmt, Symbol, SymbolTable, Type};
-use cbmc::utils::aggr_name;
+use cbmc::utils::aggr_tag;
+use cbmc::{InternStringOption, InternedString, NO_PRETTY_NAME};
 use cbmc::{MachineModel, RoundingMode};
 use rustc_data_structures::owning_ref::OwningRef;
 use rustc_data_structures::rustc_erase_owner;
@@ -101,7 +101,7 @@ impl<'tcx> GotocCtx<'tcx> {
     ) -> Symbol {
         let base_name = format!("{}_{}", prefix, c);
         let name = format!("{}::1::{}", fname, base_name);
-        let symbol = Symbol::variable(name.to_string(), base_name, t, loc);
+        let symbol = Symbol::variable(name, base_name, t, loc);
         self.symbol_table.insert(symbol.clone());
         symbol
     }
@@ -117,11 +117,15 @@ impl<'tcx> GotocCtx<'tcx> {
 impl<'tcx> GotocCtx<'tcx> {
     /// Ensures that the `name` appears in the Symbol table.
     /// If it doesn't, inserts it using `f`.
-    pub fn ensure<F: FnOnce(&mut GotocCtx<'tcx>, &str) -> Symbol>(
+    pub fn ensure<
+        F: FnOnce(&mut GotocCtx<'tcx>, InternedString) -> Symbol,
+        T: Into<InternedString>,
+    >(
         &mut self,
-        name: &str,
+        name: T,
         f: F,
     ) -> &Symbol {
+        let name = name.into();
         if !self.symbol_table.contains(name) {
             let sym = f(self, name);
             self.symbol_table.insert(sym);
@@ -133,21 +137,25 @@ impl<'tcx> GotocCtx<'tcx> {
     /// If it doesn't, inserts it.
     /// If `init_fn` returns `Some(body)`, creates an initializer for the variable using `body`.
     /// Otherwise, leaves the variable uninitialized .
-    pub fn ensure_global_var<F: FnOnce(&mut GotocCtx<'tcx>, Expr) -> Option<Stmt>>(
+    pub fn ensure_global_var<
+        F: FnOnce(&mut GotocCtx<'tcx>, Expr) -> Option<Stmt>,
+        T: Into<InternedString>,
+    >(
         &mut self,
-        name: &str,
+        name: T,
         is_file_local: bool,
         t: Type,
         loc: Location,
         init_fn: F,
     ) -> Expr {
+        let name = name.into();
         if !self.symbol_table.contains(name) {
-            let sym = Symbol::static_variable(name.to_string(), name.to_string(), t.clone(), loc)
+            let sym = Symbol::static_variable(name, name, t.clone(), loc)
                 .with_is_file_local(is_file_local);
             let var = sym.to_expr();
             self.symbol_table.insert(sym);
             if let Some(body) = init_fn(self, var) {
-                self.register_initializer(name, body);
+                self.register_initializer(&name.to_string(), body);
             }
         }
         self.symbol_table.lookup(name).unwrap().to_expr()
@@ -156,17 +164,26 @@ impl<'tcx> GotocCtx<'tcx> {
     /// Ensures that a struct with name `struct_name` appears in the symbol table.
     /// If it doesn't, inserts it using `f`.
     /// Returns: a struct-tag referencing the inserted struct.
-    pub fn ensure_struct<F: FnOnce(&mut GotocCtx<'tcx>, &str) -> Vec<DatatypeComponent>>(
+
+    pub fn ensure_struct<
+        T: Into<InternedString>,
+        U: Into<InternedString>,
+        F: FnOnce(&mut GotocCtx<'tcx>, InternedString) -> Vec<DatatypeComponent>,
+    >(
         &mut self,
-        struct_name: &str,
-        pretty_name: Option<String>,
+        struct_name: T,
+        pretty_name: Option<U>,
         f: F,
     ) -> Type {
+        let struct_name = struct_name.into();
+
         assert!(!struct_name.starts_with("tag-"));
-        if !self.symbol_table.contains(&aggr_name(struct_name)) {
+        if !self.symbol_table.contains(aggr_tag(struct_name)) {
+            let pretty_name = pretty_name.intern();
             // Prevent recursion by inserting an incomplete value.
             self.symbol_table.insert(Symbol::incomplete_struct(struct_name, pretty_name.clone()));
             let components = f(self, struct_name);
+            let struct_name: InternedString = struct_name;
             let sym = Symbol::struct_type(struct_name, pretty_name, components);
             self.symbol_table.replace_with_completion(sym);
         }
@@ -176,16 +193,22 @@ impl<'tcx> GotocCtx<'tcx> {
     /// Ensures that a union with name `union_name` appears in the symbol table.
     /// If it doesn't, inserts it using `f`.
     /// Returns: a union-tag referencing the inserted struct.
-    pub fn ensure_union<F: FnOnce(&mut GotocCtx<'tcx>, &str) -> Vec<DatatypeComponent>>(
+    pub fn ensure_union<
+        T: Into<InternedString>,
+        U: Into<InternedString>,
+        F: FnOnce(&mut GotocCtx<'tcx>, InternedString) -> Vec<DatatypeComponent>,
+    >(
         &mut self,
-        union_name: &str,
-        pretty_name: Option<String>,
+        union_name: T,
+        pretty_name: Option<U>,
         f: F,
     ) -> Type {
+        let union_name = union_name.into();
+        let pretty_name = pretty_name.intern();
         assert!(!union_name.starts_with("tag-"));
-        if !self.symbol_table.contains(&aggr_name(union_name)) {
+        if !self.symbol_table.contains(aggr_tag(union_name)) {
             // Prevent recursion by inserting an incomplete value.
-            self.symbol_table.insert(Symbol::incomplete_union(union_name, pretty_name.clone()));
+            self.symbol_table.insert(Symbol::incomplete_union(union_name, pretty_name));
             let components = f(self, union_name);
             let sym = Symbol::union_type(union_name, pretty_name, components);
             self.symbol_table.replace_with_completion(sym);
@@ -193,8 +216,8 @@ impl<'tcx> GotocCtx<'tcx> {
         Type::union_tag(union_name)
     }
 
-    pub fn find_function(&mut self, fname: &str) -> Option<Expr> {
-        self.symbol_table.lookup(&fname).map(|s| s.to_expr())
+    pub fn find_function<T: Into<InternedString>>(&mut self, fname: T) -> Option<Expr> {
+        self.symbol_table.lookup(fname).map(|s| s.to_expr())
     }
 
     /// Makes a __attribute__((constructor)) fnname() {body} initalizer function
@@ -205,7 +228,7 @@ impl<'tcx> GotocCtx<'tcx> {
                 &fn_name,
                 Type::code(vec![], Type::constructor()),
                 Some(Stmt::block(vec![body], Location::none())), //TODO is this block needed?
-                None,
+                NO_PRETTY_NAME,
                 Location::none(),
             )
             .with_is_file_local(true)

--- a/compiler/rustc_codegen_rmc/src/overrides/hooks.rs
+++ b/compiler/rustc_codegen_rmc/src/overrides/hooks.rs
@@ -11,6 +11,7 @@
 use crate::utils::{instance_name_is, instance_name_starts_with};
 use crate::GotocCtx;
 use cbmc::goto_program::{BuiltinFn, Expr, Location, Stmt, Symbol, Type};
+use cbmc::NO_PRETTY_NAME;
 use rustc_middle::mir::{BasicBlock, Place};
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::print::with_no_trimmed_paths;
@@ -370,7 +371,7 @@ impl<'tcx> GotocHook<'tcx> for MemSwap {
                     Type::empty(),
                 ),
                 Some(Stmt::block(block, loc.clone())),
-                None,
+                NO_PRETTY_NAME,
                 Location::none(),
             )
         });

--- a/compiler/rustc_codegen_rmc/src/utils/names.rs
+++ b/compiler/rustc_codegen_rmc/src/utils/names.rs
@@ -4,6 +4,7 @@
 //! Functions that make names for things
 
 use crate::GotocCtx;
+use cbmc::InternedString;
 use rustc_hir::def_id::DefId;
 use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_hir::definitions::DefPathDataName;
@@ -103,10 +104,10 @@ impl<'tcx> GotocCtx<'tcx> {
     /// InstanceDef::Virtual(def_id, idx). We could use solely the index as a key into
     /// the vtable struct, but we add the method name for debugging readability.
     ///     Example: 3_vol
-    pub fn vtable_field_name(&self, _def_id: DefId, idx: usize) -> String {
+    pub fn vtable_field_name(&self, _def_id: DefId, idx: usize) -> InternedString {
         // format!("{}_{}", idx, with_no_trimmed_paths(|| self.tcx.item_name(def_id)))
         // TODO: use def_id https://github.com/model-checking/rmc/issues/364
-        idx.to_string()
+        idx.to_string().into()
     }
 }
 

--- a/compiler/rustc_codegen_rmc/src/utils/utils.rs
+++ b/compiler/rustc_codegen_rmc/src/utils/utils.rs
@@ -146,7 +146,7 @@ impl<'tcx> GotocCtx<'tcx> {
         let components = self.symbol_table.lookup_components_in_type(t).unwrap();
         assert_eq!(components.len(), 2);
         for c in components {
-            match c.name() {
+            match c.name().to_string().as_str() {
                 "0" => self.assert_is_rust_unique_pointer_like(&c.typ()),
                 "1" => self.assert_is_rust_global_alloc_like(&c.typ()),
                 _ => panic!("Unexpected component {} in {:?}", c.name(), t),
@@ -167,7 +167,7 @@ impl<'tcx> GotocCtx<'tcx> {
         let components = self.symbol_table.lookup_components_in_type(t).unwrap();
         assert_eq!(components.len(), 2);
         for c in components {
-            match c.name() {
+            match c.name().to_string().as_str() {
                 "_marker" => self.assert_is_rust_phantom_data_like(&c.typ()),
                 "pointer" => {
                     assert!(c.typ().is_pointer() || c.typ().is_rust_fat_ptr(&self.symbol_table))


### PR DESCRIPTION
### Description of changes: 

CBMC objects to have a large number of strings which refer to names: symbols, files, etc.
These tend to be reused many times, which causes signifcant memory usage.
If we intern the strings, each unique string is only allocated once, saving memory.### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

I tried to use generics to allow interfaces not to care if they're called with `&str`, `String` or `InternedString`

Before: 
```
        Maximum resident set size (kbytes): 1024148
```

After:

```
Maximum resident set size (kbytes): 877736
```

### Testing:

* How is this change tested? Existing tests, plus additional unit test

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
