### PR TITLE
Fix rmc --gen-c

### DIFF
--- a/scripts/rmc
+++ b/scripts/rmc
@@ -28,6 +28,8 @@ def main():
         json_runnable_filename = base + "_runnable.json"
         goto_runnable_filename = base + "_runnable.goto"
         c_runnable_filename = base + "_runnable.c"
+        restrictions_runnable_filename = os.path.join(
+            args.target_dir, "debug", "deps") if args.restrict_vtable else None
         if EXIT_CODE_SUCCESS != rmc.compile_single_rust_file(args.input, base, json_runnable_filename, args, ["gen-c"]):
             return 1
 
@@ -78,8 +80,7 @@ def main():
                 c_filename,
                 restrictions_filename,
                 args.verbose,
-                args.dry_run,
-                args.restrict_vtable):
+                args.dry_run):
             return 1
 
     if args.gen_symbols:

--- a/scripts/rmc.py
+++ b/scripts/rmc.py
@@ -222,7 +222,6 @@ def compile_single_rust_file(
         input_filename,
         base,
         output_filename,
-
         extra_args,
         symbol_table_passes=[]):
     if not extra_args.keep_temps:


### PR DESCRIPTION
There was a regression introduced by 7820fa576c6 that broke rmc --gen-c. This change fixes that. I am also fixing a random white space from my previous commit.

### Resolved issues:

None


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? We don't have any regression test for --gen-c yet.

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
