### PR TITLE
Re-disabled brew update

### DIFF
--- a/scripts/setup/macos-10.15/install_deps.sh
+++ b/scripts/setup/macos-10.15/install_deps.sh
@@ -7,7 +7,7 @@ set -eux
 # Github promises weekly build image updates, so we can skip the update step and
 # worst case we should only be 1-2 weeks behind upstream brew.
 # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
-brew update
+#brew update
 
 # Install dependencies via `brew`
 brew install ctags


### PR DESCRIPTION
### Description of changes: 

I had to enable the `brew update` step in #616 because without it, `brew install cbmc` was getting version 5.42.0 instead of 5.43.0 on `macos`. Now that the GitHub runners seem to be getting the correct version, re-disabling the `brew update` step to save CI time.

### Resolved issues:


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
