### PR TITLE
Add `wget` macOS dependency

### DIFF
--- a/scripts/setup/macos-10.15/install_deps.sh
+++ b/scripts/setup/macos-10.15/install_deps.sh
@@ -10,7 +10,7 @@ set -eux
 #brew update
 
 # Install dependencies via `brew`
-brew install ctags
+brew install ctags wget
 
 # Add Python package dependencies
 PYTHON_DEPS=(


### PR DESCRIPTION
### Description of changes: 

Install `wget` via `brew` in the macOS installation script.

### Resolved issues:

Resolves #644 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Running existing regression. No changes are expected in CI since GH macOs machines come with `wget` installed.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
