### PR TITLE
Revert some changes to rust compiler code (#42)

### DIFF
--- a/compiler/rustc_codegen_rmc/src/codegen/assumptions.rs
+++ b/compiler/rustc_codegen_rmc/src/codegen/assumptions.rs
@@ -8,10 +8,9 @@ use cbmc::NO_PRETTY_NAME;
 use rustc_middle::mir::interpret::{ConstValue, Scalar};
 use rustc_middle::ty;
 use rustc_middle::ty::layout::LayoutOf;
-use rustc_middle::ty::ScalarInt;
 use rustc_middle::ty::Ty;
 use rustc_middle::ty::{IntTy, UintTy};
-use rustc_target::abi::{FieldsShape, Primitive, TagEncoding, Variants};
+use rustc_target::abi::{FieldsShape, Primitive, Size, TagEncoding, Variants};
 
 fn fold_invariants_gen<F: Fn(Expr, Expr) -> Expr>(mut iv: Vec<Expr>, dfl: Expr, comb: F) -> Expr {
     let mut res: Option<Expr> = None;
@@ -446,8 +445,9 @@ impl<'tcx> GotocCtx<'tcx> {
                 };
                 for (_, discr) in def.discriminants(tcx.tcx) {
                     let val = (discr.val << (128 - 8 * sz)) >> (128 - 8 * sz);
+                    let scalar = Scalar::from_uint(val, Size::from_bytes(sz));
                     cases.push(case.clone().eq(tcx.codegen_const_value(
-                        ConstValue::Scalar(Scalar::Int(ScalarInt { data: val, size: sz })),
+                        ConstValue::Scalar(scalar),
                         discr_t,
                         None,
                     )));

--- a/compiler/rustc_codegen_rmc/src/codegen/operand.rs
+++ b/compiler/rustc_codegen_rmc/src/codegen/operand.rs
@@ -76,6 +76,56 @@ impl<'tcx> GotocCtx<'tcx> {
         }
     }
 
+    fn codegen_slice_value(
+        &mut self,
+        v: ConstValue<'tcx>,
+        lit_ty: Ty<'tcx>,
+        span: Option<&Span>,
+        data: &Allocation,
+        start: usize,
+        end: usize,
+    ) -> Expr {
+        if let ty::Ref(_, ref_ty, _) = lit_ty.kind() {
+            match ref_ty.kind() {
+                ty::Str => {
+                    let slice = data.inspect_with_uninit_and_ptr_outside_interpreter(start..end);
+                    let s = ::std::str::from_utf8(slice).expect("non utf8 str from miri");
+                    return Expr::struct_expr_from_values(
+                        self.codegen_ty(lit_ty),
+                        vec![Expr::string_constant(s), Expr::int_constant(s.len(), Type::size_t())],
+                        &self.symbol_table,
+                    );
+                }
+                ty::Slice(slice_ty) => {
+                    if let Uint(UintTy::U8) = slice_ty.kind() {
+                        // The case where we have a slice of u8 is easy enough: make an array of u8
+                        // TODO: Handle cases with larger int types by making an array of bytes,
+                        // then using byte-extract on it.
+                        let slice =
+                            data.inspect_with_uninit_and_ptr_outside_interpreter(start..end);
+                        let vec_of_bytes: Vec<Expr> = slice
+                            .iter()
+                            .map(|b| Expr::int_constant(*b, Type::unsigned_int(8)))
+                            .collect();
+                        let len = vec_of_bytes.len();
+                        let array_expr =
+                            Expr::array_expr(Type::unsigned_int(8).array_of(len), vec_of_bytes);
+                        let data_expr = array_expr.array_to_ptr();
+                        let len_expr = Expr::int_constant(len, Type::size_t());
+                        return slice_fat_ptr(
+                            self.codegen_ty(lit_ty),
+                            data_expr,
+                            len_expr,
+                            &self.symbol_table,
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+        unimplemented!("\nv {:?}\nlit_ty {:?}\nspan {:?}", v, lit_ty, span);
+    }
+
     pub fn codegen_const_value(
         &mut self,
         v: ConstValue<'tcx>,
@@ -85,52 +135,7 @@ impl<'tcx> GotocCtx<'tcx> {
         match v {
             ConstValue::Scalar(s) => self.codegen_scalar(s, lit_ty, span),
             ConstValue::Slice { data, start, end } => {
-                let lit_kind = lit_ty.kind();
-                if let ty::Ref(_, ref_ty, _) = lit_kind {
-                    match ref_ty.kind() {
-                        ty::Str => {
-                            let slice =
-                                data.inspect_with_uninit_and_ptr_outside_interpreter(start..end);
-                            let s = ::std::str::from_utf8(slice).expect("non utf8 str from miri");
-                            return Expr::struct_expr_from_values(
-                                self.codegen_ty(lit_ty),
-                                vec![
-                                    Expr::string_constant(s),
-                                    Expr::int_constant(s.len(), Type::size_t()),
-                                ],
-                                &self.symbol_table,
-                            );
-                        }
-                        ty::Slice(slice_ty) => {
-                            if let Uint(UintTy::U8) = slice_ty.kind() {
-                                // The case where we have a slice of u8 is easy enough: make an array of u8
-                                // TODO: Handle cases with larger int types by making an array of bytes,
-                                // then using byte-extract on it.
-                                let slice = data
-                                    .inspect_with_uninit_and_ptr_outside_interpreter(start..end);
-                                let vec_of_bytes: Vec<Expr> = slice
-                                    .iter()
-                                    .map(|b| Expr::int_constant(*b, Type::unsigned_int(8)))
-                                    .collect();
-                                let len = vec_of_bytes.len();
-                                let array_expr = Expr::array_expr(
-                                    Type::unsigned_int(8).array_of(len),
-                                    vec_of_bytes,
-                                );
-                                let data_expr = array_expr.array_to_ptr();
-                                let len_expr = Expr::int_constant(len, Type::size_t());
-                                return slice_fat_ptr(
-                                    self.codegen_ty(lit_ty),
-                                    data_expr,
-                                    len_expr,
-                                    &self.symbol_table,
-                                );
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-                unimplemented!("\nv {:?}\nlit_ty {:?}\nspan {:?}", v, lit_ty, span)
+                self.codegen_slice_value(v, lit_ty, span, &data, start, end)
             }
             ConstValue::ByRef { alloc, offset } => {
                 debug!("ConstValue by ref {:?} {:?}", alloc, offset);
@@ -184,11 +189,8 @@ impl<'tcx> GotocCtx<'tcx> {
                 }
             }
             (Scalar::Int(int), ty::FnDef(d, substs)) => {
-                if int.size() == Size::ZERO {
-                    self.codegen_fndef(*d, substs, span)
-                } else {
-                    unreachable!();
-                }
+                assert_eq!(int.size(), Size::ZERO);
+                self.codegen_fndef(*d, substs, span)
             }
             (Scalar::Int(_), ty::RawPtr(tm)) => {
                 Expr::pointer_constant(s.to_u64().unwrap(), self.codegen_ty(tm.ty).to_pointer())

--- a/compiler/rustc_codegen_rmc/src/codegen/statement.rs
+++ b/compiler/rustc_codegen_rmc/src/codegen/statement.rs
@@ -41,8 +41,9 @@ impl<'tcx> GotocCtx<'tcx> {
                 Stmt::goto(self.current_fn().find_label(target), loc)
             }
             TerminatorKind::SwitchInt { discr, switch_ty, targets } => match targets {
-                SwitchTargets { values, targets } => {
-                    self.codegen_switch_int(discr, switch_ty, values, targets)
+                SwitchTargets { values, .. } => {
+                    let all_targets = targets.all_targets();
+                    self.codegen_switch_int(discr, switch_ty, values, all_targets)
                 }
             },
             TerminatorKind::Resume => Stmt::assert_false("resume instruction", loc),
@@ -197,7 +198,7 @@ impl<'tcx> GotocCtx<'tcx> {
         discr: &Operand<'tcx>,
         switch_ty: Ty<'tcx>,
         values: &SmallVec<[u128; 1]>,
-        targets: &SmallVec<[BasicBlock; 2]>,
+        targets: &[BasicBlock],
     ) -> Stmt {
         assert_eq!(targets.len(), values.len() + 1);
 

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -595,24 +595,6 @@ fn show_content_with_pager(content: &str) {
 }
 
 impl RustcDefaultCalls {
-    fn process_rlink(sess: &Session, compiler: &interface::Compiler) -> Result<(), ErrorReported> {
-        if let Input::File(file) = compiler.input() {
-            // FIXME: #![crate_type] and #![crate_name] support not implemented yet
-            let attrs = vec![];
-            sess.init_crate_types(collect_crate_types(sess, &attrs));
-            let outputs = compiler.build_output_filenames(&sess, &attrs);
-            let rlink_data = fs::read_to_string(file).unwrap_or_else(|err| {
-                sess.fatal(&format!("failed to read rlink file: {}", err));
-            });
-            let codegen_results: CodegenResults = json::decode(&rlink_data).unwrap_or_else(|err| {
-                sess.fatal(&format!("failed to decode rlink: {}", err));
-            });
-            compiler.codegen_backend().link(&sess, Box::new(codegen_results), &outputs)
-        } else {
-            sess.fatal("rlink must be a file")
-        }
-    }
-
     pub fn try_process_rlink(sess: &Session, compiler: &interface::Compiler) -> Compilation {
         if sess.opts.debugging_opts.link_only {
             if let Input::File(file) = compiler.input() {

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -35,7 +35,7 @@ pub struct SwitchTargets {
     //
     // However we’ve decided to keep this as-is until we figure a case
     // where some other approach seems to be strictly better than other.
-    pub targets: SmallVec<[BasicBlock; 2]>,
+    targets: SmallVec<[BasicBlock; 2]>,
 }
 
 impl SwitchTargets {

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -122,8 +122,8 @@ impl std::fmt::Debug for ConstInt {
 pub struct ScalarInt {
     /// The first `size` bytes of `data` are the value.
     /// Do not try to read less or more bytes than that. The remaining bytes must be 0.
-    pub data: u128,
-    pub size: u8,
+    data: u128,
+    size: u8,
 }
 
 // Cannot derive these, as the derives take references to the fields, and we

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -365,10 +365,10 @@ pub struct CReaderCacheKey {
 pub struct TyS<'tcx> {
     /// This field shouldn't be used directly and may be removed in the future.
     /// Use `TyS::kind()` instead.
-    pub kind: TyKind<'tcx>,
+    kind: TyKind<'tcx>,
     /// This field shouldn't be used directly and may be removed in the future.
     /// Use `TyS::flags()` instead.
-    pub flags: TypeFlags,
+    flags: TypeFlags,
 
     /// This is a kind of confusing thing: it stores the smallest
     /// binder such that


### PR DESCRIPTION
### Description of changes: 

We would like to eventually take rustc as is. This change reverts minor changes we have done to the compiler overtime and replace them by calls to public APIs.

### Resolved issues:

None. There are still a few changes that we need to revert.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
