### PR TITLE
Update rust toolchain version

### DIFF
--- a/rmc-docs/src/tutorial/arbitrary-variables/unsafe_update.expected
+++ b/rmc-docs/src/tutorial/arbitrary-variables/unsafe_update.expected
@@ -1,3 +1,3 @@
 [inventory::verification::unsafe_update.assertion.1] line 61 assertion failed: inventory.get(&id).unwrap() == quantity: SUCCESS
-[std::option::Option::<T>::unwrap.assertion.1] line 759 called `Option::unwrap()` on a `None` value: FAILURE
+called `Option::unwrap()` on a `None` value: FAILURE
 VERIFICATION FAILED

--- a/src/rmc-compiler/rust-toolchain.toml
+++ b/src/rmc-compiler/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2021-12-27"
+channel = "nightly-2022-01-11"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/src/rmc-compiler/rustc_codegen_rmc/src/codegen/rvalue.rs
+++ b/src/rmc-compiler/rustc_codegen_rmc/src/codegen/rvalue.rs
@@ -381,24 +381,11 @@ impl<'tcx> GotocCtx<'tcx> {
             Rvalue::CheckedBinaryOp(op, box (ref e1, ref e2)) => {
                 self.codegen_rvalue_checked_binary_op(op, e1, e2, res_ty)
             }
-            Rvalue::NullaryOp(NullOp::Box, t) => {
-                let t = self.monomorphize(*t);
-                let layout = self.layout_of(t);
-                let size = layout.size.bytes_usize();
-                let box_ty = self.tcx.mk_box(t);
-                let box_ty = self.codegen_ty(box_ty);
-                let cbmc_t = self.codegen_ty(t);
-                let box_contents = BuiltinFn::Malloc
-                    .call(vec![Expr::int_constant(size, Type::size_t())], Location::none())
-                    .cast_to(cbmc_t.to_pointer());
-                self.box_value(box_contents, box_ty)
-            }
             Rvalue::NullaryOp(k, t) => {
                 let t = self.monomorphize(*t);
                 let layout = self.layout_of(t);
                 match k {
                     NullOp::SizeOf => Expr::int_constant(layout.size.bytes_usize(), Type::size_t()),
-                    NullOp::Box => unreachable!("Should've matched previous expression"),
                     NullOp::AlignOf => Expr::int_constant(layout.align.abi.bytes(), Type::size_t()),
                 }
             }

--- a/src/rmc-compiler/rustc_codegen_rmc/src/codegen/typ.rs
+++ b/src/rmc-compiler/rustc_codegen_rmc/src/codegen/typ.rs
@@ -1296,6 +1296,8 @@ impl<'tcx> GotocCtx<'tcx> {
     /// A pointer to the mir type should be a thin pointer.
     pub fn use_thin_pointer(&self, mir_type: Ty<'tcx>) -> bool {
         // ptr_metadata_ty is not defined on all types, the projection of an associated type
+        // TODO: We should normalize the type projection here. For more details, see
+        // https://github.com/model-checking/rmc/issues/752
         return !self.is_unsized(mir_type)
             || mir_type.ptr_metadata_ty(self.tcx, |ty| ty) == self.tcx.types.unit;
     }

--- a/src/rmc-compiler/rustc_codegen_rmc/src/codegen/typ.rs
+++ b/src/rmc-compiler/rustc_codegen_rmc/src/codegen/typ.rs
@@ -1297,15 +1297,15 @@ impl<'tcx> GotocCtx<'tcx> {
     pub fn use_thin_pointer(&self, mir_type: Ty<'tcx>) -> bool {
         // ptr_metadata_ty is not defined on all types, the projection of an associated type
         return !self.is_unsized(mir_type)
-            || mir_type.ptr_metadata_ty(self.tcx) == self.tcx.types.unit;
+            || mir_type.ptr_metadata_ty(self.tcx, |ty| ty) == self.tcx.types.unit;
     }
     /// A pointer to the mir type should be a slice fat pointer.
     pub fn use_slice_fat_pointer(&self, mir_type: Ty<'tcx>) -> bool {
-        return mir_type.ptr_metadata_ty(self.tcx) == self.tcx.types.usize;
+        return mir_type.ptr_metadata_ty(self.tcx, |ty| ty) == self.tcx.types.usize;
     }
     /// A pointer to the mir type should be a vtable fat pointer.
     pub fn use_vtable_fat_pointer(&self, mir_type: Ty<'tcx>) -> bool {
-        let metadata = mir_type.ptr_metadata_ty(self.tcx);
+        let metadata = mir_type.ptr_metadata_ty(self.tcx, |ty| ty);
         return metadata != self.tcx.types.unit && metadata != self.tcx.types.usize;
     }
 

--- a/src/rmc-compiler/rustc_codegen_rmc/src/codegen/typ.rs
+++ b/src/rmc-compiler/rustc_codegen_rmc/src/codegen/typ.rs
@@ -1292,22 +1292,28 @@ pub fn is_repr_c_adt(mir_type: Ty<'tcx>) -> bool {
     }
 }
 
+/// This is a place holder function that should normalize the given type.
+///
+/// TODO: We should normalize the type projection here. For more details, see
+/// https://github.com/model-checking/rmc/issues/752
+fn normalize_type(ty: Ty<'tcx>) -> Ty<'tcx> {
+    ty
+}
+
 impl<'tcx> GotocCtx<'tcx> {
     /// A pointer to the mir type should be a thin pointer.
     pub fn use_thin_pointer(&self, mir_type: Ty<'tcx>) -> bool {
         // ptr_metadata_ty is not defined on all types, the projection of an associated type
-        // TODO: We should normalize the type projection here. For more details, see
-        // https://github.com/model-checking/rmc/issues/752
         return !self.is_unsized(mir_type)
-            || mir_type.ptr_metadata_ty(self.tcx, |ty| ty) == self.tcx.types.unit;
+            || mir_type.ptr_metadata_ty(self.tcx, normalize_type) == self.tcx.types.unit;
     }
     /// A pointer to the mir type should be a slice fat pointer.
     pub fn use_slice_fat_pointer(&self, mir_type: Ty<'tcx>) -> bool {
-        return mir_type.ptr_metadata_ty(self.tcx, |ty| ty) == self.tcx.types.usize;
+        return mir_type.ptr_metadata_ty(self.tcx, normalize_type) == self.tcx.types.usize;
     }
     /// A pointer to the mir type should be a vtable fat pointer.
     pub fn use_vtable_fat_pointer(&self, mir_type: Ty<'tcx>) -> bool {
-        let metadata = mir_type.ptr_metadata_ty(self.tcx, |ty| ty);
+        let metadata = mir_type.ptr_metadata_ty(self.tcx, normalize_type);
         return metadata != self.tcx.types.unit && metadata != self.tcx.types.usize;
     }
 


### PR DESCRIPTION
### Description of changes: 

Update toolchain version to the latest nightly version.

### Resolved issues:

Resolves #747


### Call-outs:

There has been a fixed that was pushed to rustc where they now normalize the struct-tail type when satisfying a Pointee obligation. I have not applied the fix yet, and this change keeps the same behavior for rmc. I wasn't able to reproduce the issue posted in the related PR yet. https://github.com/rust-lang/rust/pull/92248

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
