### PR TITLE
Use NULL constant for null pointer IRep

### DIFF
--- a/compiler/cbmc/src/irep/to_irep.rs
+++ b/compiler/cbmc/src/irep/to_irep.rs
@@ -228,6 +228,11 @@ impl ToIrep for ExprValue {
                 ],
             },
             ExprValue::Nondet => side_effect_irep(IrepId::Nondet, vec![]),
+            ExprValue::PointerConstant(0) => Irep {
+                id: IrepId::Constant,
+                sub: vec![],
+                named_sub: vector_map![(IrepId::Value, Irep::just_id(IrepId::NULL))],
+            },
             ExprValue::PointerConstant(i) => Irep {
                 id: IrepId::Constant,
                 sub: vec![],


### PR DESCRIPTION

### Description of changes: 

CBMC has an explicit NULL pointer value, in addition to a pointer with value 0 being an implicit null pointer. The CBMC constant propagator does a better job with the first case. This is being fixed on the CBMC side, but till then this improves performance, and doesn't cost much.   

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
