### PR TITLE
Swap to Vec instead of BTreeMap in Irep to reduce memory usage

### DIFF
--- a/compiler/cbmc/src/irep/to_irep.rs
+++ b/compiler/cbmc/src/irep/to_irep.rs
@@ -1,11 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Converts a typed goto-program into the `Irep` serilization format of CBMC
-// TODO: consider making a macro to replace `btree_map![])` for initilizing btrees.
 use super::super::goto_program;
 use super::super::MachineModel;
 use super::{Irep, IrepId};
-use crate::btree_map;
 use goto_program::{
     BinaryOperand, CIntType, DatatypeComponent, Expr, ExprValue, Location, Parameter, SelfOperand,
     Stmt, StmtBody, SwitchCase, SymbolValues, Type, UnaryOperand,
@@ -20,21 +18,21 @@ fn arguments_irep(arguments: &[Expr], mm: &MachineModel) -> Irep {
     Irep {
         id: IrepId::Arguments,
         sub: arguments.iter().map(|x| x.to_irep(mm)).collect(),
-        named_sub: btree_map![],
+        named_sub: vec![],
     }
 }
 fn code_irep(kind: IrepId, ops: Vec<Irep>) -> Irep {
     Irep {
         id: IrepId::Code,
         sub: ops,
-        named_sub: btree_map![(IrepId::Statement, Irep::just_id(kind))],
+        named_sub: vec![(IrepId::Statement, Irep::just_id(kind))],
     }
 }
 fn side_effect_irep(kind: IrepId, ops: Vec<Irep>) -> Irep {
     Irep {
         id: IrepId::SideEffect,
         sub: ops,
-        named_sub: btree_map![(IrepId::Statement, Irep::just_id(kind))],
+        named_sub: vec![(IrepId::Statement, Irep::just_id(kind))],
     }
 }
 fn switch_default_irep(body: &Stmt, mm: &MachineModel) -> Irep {
@@ -116,12 +114,12 @@ impl ToIrepId for UnaryOperand {
 impl ToIrep for DatatypeComponent {
     fn to_irep(&self, mm: &MachineModel) -> Irep {
         match self {
-            DatatypeComponent::Field { name, typ } => Irep::just_named_sub(btree_map![
+            DatatypeComponent::Field { name, typ } => Irep::just_named_sub(vec![
                 (IrepId::Name, Irep::just_string_id(name.to_string())),
                 (IrepId::PrettyName, Irep::just_string_id(name.to_string())),
                 (IrepId::Type, typ.to_irep(mm)),
             ]),
-            DatatypeComponent::Padding { name, bits } => Irep::just_named_sub(btree_map![
+            DatatypeComponent::Padding { name, bits } => Irep::just_named_sub(vec![
                 (IrepId::CIsPadding, Irep::one()),
                 (IrepId::Name, Irep::just_string_id(name.to_string())),
                 (IrepId::Type, Type::unsigned_int(*bits).to_irep(mm)),
@@ -140,15 +138,15 @@ impl ToIrep for ExprValue {
     fn to_irep(&self, mm: &MachineModel) -> Irep {
         match self {
             ExprValue::AddressOf(e) => {
-                Irep { id: IrepId::AddressOf, sub: vec![e.to_irep(mm)], named_sub: btree_map![] }
+                Irep { id: IrepId::AddressOf, sub: vec![e.to_irep(mm)], named_sub: vec![] }
             }
             ExprValue::Array { elems } => Irep {
                 id: IrepId::Array,
                 sub: elems.iter().map(|x| x.to_irep(mm)).collect(),
-                named_sub: btree_map![],
+                named_sub: vec![],
             },
             ExprValue::ArrayOf { elem } => {
-                Irep { id: IrepId::ArrayOf, sub: vec![elem.to_irep(mm)], named_sub: btree_map![] }
+                Irep { id: IrepId::ArrayOf, sub: vec![elem.to_irep(mm)], named_sub: vec![] }
             }
             ExprValue::Assign { left, right } => {
                 side_effect_irep(IrepId::Assign, vec![left.to_irep(mm), right.to_irep(mm)])
@@ -156,12 +154,12 @@ impl ToIrep for ExprValue {
             ExprValue::BinOp { op, lhs, rhs } => Irep {
                 id: op.to_irep_id(),
                 sub: vec![lhs.to_irep(mm), rhs.to_irep(mm)],
-                named_sub: btree_map![],
+                named_sub: vec![],
             },
             ExprValue::BoolConstant(c) => Irep {
                 id: IrepId::Constant,
                 sub: vec![],
-                named_sub: btree_map![(
+                named_sub: vec![(
                     IrepId::Value,
                     if *c { Irep::just_id(IrepId::True) } else { Irep::just_id(IrepId::False) },
                 )],
@@ -173,15 +171,15 @@ impl ToIrep for ExprValue {
                     IrepId::ByteExtractLittleEndian
                 },
                 sub: vec![e.to_irep(mm), Expr::int_constant(*offset, Type::ssize_t()).to_irep(mm)],
-                named_sub: btree_map![],
+                named_sub: vec![],
             },
             ExprValue::CBoolConstant(i) => Irep {
                 id: IrepId::Constant,
                 sub: vec![],
-                named_sub: btree_map![(IrepId::Value, Irep::just_hex_id(if *i { 1 } else { 0 }),)],
+                named_sub: vec![(IrepId::Value, Irep::just_hex_id(if *i { 1 } else { 0 }),)],
             },
             ExprValue::Dereference(e) => {
-                Irep { id: IrepId::Dereference, sub: vec![e.to_irep(mm)], named_sub: btree_map![] }
+                Irep { id: IrepId::Dereference, sub: vec![e.to_irep(mm)], named_sub: vec![] }
             }
             //TODO, determine if there is an endineness problem here
             ExprValue::DoubleConstant(i) => {
@@ -189,7 +187,7 @@ impl ToIrep for ExprValue {
                 Irep {
                     id: IrepId::Constant,
                     sub: vec![],
-                    named_sub: btree_map![(IrepId::Value, Irep::just_hex_id(c))],
+                    named_sub: vec![(IrepId::Value, Irep::just_hex_id(c))],
                 }
             }
             ExprValue::FloatConstant(i) => {
@@ -197,7 +195,7 @@ impl ToIrep for ExprValue {
                 Irep {
                     id: IrepId::Constant,
                     sub: vec![],
-                    named_sub: btree_map![(IrepId::Value, Irep::just_hex_id(c))],
+                    named_sub: vec![(IrepId::Value, Irep::just_hex_id(c))],
                 }
             }
             ExprValue::FunctionCall { function, arguments } => side_effect_irep(
@@ -207,22 +205,22 @@ impl ToIrep for ExprValue {
             ExprValue::If { c, t, e } => Irep {
                 id: IrepId::If,
                 sub: vec![c.to_irep(mm), t.to_irep(mm), e.to_irep(mm)],
-                named_sub: btree_map![],
+                named_sub: vec![],
             },
             ExprValue::Index { array, index } => Irep {
                 id: IrepId::Index,
                 sub: vec![array.to_irep(mm), index.to_irep(mm)],
-                named_sub: btree_map![],
+                named_sub: vec![],
             },
             ExprValue::IntConstant(i) => Irep {
                 id: IrepId::Constant,
                 sub: vec![],
-                named_sub: btree_map![(IrepId::Value, Irep::just_hex_id(i.clone()))],
+                named_sub: vec![(IrepId::Value, Irep::just_hex_id(i.clone()))],
             },
             ExprValue::Member { lhs, field } => Irep {
                 id: IrepId::Member,
                 sub: vec![lhs.to_irep(mm)],
-                named_sub: btree_map![
+                named_sub: vec![
                     (IrepId::CLvalue, Irep::one()),
                     (IrepId::ComponentName, Irep::just_string_id(field.to_string())),
                 ],
@@ -231,7 +229,7 @@ impl ToIrep for ExprValue {
             ExprValue::PointerConstant(i) => Irep {
                 id: IrepId::Constant,
                 sub: vec![],
-                named_sub: btree_map![(IrepId::Value, Irep::just_hex_id(*i))],
+                named_sub: vec![(IrepId::Value, Irep::just_hex_id(*i))],
             },
             ExprValue::SelfOp { op, e } => side_effect_irep(op.to_irep_id(), vec![e.to_irep(mm)]),
             ExprValue::StatementExpression { statements: ops } => side_effect_irep(
@@ -241,28 +239,28 @@ impl ToIrep for ExprValue {
             ExprValue::StringConstant { s } => Irep {
                 id: IrepId::StringConstant,
                 sub: vec![],
-                named_sub: btree_map![(IrepId::Value, Irep::just_string_id(s.to_string()),)],
+                named_sub: vec![(IrepId::Value, Irep::just_string_id(s.to_string()),)],
             },
             ExprValue::Struct { values } => Irep {
                 id: IrepId::Struct,
                 sub: values.iter().map(|x| x.to_irep(mm)).collect(),
-                named_sub: btree_map![],
+                named_sub: vec![],
             },
             ExprValue::Symbol { identifier } => Irep {
                 id: IrepId::Symbol,
                 sub: vec![],
-                named_sub: btree_map![(
+                named_sub: vec![(
                     IrepId::Identifier,
                     Irep::just_string_id(identifier.to_string()),
                 )],
             },
             ExprValue::Typecast(e) => {
-                Irep { id: IrepId::Typecast, sub: vec![e.to_irep(mm)], named_sub: btree_map![] }
+                Irep { id: IrepId::Typecast, sub: vec![e.to_irep(mm)], named_sub: vec![] }
             }
             ExprValue::Union { value, field } => Irep {
                 id: IrepId::Union,
                 sub: vec![value.to_irep(mm)],
-                named_sub: btree_map![(
+                named_sub: vec![(
                     IrepId::ComponentName,
                     Irep::just_string_id(field.to_string()),
                 )],
@@ -270,12 +268,12 @@ impl ToIrep for ExprValue {
             ExprValue::UnOp { op: UnaryOperand::Bswap, e } => Irep {
                 id: IrepId::Bswap,
                 sub: vec![e.to_irep(mm)],
-                named_sub: btree_map![(IrepId::BitsPerByte, Irep::just_int_id(8))],
+                named_sub: vec![(IrepId::BitsPerByte, Irep::just_int_id(8))],
             },
             ExprValue::UnOp { op: UnaryOperand::CountLeadingZeros { allow_zero }, e } => Irep {
                 id: IrepId::CountLeadingZeros,
                 sub: vec![e.to_irep(mm)],
-                named_sub: btree_map![(
+                named_sub: vec![(
                     IrepId::CBoundsCheck,
                     if *allow_zero { Irep::zero() } else { Irep::one() }
                 )],
@@ -283,18 +281,18 @@ impl ToIrep for ExprValue {
             ExprValue::UnOp { op: UnaryOperand::CountTrailingZeros { allow_zero }, e } => Irep {
                 id: IrepId::CountTrailingZeros,
                 sub: vec![e.to_irep(mm)],
-                named_sub: btree_map![(
+                named_sub: vec![(
                     IrepId::CBoundsCheck,
                     if *allow_zero { Irep::zero() } else { Irep::one() }
                 )],
             },
             ExprValue::UnOp { op, e } => {
-                Irep { id: op.to_irep_id(), sub: vec![e.to_irep(mm)], named_sub: btree_map![] }
+                Irep { id: op.to_irep_id(), sub: vec![e.to_irep(mm)], named_sub: vec![] }
             }
             ExprValue::Vector { elems } => Irep {
                 id: IrepId::Vector,
                 sub: elems.iter().map(|x| x.to_irep(mm)).collect(),
-                named_sub: btree_map![],
+                named_sub: vec![],
             },
         }
     }
@@ -304,7 +302,7 @@ impl ToIrep for Location {
     fn to_irep(&self, _mm: &MachineModel) -> Irep {
         match self {
             Location::None => Irep::nil(),
-            Location::BuiltinFunction { line, function_name } => Irep::just_named_sub(btree_map![
+            Location::BuiltinFunction { line, function_name } => Irep::just_named_sub(vec![
                 (
                     IrepId::File,
                     Irep::just_string_id(format!("<builtin-library-{}>", function_name)),
@@ -312,7 +310,7 @@ impl ToIrep for Location {
                 (IrepId::Function, Irep::just_string_id(function_name.to_string())),
             ])
             .with_named_sub_option(IrepId::Line, line.map(Irep::just_int_id)),
-            Location::Loc { file, function, line, col } => Irep::just_named_sub(btree_map![
+            Location::Loc { file, function, line, col } => Irep::just_named_sub(vec![
                 (IrepId::File, Irep::just_string_id(file.to_string())),
                 (IrepId::Line, Irep::just_int_id(*line)),
             ])
@@ -327,7 +325,7 @@ impl ToIrep for Parameter {
         Irep {
             id: IrepId::Parameter,
             sub: vec![],
-            named_sub: btree_map![(IrepId::Type, self.typ().to_irep(mm))],
+            named_sub: vec![(IrepId::Type, self.typ().to_irep(mm))],
         }
         .with_named_sub_option(
             IrepId::CIdentifier,
@@ -493,45 +491,45 @@ impl ToIrep for Type {
                 Irep {
                     id: IrepId::Array,
                     sub: vec![typ.to_irep(mm)],
-                    named_sub: btree_map![(IrepId::Size, size.to_irep(mm))],
+                    named_sub: vec![(IrepId::Size, size.to_irep(mm))],
                 }
             }
             //TODO make from_irep that matches this.
             Type::CBitField { typ, width } => Irep {
                 id: IrepId::CBitField,
                 sub: vec![typ.to_irep(mm)],
-                named_sub: btree_map![(IrepId::Width, Irep::just_int_id(*width))],
+                named_sub: vec![(IrepId::Width, Irep::just_int_id(*width))],
             },
             Type::Bool => Irep::just_id(IrepId::Bool),
             Type::CInteger(CIntType::Bool) => Irep {
                 id: IrepId::CBool,
                 sub: vec![],
-                named_sub: btree_map![(IrepId::Width, Irep::just_int_id(mm.bool_width()))],
+                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.bool_width()))],
             },
             Type::CInteger(CIntType::Char) => Irep {
                 id: if mm.char_is_unsigned() { IrepId::Unsignedbv } else { IrepId::Signedbv },
                 sub: vec![],
-                named_sub: btree_map![(IrepId::Width, Irep::just_int_id(mm.char_width()),)],
+                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.char_width()),)],
             },
             Type::CInteger(CIntType::Int) => Irep {
                 id: IrepId::Signedbv,
                 sub: vec![],
-                named_sub: btree_map![(IrepId::Width, Irep::just_int_id(mm.int_width()),)],
+                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.int_width()),)],
             },
             Type::CInteger(CIntType::SizeT) => Irep {
                 id: IrepId::Unsignedbv,
                 sub: vec![],
-                named_sub: btree_map![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
+                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
             },
             Type::CInteger(CIntType::SSizeT) => Irep {
                 id: IrepId::Signedbv,
                 sub: vec![],
-                named_sub: btree_map![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
+                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
             },
             Type::Code { parameters, return_type } => Irep {
                 id: IrepId::Code,
                 sub: vec![],
-                named_sub: btree_map![
+                named_sub: vec![
                     (
                         IrepId::Parameters,
                         Irep::just_sub(parameters.iter().map(|x| x.to_irep(mm)).collect()),
@@ -543,7 +541,7 @@ impl ToIrep for Type {
             Type::Double => Irep {
                 id: IrepId::Floatbv,
                 sub: vec![],
-                named_sub: btree_map![
+                named_sub: vec![
                     (IrepId::F, Irep::just_int_id(52)),
                     (IrepId::Width, Irep::just_int_id(64)),
                     (IrepId::CCType, Irep::just_id(IrepId::Double)),
@@ -557,13 +555,13 @@ impl ToIrep for Type {
                 Irep {
                     id: IrepId::Array,
                     sub: vec![typ.to_irep(mm)],
-                    named_sub: btree_map![(IrepId::Size, size.to_irep(mm))],
+                    named_sub: vec![(IrepId::Size, size.to_irep(mm))],
                 }
             }
             Type::Float => Irep {
                 id: IrepId::Floatbv,
                 sub: vec![],
-                named_sub: btree_map![
+                named_sub: vec![
                     (IrepId::F, Irep::just_int_id(23)),
                     (IrepId::Width, Irep::just_int_id(32)),
                     (IrepId::CCType, Irep::just_id(IrepId::Float)),
@@ -572,7 +570,7 @@ impl ToIrep for Type {
             Type::IncompleteStruct { tag } => Irep {
                 id: IrepId::Struct,
                 sub: vec![],
-                named_sub: btree_map![
+                named_sub: vec![
                     (IrepId::Tag, Irep::just_string_id(tag.to_string())),
                     (IrepId::Incomplete, Irep::one()),
                 ],
@@ -580,7 +578,7 @@ impl ToIrep for Type {
             Type::IncompleteUnion { tag } => Irep {
                 id: IrepId::Union,
                 sub: vec![],
-                named_sub: btree_map![
+                named_sub: vec![
                     (IrepId::Tag, Irep::just_string_id(tag.to_string())),
                     (IrepId::Incomplete, Irep::one()),
                 ],
@@ -590,23 +588,23 @@ impl ToIrep for Type {
                 Irep {
                     id: IrepId::Array,
                     sub: vec![typ.to_irep(mm)],
-                    named_sub: btree_map![(IrepId::Size, infinity)],
+                    named_sub: vec![(IrepId::Size, infinity)],
                 }
             }
             Type::Pointer { typ } => Irep {
                 id: IrepId::Pointer,
                 sub: vec![typ.to_irep(mm)],
-                named_sub: btree_map![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
+                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
             },
             Type::Signedbv { width } => Irep {
                 id: IrepId::Signedbv,
                 sub: vec![],
-                named_sub: btree_map![(IrepId::Width, Irep::just_int_id(*width))],
+                named_sub: vec![(IrepId::Width, Irep::just_int_id(*width))],
             },
             Type::Struct { tag, components } => Irep {
                 id: IrepId::Struct,
                 sub: vec![],
-                named_sub: btree_map![
+                named_sub: vec![
                     (IrepId::Tag, Irep::just_string_id(tag.to_string())),
                     (
                         IrepId::Components,
@@ -617,14 +615,14 @@ impl ToIrep for Type {
             Type::StructTag(name) => Irep {
                 id: IrepId::StructTag,
                 sub: vec![],
-                named_sub: btree_map![
+                named_sub: vec![
                     (IrepId::Identifier, Irep::just_string_id(name.to_string()),)
                 ],
             },
             Type::Union { tag, components } => Irep {
                 id: IrepId::Union,
                 sub: vec![],
-                named_sub: btree_map![
+                named_sub: vec![
                     (IrepId::Tag, Irep::just_string_id(tag.to_string())),
                     (
                         IrepId::Components,
@@ -635,19 +633,19 @@ impl ToIrep for Type {
             Type::UnionTag(name) => Irep {
                 id: IrepId::UnionTag,
                 sub: vec![],
-                named_sub: btree_map![
+                named_sub: vec![
                     (IrepId::Identifier, Irep::just_string_id(name.to_string()),)
                 ],
             },
             Type::Unsignedbv { width } => Irep {
                 id: IrepId::Unsignedbv,
                 sub: Vec::new(),
-                named_sub: btree_map![(IrepId::Width, Irep::just_int_id(*width))],
+                named_sub: vec![(IrepId::Width, Irep::just_int_id(*width))],
             },
             Type::VariadicCode { parameters, return_type } => Irep {
                 id: IrepId::Code,
                 sub: vec![],
-                named_sub: btree_map![
+                named_sub: vec![
                     (
                         IrepId::Parameters,
                         Irep::just_sub(parameters.iter().map(|x| x.to_irep(mm)).collect())
@@ -661,7 +659,7 @@ impl ToIrep for Type {
                 Irep {
                     id: IrepId::Vector,
                     sub: vec![typ.to_irep(mm)],
-                    named_sub: btree_map![(IrepId::Size, size.to_irep(mm))],
+                    named_sub: vec![(IrepId::Size, size.to_irep(mm))],
                 }
             }
         }

--- a/compiler/cbmc/src/irep/to_irep.rs
+++ b/compiler/cbmc/src/irep/to_irep.rs
@@ -22,11 +22,7 @@ fn arguments_irep(arguments: &[Expr], mm: &MachineModel) -> Irep {
     }
 }
 fn code_irep(kind: IrepId, ops: Vec<Irep>) -> Irep {
-    Irep {
-        id: IrepId::Code,
-        sub: ops,
-        named_sub: vec![(IrepId::Statement, Irep::just_id(kind))],
-    }
+    Irep { id: IrepId::Code, sub: ops, named_sub: vec![(IrepId::Statement, Irep::just_id(kind))] }
 }
 fn side_effect_irep(kind: IrepId, ops: Vec<Irep>) -> Irep {
     Irep {
@@ -176,7 +172,7 @@ impl ToIrep for ExprValue {
             ExprValue::CBoolConstant(i) => Irep {
                 id: IrepId::Constant,
                 sub: vec![],
-                named_sub: vec![(IrepId::Value, Irep::just_hex_id(if *i { 1 } else { 0 }),)],
+                named_sub: vec![(IrepId::Value, Irep::just_hex_id(if *i { 1 } else { 0 }))],
             },
             ExprValue::Dereference(e) => {
                 Irep { id: IrepId::Dereference, sub: vec![e.to_irep(mm)], named_sub: vec![] }
@@ -239,7 +235,7 @@ impl ToIrep for ExprValue {
             ExprValue::StringConstant { s } => Irep {
                 id: IrepId::StringConstant,
                 sub: vec![],
-                named_sub: vec![(IrepId::Value, Irep::just_string_id(s.to_string()),)],
+                named_sub: vec![(IrepId::Value, Irep::just_string_id(s.to_string()))],
             },
             ExprValue::Struct { values } => Irep {
                 id: IrepId::Struct,
@@ -249,10 +245,7 @@ impl ToIrep for ExprValue {
             ExprValue::Symbol { identifier } => Irep {
                 id: IrepId::Symbol,
                 sub: vec![],
-                named_sub: vec![(
-                    IrepId::Identifier,
-                    Irep::just_string_id(identifier.to_string()),
-                )],
+                named_sub: vec![(IrepId::Identifier, Irep::just_string_id(identifier.to_string()))],
             },
             ExprValue::Typecast(e) => {
                 Irep { id: IrepId::Typecast, sub: vec![e.to_irep(mm)], named_sub: vec![] }
@@ -260,10 +253,7 @@ impl ToIrep for ExprValue {
             ExprValue::Union { value, field } => Irep {
                 id: IrepId::Union,
                 sub: vec![value.to_irep(mm)],
-                named_sub: vec![(
-                    IrepId::ComponentName,
-                    Irep::just_string_id(field.to_string()),
-                )],
+                named_sub: vec![(IrepId::ComponentName, Irep::just_string_id(field.to_string()))],
             },
             ExprValue::UnOp { op: UnaryOperand::Bswap, e } => Irep {
                 id: IrepId::Bswap,
@@ -275,7 +265,7 @@ impl ToIrep for ExprValue {
                 sub: vec![e.to_irep(mm)],
                 named_sub: vec![(
                     IrepId::CBoundsCheck,
-                    if *allow_zero { Irep::zero() } else { Irep::one() }
+                    if *allow_zero { Irep::zero() } else { Irep::one() },
                 )],
             },
             ExprValue::UnOp { op: UnaryOperand::CountTrailingZeros { allow_zero }, e } => Irep {
@@ -283,7 +273,7 @@ impl ToIrep for ExprValue {
                 sub: vec![e.to_irep(mm)],
                 named_sub: vec![(
                     IrepId::CBoundsCheck,
-                    if *allow_zero { Irep::zero() } else { Irep::one() }
+                    if *allow_zero { Irep::zero() } else { Irep::one() },
                 )],
             },
             ExprValue::UnOp { op, e } => {
@@ -509,22 +499,22 @@ impl ToIrep for Type {
             Type::CInteger(CIntType::Char) => Irep {
                 id: if mm.char_is_unsigned() { IrepId::Unsignedbv } else { IrepId::Signedbv },
                 sub: vec![],
-                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.char_width()),)],
+                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.char_width()))],
             },
             Type::CInteger(CIntType::Int) => Irep {
                 id: IrepId::Signedbv,
                 sub: vec![],
-                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.int_width()),)],
+                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.int_width()))],
             },
             Type::CInteger(CIntType::SizeT) => Irep {
                 id: IrepId::Unsignedbv,
                 sub: vec![],
-                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
+                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.pointer_width()))],
             },
             Type::CInteger(CIntType::SSizeT) => Irep {
                 id: IrepId::Signedbv,
                 sub: vec![],
-                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
+                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.pointer_width()))],
             },
             Type::Code { parameters, return_type } => Irep {
                 id: IrepId::Code,
@@ -594,7 +584,7 @@ impl ToIrep for Type {
             Type::Pointer { typ } => Irep {
                 id: IrepId::Pointer,
                 sub: vec![typ.to_irep(mm)],
-                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.pointer_width()),)],
+                named_sub: vec![(IrepId::Width, Irep::just_int_id(mm.pointer_width()))],
             },
             Type::Signedbv { width } => Irep {
                 id: IrepId::Signedbv,
@@ -615,9 +605,7 @@ impl ToIrep for Type {
             Type::StructTag(name) => Irep {
                 id: IrepId::StructTag,
                 sub: vec![],
-                named_sub: vec![
-                    (IrepId::Identifier, Irep::just_string_id(name.to_string()),)
-                ],
+                named_sub: vec![(IrepId::Identifier, Irep::just_string_id(name.to_string()))],
             },
             Type::Union { tag, components } => Irep {
                 id: IrepId::Union,
@@ -633,9 +621,7 @@ impl ToIrep for Type {
             Type::UnionTag(name) => Irep {
                 id: IrepId::UnionTag,
                 sub: vec![],
-                named_sub: vec![
-                    (IrepId::Identifier, Irep::just_string_id(name.to_string()),)
-                ],
+                named_sub: vec![(IrepId::Identifier, Irep::just_string_id(name.to_string()))],
             },
             Type::Unsignedbv { width } => Irep {
                 id: IrepId::Unsignedbv,

--- a/compiler/cbmc/src/irep/to_json.rs
+++ b/compiler/cbmc/src/irep/to_json.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use super::{Irep, IrepId, Symbol, SymbolTable};
+use std::collections::BTreeMap;
 use crate::btree_map;
 use rustc_serialize::json::*;
 
@@ -11,7 +12,11 @@ impl ToJson for Irep {
             output.insert("sub".to_string(), self.sub.to_json());
         }
         if !self.named_sub.is_empty() {
-            output.insert("namedSub".to_string(), self.named_sub.to_json());
+            let mut d = BTreeMap::new();
+            for (key, value) in &self.named_sub {
+                d.insert(key.to_string(), value.to_json());
+            }
+            output.insert("namedSub".to_string(), Json::Object(d));
         }
         Json::Object(output)
     }

--- a/compiler/cbmc/src/irep/to_json.rs
+++ b/compiler/cbmc/src/irep/to_json.rs
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 use super::{Irep, IrepId, Symbol, SymbolTable};
-use std::collections::BTreeMap;
 use crate::btree_map;
 use rustc_serialize::json::*;
+use std::collections::BTreeMap;
 
 impl ToJson for Irep {
     fn to_json(&self) -> Json {


### PR DESCRIPTION
### Description of changes: 

When running a std lib build test with `time -v` I went from

```
    Maximum resident set size (kbytes): 11866204
    Maximum resident set size (kbytes): 11866052
```

to

```
    Maximum resident set size (kbytes): 9417760
    Maximum resident set size (kbytes): 9417552
```

Which is a savings of 2.4 GB of memory. This isn't enough to unblock running this test in CI yet, but it is (a) I think a good change and (b) doesn't get in the way of the real fix Celina is working on.

(The `Json` type we use from `rustc_serialize` also uses `BTreeMap` and it likely accounts for another good 2.5GB (at least, possibly even 5GB) of wasted memory. But that's part of rustc, so let's not change that. So our savings here is despite still having to build all those BTreeMaps.)

### Resolved issues:

Part of #608. Possibly all of it, if we determine string interning there isn't the win I thought it might be.

### Call-outs:

1. We don't actually call `lookup` anywhere, it's only used in `from_irep` which we don't use in RMC normally. So a small part of this code is untested afaict.
2. There's a slight change in theoretical behavior in `with_named_sub`. If the entry was already present it would previously get updated, while now we'd "duplicate" it. I did inspect all uses of this function, and we don't have any place where we're trying to do an "update" with this function, so there's no issue right now, but that's possibly a future footgun?
3. I think we should merge only if we think this is a good representation change. I think it is, but the memory savings won't be as important (I think) once the streaming-serialization fix is in.

### Testing:

* How is this change tested? existing regression suite

* Is this a refactor change? yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
