### PR TITLE
Inherit parent environment when running cargo build

### DIFF
--- a/scripts/rmc.py
+++ b/scripts/rmc.py
@@ -269,8 +269,7 @@ def cargo_build(
         build_cmd += ["--target", str(build_target)]
     build_env = os.environ
     build_env.update({"RUSTFLAGS": " ".join(rustflags),
-                      "RUSTC": rustc_path,
-                      "PATH": os.environ["PATH"]
+                      "RUSTC": rustc_path
                       })
     if debug:
         add_rmc_rustc_debug_to_env(build_env)

--- a/scripts/rmc.py
+++ b/scripts/rmc.py
@@ -267,10 +267,11 @@ def cargo_build(
     build_cmd = ["cargo", "build", "--lib", "--target-dir", str(target_dir)]
     if build_target:
         build_cmd += ["--target", str(build_target)]
-    build_env = {"RUSTFLAGS": " ".join(rustflags),
+    build_env = os.environ
+    build_env.update({"RUSTFLAGS": " ".join(rustflags),
                  "RUSTC": rustc_path,
                  "PATH": os.environ["PATH"]
-                 }
+                 })
     if debug:
         add_rmc_rustc_debug_to_env(build_env)
     if verbose:

--- a/scripts/rmc.py
+++ b/scripts/rmc.py
@@ -269,9 +269,9 @@ def cargo_build(
         build_cmd += ["--target", str(build_target)]
     build_env = os.environ
     build_env.update({"RUSTFLAGS": " ".join(rustflags),
-                 "RUSTC": rustc_path,
-                 "PATH": os.environ["PATH"]
-                 })
+                      "RUSTC": rustc_path,
+                      "PATH": os.environ["PATH"]
+                      })
     if debug:
         add_rmc_rustc_debug_to_env(build_env)
     if verbose:


### PR DESCRIPTION
### Description of changes: 

The `cargo rmc` script currently does not pass the environment to the `cargo build` command (unlike the `rmc` script which passes the environment down to the compile command). Thus doing `RUST_BACKTRACE=1 cargo rmc` doesn't result in enabling the backtrace as one would expect.

### Resolved issues:


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
