### PR TITLE
Remove `panic::Location::<'a>::caller` from skippable functions

### DIFF
--- a/compiler/rustc_codegen_rmc/src/codegen/function.rs
+++ b/compiler/rustc_codegen_rmc/src/codegen/function.rs
@@ -17,8 +17,6 @@ impl<'tcx> GotocCtx<'tcx> {
             "fmt::ArgumentV1::<'a>::as_usize" => true,
             // https://github.com/model-checking/rmc/issues/204
             name if name.ends_with("__getit") => true,
-            // https://github.com/model-checking/rmc/issues/205
-            "panic::Location::<'a>::caller" => true,
             // https://github.com/model-checking/rmc/issues/281
             name if name.starts_with("bridge::client") => true,
             // https://github.com/model-checking/rmc/issues/282


### PR DESCRIPTION
### Description of changes: 

Remove `panic::Location::<'a>::caller` from the list of functions to skip.

In #376 it was implemented as `codegen_unimplemented_intrinsic`. #374 is open for handling it.

### Resolved issues:

Resolves #205 

### Call-outs:

Waiting for `std-lib-regression.sh` to be fixed in #593 so CI shows no issues with std-lib codegen.
<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Running `std-lib-regression.sh` with changes similar to #593 

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
