### PR TITLE
Add missing type constructors

### DIFF
--- a/compiler/cbmc/src/goto_program/typ.rs
+++ b/compiler/cbmc/src/goto_program/typ.rs
@@ -369,7 +369,7 @@ impl Type {
         }
     }
 
-    pub fn is_c_sizet(&self) -> bool {
+    pub fn is_c_size_t(&self) -> bool {
         match self {
             Type::CInteger(CIntType::SizeT) => true,
             _ => false,

--- a/compiler/cbmc/src/goto_program/typ.rs
+++ b/compiler/cbmc/src/goto_program/typ.rs
@@ -369,6 +369,20 @@ impl Type {
         }
     }
 
+    pub fn is_c_sizet(&self) -> bool {
+        match self {
+            Type::CInteger(CIntType::SizeT) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_c_ssizet(&self) -> bool {
+        match self {
+            Type::CInteger(CIntType::SSizeT) => true,
+            _ => false,
+        }
+    }
+
     pub fn is_code(&self) -> bool {
         match self {
             Code { .. } => true,
@@ -618,6 +632,14 @@ impl Type {
 
     pub fn c_int() -> Self {
         CInteger(CIntType::Int)
+    }
+
+    pub fn c_size_t() -> Self {
+        CInteger(CIntType::SizeT)
+    }
+
+    pub fn c_ssize_t() -> Self {
+        CInteger(CIntType::SSizeT)
     }
 
     /// corresponds to [code_typet] in CBMC, representing a function type

--- a/compiler/cbmc/src/goto_program/typ.rs
+++ b/compiler/cbmc/src/goto_program/typ.rs
@@ -376,7 +376,7 @@ impl Type {
         }
     }
 
-    pub fn is_c_ssizet(&self) -> bool {
+    pub fn is_c_ssize_t(&self) -> bool {
         match self {
             Type::CInteger(CIntType::SSizeT) => true,
             _ => false,


### PR DESCRIPTION
### Description of changes: 

While working on #708 I wanted to make an element with type `ssize_t`. I discovered that there was no constructor for that type. Adding it.

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

We should really audit this code at some point to find the rest of the missing constructors. There are probably more.

### Testing:

* How is this change tested?  Regressions still pass. Really, we should have unit tests for these things, but that's a future task.

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
