### PR TITLE
add regression for link restrictions tool

### DIFF
--- a/library/rmc_restrictions/Cargo.toml
+++ b/library/rmc_restrictions/Cargo.toml
@@ -9,6 +9,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rustc_data_structures = { path = "../../compiler/rustc_data_structures" }
 serde = {version = "1", features = ["derive"]}
 cbmc = { path = "../../src/rmc-compiler/cbmc" }

--- a/scripts/rmc-regression.sh
+++ b/scripts/rmc-regression.sh
@@ -27,6 +27,9 @@ check-cbmc-viewer-version.py --major 2 --minor 5
 (cd src/rmc-compiler/cbmc; cargo test)
 (cd src/rmc-compiler; cargo test)
 
+# Build tool for linking RMC pointer restrictions
+cargo build --release --manifest-path src/tools/rmc-link-restrictions/Cargo.toml 
+
 # Standalone rmc tests, expected tests, and cargo tests
 ./x.py build -i src/tools/compiletest --stage 0
 export COMPILETEST_FORCE_STAGE0=1  # We don't care about the stage anymore. Remove this once we replace ./x.py test

--- a/src/tools/rmc-link-restrictions/Cargo.toml
+++ b/src/tools/rmc-link-restrictions/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rustc_data_structures = { path = "../../../compiler/rustc_data_structures" }
 rmc_restrictions = { path = "../../../library/rmc_restrictions" }
 serde = {version = "1", features = ["derive"]}
 serde_json = {version = "1"}
+cbmc = { path = "../../rmc-compiler/cbmc" }

--- a/src/tools/rmc-link-restrictions/src/main.rs
+++ b/src/tools/rmc-link-restrictions/src/main.rs
@@ -1,16 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use cbmc::InternedString;
 use rmc_restrictions::{TraitDefinedMethod, VtableCtxResults};
-use rustc_data_structures::fx::FxHashMap;
+use std::collections::HashMap;
 use std::env;
 use std::fs::File;
 use std::io::BufReader;
 
 fn link_function_pointer_restrictions(data_per_crate: Vec<VtableCtxResults>) -> serde_json::Value {
-    let mut output = FxHashMap::default();
-    let mut combined_possible_methods: FxHashMap<TraitDefinedMethod, Vec<std::string::String>> =
-        FxHashMap::default();
+    let mut output = HashMap::new();
+    let mut combined_possible_methods: HashMap<TraitDefinedMethod, Vec<InternedString>> =
+        HashMap::new();
 
     // Combine method possibilities
     for crate_data in &data_per_crate {
@@ -32,7 +33,7 @@ fn link_function_pointer_restrictions(data_per_crate: Vec<VtableCtxResults>) -> 
             if let Some(possibilities) = combined_possible_methods.get(&trait_def) {
                 output.insert(cbmc_call_site_name, possibilities.clone());
             } else {
-                output.insert(cbmc_call_site_name, Vec::<String>::new());
+                output.insert(cbmc_call_site_name, Vec::<InternedString>::new());
             }
         }
     }


### PR DESCRIPTION
### Description of changes: 

We can't land proper tests for the link restrictions feature until the CBMC release is out (RMC issue #671), but we should at least build the code. Fix build and add to regression script.

### Resolved issues:

Resolves #684

### Call-outs:

To build in tree, this removes some unused rustc dependencies from the cbmc crate.

### Testing:

* How is this change tested?

Adding build command to regression tests.

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
