### PR TITLE
Revert change to rustc SwitchTargets type.

### DIFF
--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -21,7 +21,7 @@ pub use super::query::*;
 pub struct SwitchTargets {
     /// Possible values. The locations to branch to in each case
     /// are found in the corresponding indices from the `targets` vector.
-    pub values: SmallVec<[u128; 1]>,
+    values: SmallVec<[u128; 1]>,
 
     /// Possible branch sites. The last element of this vector is used
     /// for the otherwise branch, so targets.len() == values.len() + 1

--- a/src/test/rmc/Match/match_bool.rs
+++ b/src/test/rmc/Match/match_bool.rs
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// compile-flags: --crate-type lib
+// rmc-flags: --function match_bool
+
+#[rmc::proof]
+pub fn match_bool(arg: bool) {
+    let var = match arg {
+        true => !arg,
+        _ => arg,
+    };
+
+    let var2 = match arg {
+        _ => false,
+    };
+
+    assert!(var == var2);
+
+    let mut i = 0;
+
+    match arg {
+        true => i = 1,
+        false => i = 2,
+        _ => i = 3,
+    }
+
+    assert!(i == 1 || i == 2);
+}

--- a/src/test/rmc/Match/match_bool.rs
+++ b/src/test/rmc/Match/match_bool.rs
@@ -4,7 +4,8 @@
 // rmc-flags: --function match_bool
 
 #[rmc::proof]
-pub fn match_bool(arg: bool) {
+pub fn match_bool() {
+    let arg: bool = rmc::nondet();
     let var = match arg {
         true => !arg,
         _ => arg,


### PR DESCRIPTION
### Description of changes: 

We have changed the visibility of one of the members of SwitchTargets to have access to their values during codegen. I re-wrote the code to use standard API so we don't need to keep using a forked version of the compiler. Issue #42.

The only changes left are the ones to enable rmc codegen and a a few options we enabled. Those should be handled once we have a new driver.

### Resolved issues:

None

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Added new test + all older tests.

* Is this a refactor change? Yes

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
