### PR TITLE
Refactor with `Book` struct and set default edition for each book

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,6 +994,7 @@ dependencies = [
  "rustdoc",
  "serde",
  "serde_json",
+ "toml",
  "walkdir",
 ]
 

--- a/src/tools/dashboard/Cargo.toml
+++ b/src/tools/dashboard/Cargo.toml
@@ -13,3 +13,4 @@ rustdoc = { path = "../../librustdoc" }
 walkdir = "2.3.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+toml = "0.5"

--- a/src/tools/dashboard/src/books.rs
+++ b/src/tools/dashboard/src/books.rs
@@ -43,7 +43,7 @@ struct SummaryData {
     summary_start: String,
 }
 
-// Data needed for parsing book without a `SUMMARY.md` file
+// Data needed for parsing book without a summary file
 struct DirectoryData {
     // Directory to be processed, starting from root of the book
     src: PathBuf,
@@ -260,6 +260,8 @@ fn setup_nomicon_book() -> Book {
     }
 }
 
+/// Set up the
+/// [Rust Unstable Book](https://doc.rust-lang.org/beta/unstable-book/).
 fn setup_unstable_book() -> Book {
     let directory_data = DirectoryData {
         src: ["src", "doc", "unstable-book", "src"].iter().collect(),

--- a/src/tools/dashboard/src/books.rs
+++ b/src/tools/dashboard/src/books.rs
@@ -26,164 +26,275 @@ use std::{
     io::BufReader,
     iter::FromIterator,
     path::{Path, PathBuf},
+    str::FromStr,
 };
+use toml::Value;
 use walkdir::WalkDir;
 
-/// Parses the chapter/section hierarchy in the markdown file specified by
-/// `summary_path` and returns a mapping from markdown files containing rust
-/// code to corresponding directories where the extracted rust code should
-/// reside.
-fn parse_hierarchy(
-    book_name: &str,
+// Books may include a `SUMMARY.md` file or not. If they do, the info in
+// `SummaryData` is helpful to parse the hierarchy, otherwise we use a
+// `DirectoryData` structure
+
+// Data needed for parsing a book with a summary file
+struct SummaryData {
+    // Path to the summary file
     summary_path: PathBuf,
-    summary_start: &str,
-    mut map: HashMap<PathBuf, PathBuf>,
-) -> HashMap<PathBuf, PathBuf> {
-    let summary_dir = summary_path.parent().unwrap().to_path_buf();
-    let summary = fs::read_to_string(summary_path).unwrap();
-    assert!(
-        summary.starts_with(summary_start),
-        "Error: The start of {} summary file changed.",
-        book_name
-    );
-    // Skip the `start` of the summary.
-    let n = Parser::new(summary_start).count();
-    let parser = Parser::new(&summary).skip(n);
-    // Set `book_name` as the root of the hierarchical path.
-    let mut hierarchy: PathBuf = ["src", "test", "dashboard", "books", book_name].iter().collect();
-    let mut prev_event_is_text_or_code = false;
-    for event in parser {
-        match event {
-            Event::End(Tag::Item) => {
-                // Pop the current chapter/section from the hierarchy once
-                // we are done processing it and its subsections.
-                hierarchy.pop();
-                prev_event_is_text_or_code = false;
-            }
-            Event::End(Tag::Link(_, path, _)) => {
-                // At the start of the link tag, the hierarchy does not yet
-                // contain the title of the current chapter/section. So, we wait
-                // for the end of the link tag before adding the path and
-                // hierarchy of the current chapter/section to the map.
-                let mut full_path = summary_dir.clone();
-                full_path.extend(path.split('/'));
-                map.insert(full_path, hierarchy.clone());
-                prev_event_is_text_or_code = false;
-            }
-            Event::Text(text) | Event::Code(text) => {
-                // Remove characters that are problematic to the file system or
-                // terminal.
-                let text = text.replace(&['/', '(', ')', '\''][..], "_");
-                // Does the chapter/section title contain normal text and inline
-                // code?
-                if prev_event_is_text_or_code {
-                    // If so, we combine them into one hierarchy level.
-                    let prev_text = hierarchy.file_name().unwrap().to_str().unwrap().to_string();
-                    hierarchy.pop();
-                    hierarchy.push(format!("{}{}", prev_text, text));
-                } else {
-                    // If not, add the current title to the hierarchy.
-                    hierarchy.push(text.to_string());
-                }
-                prev_event_is_text_or_code = true;
-            }
-            _ => (),
-        }
-    }
-    map
+    // Line that indicates the start of the summary section
+    summary_start: String,
 }
 
-/// Parses [The Rust Reference](https://doc.rust-lang.org/nightly/reference)
+// Data needed for parsing book without a `SUMMARY.md` file
+struct DirectoryData {
+    // Directory to be processed, starting from root of the book
+    src: PathBuf,
+    // Directory where the examples extracted from the book should reside
+    dest: PathBuf,
+}
+
+// Data structure representing a Rust book
+struct Book {
+    // Name of the book
+    name: String,
+    // Default Rust edition
+    default_edition: Edition,
+    // Data about the summary file
+    summary_data: Option<SummaryData>,
+    // Data about the source/destination directories
+    directory_data: Option<DirectoryData>,
+    // Path to the `book.toml` file
+    toml_path: PathBuf,
+    // The hierarchy map used for example extraction
+    hierarchy: HashMap<PathBuf, PathBuf>,
+}
+
+impl Book {
+    /// Parse the chapter/section hierarchy and set the default edition
+    fn parse_hierarchy(&mut self) {
+        if self.summary_data.is_some() {
+            assert!(self.directory_data.is_none());
+            self.parse_hierarchy_with_summary();
+        } else {
+            assert!(self.directory_data.is_some());
+            self.parse_hierarchy_without_summary();
+        }
+        self.default_edition = self.get_rust_edition().unwrap_or(Edition::Edition2015);
+    }
+
+    /// Parses the chapter/section hierarchy in the markdown file specified by
+    /// `summary_path` and returns a mapping from markdown files containing rust
+    /// code to corresponding directories where the extracted rust code should
+    /// reside.
+    fn parse_hierarchy_with_summary(&mut self) {
+        let summary_path = &self.summary_data.as_ref().unwrap().summary_path;
+        let summary_start = &self.summary_data.as_ref().unwrap().summary_start;
+        let summary_dir = summary_path.parent().unwrap().to_path_buf();
+        let summary = fs::read_to_string(summary_path.clone()).unwrap();
+        assert!(
+            summary.starts_with(&summary_start.as_str()),
+            "Error: The start of {} summary file changed.",
+            self.name
+        );
+        // Skip the `start` of the summary.
+        let n = Parser::new(summary_start.as_str()).count();
+        let parser = Parser::new(&summary).skip(n);
+        // Set `self.name` as the root of the hierarchical path.
+        let mut hierarchy_path: PathBuf =
+            ["src", "test", "dashboard", "books", self.name.as_str()].iter().collect();
+        let mut prev_event_is_text_or_code = false;
+        for event in parser {
+            match event {
+                Event::End(Tag::Item) => {
+                    // Pop the current chapter/section from the hierarchy once
+                    // we are done processing it and its subsections.
+                    hierarchy_path.pop();
+                    prev_event_is_text_or_code = false;
+                }
+                Event::End(Tag::Link(_, path, _)) => {
+                    // At the start of the link tag, the hierarchy does not yet
+                    // contain the title of the current chapter/section. So, we wait
+                    // for the end of the link tag before adding the path and
+                    // hierarchy of the current chapter/section to the map.
+                    let mut full_path = summary_dir.clone();
+                    full_path.extend(path.split('/'));
+                    self.hierarchy.insert(full_path, hierarchy_path.clone());
+                    prev_event_is_text_or_code = false;
+                }
+                Event::Text(text) | Event::Code(text) => {
+                    // Remove characters that are problematic to the file system or
+                    // terminal.
+                    let text = text.replace(&['/', '(', ')', '\''][..], "_");
+                    // Does the chapter/section title contain normal text and inline
+                    // code?
+                    if prev_event_is_text_or_code {
+                        // If so, we combine them into one hierarchy level.
+                        let prev_text =
+                            hierarchy_path.file_name().unwrap().to_str().unwrap().to_string();
+                        hierarchy_path.pop();
+                        hierarchy_path.push(format!("{}{}", prev_text, text));
+                    } else {
+                        // If not, add the current title to the hierarchy.
+                        hierarchy_path.push(text.to_string());
+                    }
+                    prev_event_is_text_or_code = true;
+                }
+                _ => (),
+            }
+        }
+    }
+
+    /// Parses books that do not have a `SUMMARY.md` file (i.e., a table of
+    /// contents). We parse them manually and make a "best effort" to make it
+    /// look like the online version.
+    fn parse_hierarchy_without_summary(&mut self) {
+        let directory_data = self.directory_data.as_ref().unwrap();
+        let src = &directory_data.src;
+        let dest = &directory_data.dest;
+        let mut src_prefix: PathBuf = src.clone();
+        let mut dest_prefix: PathBuf = dest.clone();
+        for entry in WalkDir::new(&src_prefix) {
+            let entry = entry.unwrap().into_path();
+            // `WalkDir` returns entries in a depth-first fashion. Once we are done
+            // processing a directory, it will jump to a different child entry of a
+            // predecessor. To copy examples to the correct location, we need to
+            // know how far back we jumped and update `dest_prefix` accordingly.
+            while !entry.starts_with(&src_prefix) {
+                src_prefix.pop();
+                dest_prefix.pop();
+            }
+            if entry.is_dir() {
+                src_prefix.push(entry.file_name().unwrap());
+                // Follow the book's title case format for directories.
+                dest_prefix.push(to_title_case(entry.file_name().unwrap().to_str().unwrap()));
+            } else {
+                // Only process markdown files.
+                if entry.extension() == Some(OsStr::new("md")) {
+                    let entry_stem = entry.file_stem().unwrap().to_str().unwrap();
+                    // If a file has the stem name as a sibling directory...
+                    if src_prefix.join(entry.file_stem().unwrap()).exists() {
+                        // Its extracted examples should reside under that
+                        // directory.
+                        self.hierarchy
+                            .insert(entry.clone(), dest_prefix.join(to_title_case(entry_stem)));
+                    } else {
+                        // Otherwise, follow the book's snake case format for files.
+                        self.hierarchy
+                            .insert(entry.clone(), dest_prefix.join(to_snake_case(entry_stem)));
+                    }
+                }
+            }
+        }
+    }
+
+    // Get the Rust edition from the `book.toml` file
+    fn get_rust_edition(&self) -> Option<Edition> {
+        let file = fs::read_to_string(&self.toml_path).unwrap();
+        let toml_data: toml::Value = toml::from_str(&file).unwrap();
+        // The Rust edition is specified in the `rust.edition` attribute
+        let rust_block = toml_data.get("rust")?;
+        let edition_attr = rust_block.get("edition")?;
+        let edition_str = edition_attr.as_str()?;
+        Some(Edition::from_str(edition_str).unwrap())
+    }
+
+    /// Extracts examples from the markdown files specified by each key in the given
+    /// `map`, pre-processes those examples, and saves them in the directory
+    /// specified by the corresponding value.
+    fn extract_examples(&self) {
+        let mut config_paths = get_config_paths(self.name.as_str());
+        for (par_from, par_to) in &self.hierarchy {
+            extract(&par_from, &par_to, &mut config_paths, self.default_edition);
+        }
+        if !config_paths.is_empty() {
+            panic!(
+                "Error: The examples corresponding to the following config files \
+             were not encountered in the pre-processing step:\n{}This is most \
+             likely because the line numbers of the config files are not in \
+             sync with the line numbers of the corresponding code blocks in \
+             the latest versions of the Rust books. Please update the line \
+             numbers of the config files and rerun the program.",
+                paths_to_string(config_paths)
+            );
+        }
+    }
+}
+/// Set up [The Rust Reference](https://doc.rust-lang.org/nightly/reference)
 /// book.
-fn parse_reference_hierarchy() -> HashMap<PathBuf, PathBuf> {
-    parse_hierarchy(
-        "The Rust Reference",
-        ["src", "doc", "reference", "src", "SUMMARY.md"].iter().collect(),
-        "# The Rust Reference\n\n[Introduction](introduction.md)",
-        HashMap::from_iter([(
+fn setup_reference_book() -> Book {
+    let summary_data = SummaryData {
+        summary_start: "# The Rust Reference\n\n[Introduction](introduction.md)".to_string(),
+        summary_path: ["src", "doc", "reference", "src", "SUMMARY.md"].iter().collect(),
+    };
+    Book {
+        name: "The Rust Reference".to_string(),
+        summary_data: Some(summary_data),
+        directory_data: None,
+        toml_path: ["src", "doc", "reference", "book.toml"].iter().collect(),
+        hierarchy: HashMap::from_iter([(
             ["src", "doc", "reference", "src", "introduction.md"].iter().collect(),
             ["src", "test", "dashboard", "books", "The Rust Reference", "Introduction"]
                 .iter()
                 .collect(),
         )]),
-    )
+        default_edition: Edition::Edition2015,
+    }
 }
 
-/// Parses [The Rustonomicon](https://doc.rust-lang.org/nightly/nomicon) book.
-fn parse_nomicon_hierarchy() -> HashMap<PathBuf, PathBuf> {
-    parse_hierarchy(
-        "The Rustonomicon",
-        ["src", "doc", "nomicon", "src", "SUMMARY.md"].iter().collect(),
-        "# Summary\n\n[Introduction](intro.md)",
-        HashMap::from_iter([(
+/// Set up [The Rustonomicon](https://doc.rust-lang.org/nightly/nomicon) book.
+fn setup_nomicon_book() -> Book {
+    let summary_data = SummaryData {
+        summary_path: ["src", "doc", "nomicon", "src", "SUMMARY.md"].iter().collect(),
+        summary_start: "# Summary\n\n[Introduction](intro.md)".to_string(),
+    };
+    Book {
+        name: "The Rustonomicon".to_string(),
+        summary_data: Some(summary_data),
+        directory_data: None,
+        toml_path: ["src", "doc", "nomicon", "book.toml"].iter().collect(),
+        hierarchy: HashMap::from_iter([(
             ["src", "doc", "nomicon", "src", "intro.md"].iter().collect(),
             ["src", "test", "dashboard", "books", "The Rustonomicon", "Introduction"]
                 .iter()
                 .collect(),
         )]),
-    )
+        default_edition: Edition::Edition2015,
+    }
 }
 
-/// Parses the
+fn setup_unstable_book() -> Book {
+    let directory_data = DirectoryData {
+        src: ["src", "doc", "unstable-book", "src"].iter().collect(),
+        dest: ["src", "test", "dashboard", "books", "The Unstable Book"].iter().collect(),
+    };
+    Book {
+        name: "The Rust Unstable Book".to_string(),
+        summary_data: None,
+        directory_data: Some(directory_data),
+        toml_path: ["src", "doc", "unstable-book", "book.toml"].iter().collect(),
+        hierarchy: HashMap::new(),
+        default_edition: Edition::Edition2015,
+    }
+}
+
+/// Set up the
 /// [Rust by Example](https://doc.rust-lang.org/nightly/rust-by-example) book.
-fn parse_rust_by_example_hierarchy() -> HashMap<PathBuf, PathBuf> {
-    parse_hierarchy(
-        "Rust by Example",
-        ["src", "doc", "rust-by-example", "src", "SUMMARY.md"].iter().collect(),
-        "# Summary\n\n[Introduction](index.md)",
-        HashMap::from_iter([(
+fn setup_rust_by_example_book() -> Book {
+    let summary_data = SummaryData {
+        summary_path: ["src", "doc", "rust-by-example", "src", "SUMMARY.md"].iter().collect(),
+        summary_start: "# Summary\n\n[Introduction](index.md)".to_string(),
+    };
+    Book {
+        name: "Rust by Example".to_string(),
+        summary_data: Some(summary_data),
+        directory_data: None,
+        toml_path: ["src", "doc", "rust-by-example", "book.toml"].iter().collect(),
+        hierarchy: HashMap::from_iter([(
             ["src", "doc", "rust-by-example", "src", "index.md"].iter().collect(),
             ["src", "test", "dashboard", "books", "Rust by Example", "Introduction"]
                 .iter()
                 .collect(),
         )]),
-    )
-}
-
-/// Parses [The Unstable Book](https://doc.rust-lang.org/nightly/unstable-book).
-/// Unlike the other books, this one does not have a `SUMMARY.md` file (i.e., a
-/// table of contents). So we parse it manually and make a "best effort" to make
-/// it look like the online version.
-fn parse_unstable_book_hierarchy() -> HashMap<PathBuf, PathBuf> {
-    // Keeps track of directory we are currently processing, starting from root
-    // of the book.
-    let mut src_prefix: PathBuf = ["src", "doc", "unstable-book", "src"].iter().collect();
-    // Corresponding directory where the examples extracted from the book should
-    // reside.
-    let mut dest_prefix: PathBuf =
-        ["src", "test", "dashboard", "books", "The Unstable Book"].iter().collect();
-    let mut map = HashMap::new();
-    for entry in WalkDir::new(&src_prefix) {
-        let entry = entry.unwrap().into_path();
-        // `WalkDir` returns entries in a depth-first fashion. Once we are done
-        // processing a directory, it will jump to a different child entry of a
-        // predecessor. To copy examples to the correct location, we need to
-        // know how far back we jumped and update `dest_prefix` accordingly.
-        while !entry.starts_with(&src_prefix) {
-            src_prefix.pop();
-            dest_prefix.pop();
-        }
-        if entry.is_dir() {
-            src_prefix.push(entry.file_name().unwrap());
-            // Follow the book's title case format for directories.
-            dest_prefix.push(to_title_case(entry.file_name().unwrap().to_str().unwrap()));
-        } else {
-            // Only process markdown files.
-            if entry.extension() == Some(OsStr::new("md")) {
-                let entry_stem = entry.file_stem().unwrap().to_str().unwrap();
-                // If a file has the stem name as a sibling directory...
-                if src_prefix.join(entry.file_stem().unwrap()).exists() {
-                    // Its extracted examples should reside under that
-                    // directory.
-                    map.insert(entry.clone(), dest_prefix.join(to_title_case(entry_stem)));
-                } else {
-                    // Otherwise, follow the book's snake case format for files.
-                    map.insert(entry.clone(), dest_prefix.join(to_snake_case(entry_stem)));
-                }
-            }
-        }
+        default_edition: Edition::Edition2015,
     }
-    map
 }
 
 /// This data structure contains the code and configs of an example in the Rust books.
@@ -284,13 +395,18 @@ fn prepend_props(path: &Path, example: &mut Example, config_paths: &mut HashSet<
 /// Extracts examples from the markdown file specified by `par_from`,
 /// pre-processes those examples, and saves them in the directory specified by
 /// `par_to`.
-fn extract(par_from: &Path, par_to: &Path, config_paths: &mut HashSet<PathBuf>) {
+fn extract(
+    par_from: &Path,
+    par_to: &Path,
+    config_paths: &mut HashSet<PathBuf>,
+    default_edition: Edition,
+) {
     let code = fs::read_to_string(&par_from).unwrap();
     let mut examples = Examples(Vec::new());
     rustdoc::html::markdown::find_testable_code(&code, &mut examples, ErrorCodes::No, false, None);
     for mut example in examples.0 {
         apply_diff(par_to, &mut example, config_paths);
-        example.config.edition = Some(example.config.edition.unwrap_or(Edition::Edition2021));
+        example.config.edition = Some(example.config.edition.unwrap_or(default_edition));
         example.code = rustdoc::doctest::make_test(
             &example.code,
             None,
@@ -307,35 +423,17 @@ fn extract(par_from: &Path, par_to: &Path, config_paths: &mut HashSet<PathBuf>) 
     }
 }
 
-/// Extracts examples from the markdown files specified by each key in the given
-/// `map`, pre-processes those examples, and saves them in the directory
-/// specified by the corresponding value.
-fn extract_examples(par_map: HashMap<PathBuf, PathBuf>) {
-    let mut config_paths = get_config_paths();
-    for (par_from, par_to) in par_map {
-        extract(&par_from, &par_to, &mut config_paths);
-    }
-    if !config_paths.is_empty() {
-        panic!(
-            "Error: The examples corresponding to the following config files \
-             were not encountered in the pre-processing step:\n{}This is most \
-             likely because the line numbers of the config files are not in \
-             sync with the line numbers of the corresponding code blocks in \
-             the latest versions of the Rust books. Please update the line \
-             numbers of the config files and rerun the program.",
-            paths_to_string(config_paths)
-        );
-    }
-}
-
 /// Returns a set of paths to the config files for examples in the Rust books.
-fn get_config_paths() -> HashSet<PathBuf> {
-    let config_dir: PathBuf = ["src", "tools", "dashboard", "configs"].iter().collect();
+fn get_config_paths(book_name: &str) -> HashSet<PathBuf> {
+    let config_dir: PathBuf =
+        ["src", "tools", "dashboard", "configs", "books", book_name].iter().collect();
     let mut config_paths = HashSet::new();
-    for entry in WalkDir::new(config_dir) {
-        let entry = entry.unwrap().into_path();
-        if entry.is_file() {
-            config_paths.insert(entry);
+    if config_dir.exists() {
+        for entry in WalkDir::new(config_dir) {
+            let entry = entry.unwrap().into_path();
+            if entry.is_file() {
+                config_paths.insert(entry);
+            }
         }
     }
     config_paths
@@ -442,15 +540,20 @@ pub fn generate_dashboard() {
     let litani_log: PathBuf = ["build", "output", "latest", "run.json"].iter().collect();
     let text_dash: PathBuf =
         ["build", "output", "latest", "html", "dashboard.txt"].iter().collect();
-    // Parse the chapter/section hierarchy for the books.
-    let mut map = HashMap::new();
-    map.extend(parse_reference_hierarchy());
-    map.extend(parse_nomicon_hierarchy());
-    map.extend(parse_unstable_book_hierarchy());
-    map.extend(parse_rust_by_example_hierarchy());
-    // Extract examples from the books, pre-process them, and save them
-    // following the partial hierarchy in map.
-    extract_examples(map);
+    // Set up books
+    let mut books: Vec<Book> = vec![
+        setup_reference_book(),
+        setup_nomicon_book(),
+        setup_unstable_book(),
+        setup_rust_by_example_book(),
+    ];
+    for mut book in books {
+        // Parse the chapter/section hierarchy
+        book.parse_hierarchy();
+        // Extract examples, pre-process them, and save them according to the
+        // parsed hierarchy
+        book.extract_examples();
+    }
     // Generate Litani's HTML dashboard
     litani_run_tests();
     // Parse Litani's output


### PR DESCRIPTION
### Description of changes: 

Turns out default editions are different for each book: https://rust-lang.zulipchat.com/#narrow/stream/237824-t-lang.2Fdoc

Refactored the dashboard code to include an extensible `Book` structure which contains all information related to a particular book. This allows us to set the correct default edition for the examples in each book.

### Resolved issues:

Resolves #666 

### Testing:

* How is this change tested? Running dashboard locally.

* Is this a refactor change? No, but includes some refactoring.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
