### PR TITLE
Re-enable RMC to allow users to verify non-public main.

### DIFF
--- a/scripts/rmc-rustc
+++ b/scripts/rmc-rustc
@@ -53,8 +53,7 @@ then
     echo ${RMC_PATH}
 else
     set_rmc_lib_path
-    RMC_FLAGS="--crate-type=lib \
-            -Z codegen-backend=gotoc \
+    RMC_FLAGS="-Z codegen-backend=gotoc \
             -Z trim-diagnostic-paths=no \
             -Z human_readable_cgu_names \
             --cfg=rmc \

--- a/scripts/rmc.py
+++ b/scripts/rmc.py
@@ -264,7 +264,7 @@ def cargo_build(
 
     rustflags = rustc_flags(mangler, symbol_table_passes) + get_config("--rmc-flags").split()
     rustc_path = get_config("--rmc-path").strip()
-    build_cmd = ["cargo", "build", "--lib", "--target-dir", str(target_dir)]
+    build_cmd = ["cargo", "build", "--target-dir", str(target_dir)]
     if build_target:
         build_cmd += ["--target", str(build_target)]
     build_env = os.environ

--- a/src/test/cargo-rmc/simple-main/Cargo.toml
+++ b/src/test/cargo-rmc/simple-main/Cargo.toml
@@ -5,9 +5,6 @@ name = "empty-main"
 version = "0.1.0"
 edition = "2018"
 
-[lib]
-path="src/main.rs"
-
 [dependencies]
 
 [workspace]

--- a/src/test/cargo-rmc/simple-main/src/main.rs
+++ b/src/test/cargo-rmc/simple-main/src/main.rs
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-pub fn main() {
+fn main() {
     assert!(1 == 2);
 }

--- a/src/test/expected/one-assert/test.rs
+++ b/src/test/expected/one-assert/test.rs
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-
-pub fn main() {
+// rmc-flags: --function check_assert
+// compile-flags: --crate-type lib
+#[no_mangle]
+pub fn check_assert() {
     let x: u8 = rmc::nondet();
     let y = x;
     assert!(x == y);

--- a/src/test/rmc/ArithOperators/main.rs
+++ b/src/test/rmc/ArithOperators/main.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-pub fn main() {
+fn main() {
     let a: u32 = rmc::nondet();
     assert!(a / 2 <= a);
     assert!(a / 2 * 2 >= a / 2);

--- a/src/tools/dashboard/src/books.rs
+++ b/src/tools/dashboard/src/books.rs
@@ -281,11 +281,6 @@ fn prepend_props(path: &Path, example: &mut Example, config_paths: &mut HashSet<
     example.code = format!("{}{}", props, example.code);
 }
 
-/// Make the main function of a test public so it can be verified by rmc.
-fn pub_main(code: String) -> String {
-    code.replace("fn main", "pub fn main")
-}
-
 /// Extracts examples from the markdown file specified by `par_from`,
 /// pre-processes those examples, and saves them in the directory specified by
 /// `par_to`.
@@ -296,17 +291,15 @@ fn extract(par_from: &Path, par_to: &Path, config_paths: &mut HashSet<PathBuf>) 
     for mut example in examples.0 {
         apply_diff(par_to, &mut example, config_paths);
         example.config.edition = Some(example.config.edition.unwrap_or(Edition::Edition2021));
-        example.code = pub_main(
-            rustdoc::doctest::make_test(
-                &example.code,
-                None,
-                false,
-                &Default::default(),
-                example.config.edition.unwrap(),
-                None,
-            )
-            .0,
-        );
+        example.code = rustdoc::doctest::make_test(
+            &example.code,
+            None,
+            false,
+            &Default::default(),
+            example.config.edition.unwrap_or(Edition::Edition2018),
+            None,
+        )
+        .0;
         prepend_props(par_to, &mut example, config_paths);
         let rs_path = par_to.join(format!("{}.rs", example.line));
         fs::create_dir_all(rs_path.parent().unwrap()).unwrap();

--- a/src/tools/dashboard/src/books.rs
+++ b/src/tools/dashboard/src/books.rs
@@ -296,7 +296,7 @@ fn extract(par_from: &Path, par_to: &Path, config_paths: &mut HashSet<PathBuf>) 
             None,
             false,
             &Default::default(),
-            example.config.edition.unwrap_or(Edition::Edition2018),
+            example.config.edition.unwrap(),
             None,
         )
         .0;


### PR DESCRIPTION
Users don't usually set their main function to be public and we should enable them to verify their main function. For now, users will have to manually set the create type when running RMC directly. For cargo rmc, this should be automatically set up by cargo.

### Resolved issues:

Resolves #655 

### Call-outs:

We should figure out what is the default behavior of RMC and we might want to add a mechanism to figure out which one to use based on the user configuration. For example, maybe we can check what is the target function for the verification.

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
