### PR TITLE
Get rid of skip monomorphizer hack (#485)

### DIFF
--- a/compiler/rustc_codegen_rmc/src/compiler_interface.rs
+++ b/compiler/rustc_codegen_rmc/src/compiler_interface.rs
@@ -3,8 +3,8 @@
 
 //! This file contains the code necessary to interface with the compiler backend
 
-use crate::overrides::skip_monomorphize;
 use crate::GotocCtx;
+
 use bitflags::_core::any::Any;
 use cbmc::goto_program::symtab_transformer;
 use cbmc::goto_program::SymbolTable;
@@ -46,9 +46,7 @@ impl CodegenBackend for GotocCodegenBackend {
         Box::new(rustc_codegen_ssa::back::metadata::DefaultMetadataLoader)
     }
 
-    fn provide(&self, providers: &mut Providers) {
-        providers.skip_monomorphize = skip_monomorphize;
-    }
+    fn provide(&self, _providers: &mut Providers) {}
 
     fn provide_extern(&self, _providers: &mut ty::query::ExternProviders) {}
 

--- a/compiler/rustc_codegen_rmc/src/overrides/hooks.rs
+++ b/compiler/rustc_codegen_rmc/src/overrides/hooks.rs
@@ -326,6 +326,7 @@ struct MemSwap;
 
 impl<'tcx> GotocHook<'tcx> for MemSwap {
     fn hook_applies(&self, tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
+        // We need to keep the old std / core functions here because we don't compile std yet.
         let name = with_no_trimmed_paths(|| tcx.def_path_str(instance.def_id()));
         name == "core::mem::swap"
             || name == "std::mem::swap"
@@ -687,8 +688,4 @@ impl<'tcx> GotocHooks<'tcx> {
         }
         None
     }
-}
-
-pub fn skip_monomorphize<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
-    fn_hooks().hooks.iter().any(|hook| hook.hook_applies(tcx, instance))
 }

--- a/compiler/rustc_codegen_rmc/src/overrides/mod.rs
+++ b/compiler/rustc_codegen_rmc/src/overrides/mod.rs
@@ -8,4 +8,4 @@
 
 mod hooks;
 
-pub use hooks::{fn_hooks, skip_monomorphize, GotocHooks};
+pub use hooks::{fn_hooks, GotocHooks};

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -874,7 +874,6 @@ impl CrateInfo {
 }
 
 pub fn provide(providers: &mut Providers) {
-    providers.skip_monomorphize = |_, _| false;
     providers.backend_optimization_level = |tcx, cratenum| {
         let for_speed = match tcx.sess.opts.optimize {
             // If globally no optimisation is done, #[optimize] has no effect.

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1862,11 +1862,4 @@ rustc_queries! {
         no_hash
         desc { "performing HIR wf-checking for predicate {:?} at item {:?}", key.0, key.1 }
     }
-
-    query skip_monomorphize(key: ty::Instance<'tcx>)
-        -> bool {
-        eval_always
-        no_hash
-        desc { "Check if we should skip monomorphization for `{}`", key}
-    }
 }

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -317,7 +317,6 @@ pub fn collect_crate_mono_items(
     (visited.into_inner(), inlining_map.into_inner())
 }
 
-// Temporary function that allow us to skip monomorphizing lang_start.
 // Find all non-generic items by walking the HIR. These items serve as roots to
 // start monomorphizing from.
 fn collect_roots(tcx: TyCtxt<'_>, mode: MonoItemCollectionMode) -> Vec<MonoItem<'_>> {
@@ -919,10 +918,6 @@ fn visit_instance_use<'tcx>(
 ) {
     debug!("visit_item_use({:?}, is_direct_call={:?})", instance, is_direct_call);
     if !should_codegen_locally(tcx, &instance) {
-        return;
-    }
-
-    if tcx.skip_monomorphize(instance) {
         return;
     }
 

--- a/src/test/rmc/FunctionAbstractions/mem_replace.rs
+++ b/src/test/rmc/FunctionAbstractions/mem_replace.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::mem;
+
+pub fn main() {
+    let mut var1 = rmc::nondet::<i32>();
+    let mut var2 = rmc::nondet::<i32>();
+    let old_var1 = var1;
+    unsafe {
+        assert_eq!(mem::replace(&mut var1, var2), old_var1);
+    }
+    assert_eq!(var1, var2);
+}

--- a/src/test/rmc/FunctionAbstractions/mem_swap.rs
+++ b/src/test/rmc/FunctionAbstractions/mem_swap.rs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::mem;
+
+pub fn main() {
+    let mut var1 = rmc::nondet::<i32>();
+    let mut var2 = rmc::nondet::<i32>();
+    let old_var1 = var1;
+    let old_var2 = var2;
+    unsafe {
+        mem::swap(&mut var1, &mut var2);
+    }
+    assert_eq!(var1, old_var2);
+    assert_eq!(var2, old_var1);
+}

--- a/src/test/rmc/FunctionAbstractions/ptr_read.rs
+++ b/src/test/rmc/FunctionAbstractions/ptr_read.rs
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::ptr::read;
+
+pub fn main() {
+    let var = 1;
+    unsafe {
+        assert_eq!(read(&var), var);
+    }
+}

--- a/src/test/rmc/FunctionAbstractions/ptr_write.rs
+++ b/src/test/rmc/FunctionAbstractions/ptr_write.rs
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::ptr::write;
+
+pub fn main() {
+    let mut var = 1;
+    unsafe {
+        write(&mut var, 10);
+    }
+    assert_eq!(var, 10);
+}

--- a/src/test/rmc/Never/never_return.rs
+++ b/src/test/rmc/Never/never_return.rs
@@ -11,8 +11,7 @@ pub fn err() -> ! {
 // Give an empty main to make rustc happy.
 #[no_mangle]
 pub fn main() {
-    //let var = rmc::nondet::<i32>();
-    let var = 2;
+    let var = rmc::nondet::<i32>();
     if var > 0 {
         err();
     }

--- a/src/test/rmc/Never/never_return.rs
+++ b/src/test/rmc/Never/never_return.rs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#![feature(never_type)]
+
+/// Test using the never type
+pub fn err() -> ! {
+    panic!("EXPECTED FAIL: Function should always fail");
+}
+
+// Give an empty main to make rustc happy.
+#[no_mangle]
+pub fn main() {
+    //let var = rmc::nondet::<i32>();
+    let var = 2;
+    if var > 0 {
+        err();
+    }
+}


### PR DESCRIPTION
### Description of changes: 

Remove the hack we added to monomorphizer to skip functions that we were not able to handle.

The latest fixes that we added to RMC was enough to allow us to run the monomorphizer as is. We no longer require the hooks to be moved to an mir_transformation. We can investigate that further before pushing to main.

### Resolved issues:

Resolves #485

### Testing:

* How is this change tested?

I added tests to the functions that were causing trouble before.

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
