### PR TITLE
Small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,5 +82,6 @@ src/test/rustdoc-gui/src/**.lock
 /src/test/dashboard
 *Cargo.lock
 src/test/rmc-dependency-test/diamond-dependency/build
+src/test/rmc-multicrate/type-mismatch/mismatch/target
 /rmc-docs/book
 /rmc-docs/mdbook*

--- a/compiler/cbmc/src/cbmc_string.rs
+++ b/compiler/cbmc/src/cbmc_string.rs
@@ -19,7 +19,7 @@ use string_interner::StringInterner;
 /// To create an interned string, either do
 /// `let i : InternedString = s.into();` or
 /// `let i = s.intern();`
-#[derive(Debug, Clone, Hash, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Hash, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InternedString(SymbolU32);
 
 // Use a `Mutex` to make this thread safe.
@@ -51,6 +51,12 @@ impl InternedString {
 impl std::fmt::Display for InternedString {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(fmt, "{}", INTERNER.lock().unwrap().resolve(self.0).unwrap())
+    }
+}
+/// Custom-implement Debug, so our debug logging contains meaningful strings, not numbers
+impl std::fmt::Debug for InternedString {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(fmt, "{:?}", INTERNER.lock().unwrap().resolve(self.0).unwrap())
     }
 }
 

--- a/compiler/cbmc/src/goto_program/location.rs
+++ b/compiler/cbmc/src/goto_program/location.rs
@@ -3,8 +3,8 @@
 use crate::cbmc_string::{InternStringOption, InternedString};
 use std::convert::TryInto;
 use std::fmt::Debug;
-/// A `Location` represents a source location.
 
+/// A `Location` represents a source location.
 #[derive(Copy, Clone, Debug)]
 pub enum Location {
     /// Unknown source location
@@ -29,6 +29,21 @@ impl Location {
         match self {
             Location::BuiltinFunction { .. } => true,
             _ => false,
+        }
+    }
+
+    /// Convert a location to a short string suitable for (e.g.) logging.
+    /// Goal is to return just "file:line" as clearly as possible.
+    pub fn short_string(&self) -> String {
+        match self {
+            Location::None => "<none>".to_string(),
+            Location::BuiltinFunction { function_name, line: Some(line) } => {
+                format!("<{}>:{}", function_name.to_string(), line)
+            }
+            Location::BuiltinFunction { function_name, line: None } => {
+                format!("<{}>", function_name.to_string())
+            }
+            Location::Loc { file, line, .. } => format!("{}:{}", file.to_string(), line),
         }
     }
 }

--- a/compiler/cbmc/src/goto_program/location.rs
+++ b/compiler/cbmc/src/goto_program/location.rs
@@ -38,12 +38,12 @@ impl Location {
         match self {
             Location::None => "<none>".to_string(),
             Location::BuiltinFunction { function_name, line: Some(line) } => {
-                format!("<{}>:{}", function_name.to_string(), line)
+                format!("<{}>:{}", function_name, line)
             }
             Location::BuiltinFunction { function_name, line: None } => {
-                format!("<{}>", function_name.to_string())
+                format!("<{}>", function_name)
             }
-            Location::Loc { file, line, .. } => format!("{}:{}", file.to_string(), line),
+            Location::Loc { file, line, .. } => format!("{}:{}", file, line),
         }
     }
 }

--- a/compiler/rustc_codegen_rmc/src/utils/utils.rs
+++ b/compiler/rustc_codegen_rmc/src/utils/utils.rs
@@ -4,6 +4,7 @@ use super::super::codegen::TypeExt;
 use crate::GotocCtx;
 use cbmc::btree_string_map;
 use cbmc::goto_program::{Expr, Location, Stmt, SymbolTable, Type};
+use tracing::debug;
 
 // Should move into rvalue
 //make this a member function
@@ -33,6 +34,9 @@ impl<'tcx> GotocCtx<'tcx> {
         loc: Location,
         url: &str,
     ) -> Expr {
+        // We should possibly upgrade this to a warning in the future, but for now emit at least something
+        debug!("codegen_unimplemented: {} at {}", operation_name, loc.short_string());
+
         let body = vec![
             // Assert false to alert the user that there is a path that uses an unimplemented feature.
             Stmt::assert_false(

--- a/rmc-docs/src/dev-documentation.md
+++ b/rmc-docs/src/dev-documentation.md
@@ -81,6 +81,11 @@ git merge origin/main
 # and because we squash and merge, an extra merge commit in a PR doesn't hurt.
 ```
 ```bash
+# Checkout a pull request locally without the github cli
+git fetch origin pull/$ID/head:pr/$ID
+git switch pr/$ID
+```
+```bash
 # Search only git-tracked files
 git grep codegen_panic
 ```

--- a/scripts/std-lib-regression.sh
+++ b/scripts/std-lib-regression.sh
@@ -9,9 +9,13 @@ PLATFORM=$(uname -sp)
 if [[ $PLATFORM == "Linux x86_64" ]]
 then
   TARGET="x86_64-unknown-linux-gnu"
+  # 'env' necessary to avoid bash built-in 'time'
+  WRAPPER="env time -v"
 elif [[ $PLATFORM == "Darwin i386" ]]
 then
   TARGET="x86_64-apple-darwin"
+  # mac 'time' doesn't have -v
+  WRAPPER=""
 else
   echo
   echo "Std-Lib codegen regression only works on Linux or OSX x86 platforms, skipping..."
@@ -45,7 +49,7 @@ echo "Starting cargo build with RMC"
 export RUSTC_LOG=error
 export RUSTFLAGS=$(${SCRIPT_DIR}/rmc-rustc --rmc-flags)
 export RUSTC=$(${SCRIPT_DIR}/rmc-rustc --rmc-path)
-cargo +nightly build -Z build-std --lib --target $TARGET
+$WRAPPER cargo +nightly build -Z build-std --lib --target $TARGET
 
 echo
 echo "Finished RMC codegen for the Rust standard library successfully..."


### PR DESCRIPTION
### Description of changes: 

This is a series of small changes not worth their own pull request.

1. Add a missing gitignore
2. Add doc note about checking out a PR locally
3. Add `time -v` to stdlib CI
4. Add a `debug!` message to `codegen_unimplemented`

The last is the most interesting by far. On the stdlib test I ran:

```
export RUSTC_LOG=rustc_codegen_rmc
export RUSTC=$(rmc-rustc --rmc-path)
export RUSTFLAGS=$(rmc-rustc --rmc-flags)
/usr/bin/time -v cargo +nightly build -Z build-std --lib --target x86_64-unknown-linux-gnu &> build.log
grep codegen_unimplemented build.log
```

and got (edited down to make it slightly briefer):

```
codegen_unimplemented: InlineAsm at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.49/src/mem/x86_64.rs:38
codegen_unimplemented: InlineAsm at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.49/src/mem/x86_64.rs:55
codegen_unimplemented: InlineAsm at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.49/src/mem/x86_64.rs:90
codegen_unimplemented: InlineAsm at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.49/src/int/specialized_div_rem/mod.rs:187
codegen_unimplemented: InlineAsm at /home/ubuntu/rmc/library/stdarch/crates/core_arch/src/x86/cpuid.rs:76
codegen_unimplemented: caller_location at /home/ubuntu/rmc/library/core/src/panic/location.rs:87
codegen_unimplemented: drop_in_place for _ZN4core3ptr42drop_in_place$LT$alloc..string..String$GT$17hd3be4ad50b456e07E_unimplemented at <none>
codegen_unimplemented: drop_in_place call for Expr { value: Symbol { identifier: InternedString(SymbolU32 { value: 7581 }) }, typ: Code { parameters: [Parameter { typ: Pointer { typ: StructTag(InternedString(SymbolU32 { value: 7583 })) }, identifier: None, base_name: None }], return_type: StructTag(InternedString(SymbolU32 { value: 105 })) }, location: None } at <none>
codegen_unimplemented: drop_in_place call for Expr { value: Symbol { identifier: InternedString(SymbolU32 { value: 7589 }) }, typ: Code { parameters: [Parameter { typ: Pointer { typ: StructTag(InternedString(SymbolU32 { value: 7591 })) }, identifier: None, base_name: None }], return_type: StructTag(InternedString(SymbolU32 { value: 105 })) }, location: None } at <none>
codegen_unimplemented: drop_in_place call for Expr { value: Symbol { identifier: InternedString(SymbolU32 { value: 7589 }) }, typ: Code { parameters: [Parameter { typ: Pointer { typ: StructTag(InternedString(SymbolU32 { value: 7591 })) }, identifier: None, base_name: None }], return_type: StructTag(InternedString(SymbolU32 { value: 105 })) }, location: None } at <none>
codegen_unimplemented: try at /home/ubuntu/rmc/library/std/src/panicking.rs:370
codegen_unimplemented: try at /home/ubuntu/rmc/library/std/src/panicking.rs:370
codegen_unimplemented: drop_in_place for _ZN4core3ptr39drop_in_place$LT$std..path..PathBuf$GT$17hf63317f5a38a7adcE_unimplemented at <none>
codegen_unimplemented: drop_in_place call for Expr { value: Symbol { identifier: InternedString(SymbolU32 { value: 32133 }) }, typ: Code { parameters: [Parameter { typ: Pointer { typ: StructTag(InternedString(SymbolU32 { value: 5796 })) }, identifier: None, base_name: None }], return_type: StructTag(InternedString(SymbolU32 { value: 534 })) }, location: None } at <none>
codegen_unimplemented: drop_in_place call for Expr { value: Symbol { identifier: InternedString(SymbolU32 { value: 32377 }) }, typ: Code { parameters: [Parameter { typ: Pointer { typ: StructTag(InternedString(SymbolU32 { value: 32379 })) }, identifier: None, base_name: None }], return_type: StructTag(InternedString(SymbolU32 { value: 534 })) }, location: None } at <none>
codegen_unimplemented: try at /home/ubuntu/rmc/library/std/src/panicking.rs:370
codegen_unimplemented: try at /home/ubuntu/rmc/library/std/src/panicking.rs:370
codegen_unimplemented: try at /home/ubuntu/rmc/library/std/src/panicking.rs:370
codegen_unimplemented: try at /home/ubuntu/rmc/library/std/src/panicking.rs:370
codegen_unimplemented: Rvalue::ThreadLocalRef at <none>
codegen_unimplemented: Rvalue::ThreadLocalRef at <none>
```

### Call-outs:

We should possibly add a cust `Debug` implementation for `InternedString` that prints the actual string. I might add that as another commit to this PR before merging...

### Testing:

* How is this change tested? existing suite

* Is this a refactor change? mostly

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
