### PR TITLE
Dashboard: Default to edition 2021 and ensure it is always set

### DIFF
--- a/src/tools/dashboard/src/books.rs
+++ b/src/tools/dashboard/src/books.rs
@@ -262,10 +262,11 @@ fn prepend_props(path: &Path, example: &mut Example, config_paths: &mut HashSet<
     } else {
         TestProps::new(path.to_path_buf(), None, Vec::new(), Vec::new())
     };
-    if example.config.edition != Some(Edition::Edition2015) {
-        props.rustc_args.push(String::from("--edition"));
-        props.rustc_args.push(String::from("2018"));
-    }
+    // Add edition flag to the example
+    let edition_year = format!("{}", example.config.edition.unwrap());
+    props.rustc_args.push(String::from("--edition"));
+    props.rustc_args.push(edition_year);
+
     if props.fail_step.is_none() {
         if example.config.compile_fail {
             // Most examples with `compile_fail` annotation fail because of
@@ -294,13 +295,14 @@ fn extract(par_from: &Path, par_to: &Path, config_paths: &mut HashSet<PathBuf>) 
     rustdoc::html::markdown::find_testable_code(&code, &mut examples, ErrorCodes::No, false, None);
     for mut example in examples.0 {
         apply_diff(par_to, &mut example, config_paths);
+        example.config.edition = Some(example.config.edition.unwrap_or(Edition::Edition2021));
         example.code = pub_main(
             rustdoc::doctest::make_test(
                 &example.code,
                 None,
                 false,
                 &Default::default(),
-                example.config.edition.unwrap_or(Edition::Edition2018),
+                example.config.edition.unwrap(),
                 None,
             )
             .0,


### PR DESCRIPTION
### Description of changes: 

Solves a number of issues in how we handle Rust editions for examples by:
 1. Making explicit edition for all dashboard examples, defaulting to 2021 edition if none is indicated.
 2. Emitting edition flags for all examples.

### Resolved issues:

Resolves #638 


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Running the dashboard.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
