### PR TITLE
Add a hint for how to fix missing RMC library

### DIFF
--- a/scripts/rmc-rustc
+++ b/scripts/rmc-rustc
@@ -41,6 +41,7 @@ set_rmc_lib_path() {
             echo "ERROR: Could not find RMC library."
             echo "Looked for: \"$REPO_DIR/target/*/librmc.rlib\""
             echo "Was RMC library successfully built first?"
+            echo "Try running <RMC_ROOT>/scripts/setup/build_rmc_lib.sh"
             exit 1
         fi
         RMC_LIB_PATH=$(dirname ${RMC_LIB_CANDIDATES[0]})
@@ -52,6 +53,7 @@ set_rmc_lib_path() {
         echo "ERROR: Could not find RMC library."
         echo "Looked for: \"${RMC_LIB_PATH}/deps/librmc_macros-*\""
         echo "Was RMC library successfully built first?"
+        echo "Try running <RMC_ROOT>/scripts/setup/build_rmc_lib.sh"
         exit 1
     fi
     RMC_MACRO_LIB_PATH="${MACRO_LIB_CANDIDATE[0]}"

--- a/scripts/rmc-rustc
+++ b/scripts/rmc-rustc
@@ -40,7 +40,6 @@ set_rmc_lib_path() {
         then
             echo "ERROR: Could not find RMC library."
             echo "Looked for: \"$REPO_DIR/target/*/librmc.rlib\""
-            echo "Was RMC library successfully built first?"
             echo "Try running <RMC_ROOT>/scripts/setup/build_rmc_lib.sh"
             exit 1
         fi
@@ -52,7 +51,6 @@ set_rmc_lib_path() {
     then
         echo "ERROR: Could not find RMC library."
         echo "Looked for: \"${RMC_LIB_PATH}/deps/librmc_macros-*\""
-        echo "Was RMC library successfully built first?"
         echo "Try running <RMC_ROOT>/scripts/setup/build_rmc_lib.sh"
         exit 1
     fi


### PR DESCRIPTION
### Description of changes: 

Currently, when the RMC library hasn't been built, we fail with an error message, but no indication to the user of how to fix it. Add to the error message the script they can run to fix it.
### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:
This only works if the user has built RMC from source, and knows where the repo with the scripts are.  Could we give them a reference to the absolute path to run the script from?

### Testing:

* How is this change tested? Ran it locally, saw the new message.

* Is this a refactor change? Documentation / error message fix.

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
