### PR TITLE
Move `compiletest` out of `x.py`

### DIFF
--- a/scripts/rmc-regression.sh
+++ b/scripts/rmc-regression.sh
@@ -41,7 +41,7 @@ check-cbmc-viewer-version.py --major 2 --minor 5
 cargo build --release --manifest-path src/tools/rmc-link-restrictions/Cargo.toml 
 
 # Build compiletest
-cargo build --release --manifest-path src/tools/compiletest/Cargo.toml
+(cd "${RMC_DIR}/src/tools/compiletest"; cargo build --release)
 
 # Declare testing suite information (suite and mode)
 TESTS=(
@@ -61,7 +61,7 @@ for testp in "${TESTS[@]}"; do
   suite=${testl[0]}
   mode=${testl[1]}
   echo "Check compiletest suite=$suite mode=$mode ($TARGET -> $TARGET)"
-  ./target/release/compiletest --rmc-dir-path /home/ubuntu/rmc-dash/scripts --src-base /home/ubuntu/rmc-dash/src/test/$suite --build-base /home/ubuntu/rmc-dash/build/$TARGET/test/$suite --stage-id stage1-$TARGET --suite $suite --mode $mode --target $TARGET --host $TARGET --quiet --channel dev
+  ./target/release/compiletest --rmc-dir-path scripts --src-base src/test/$suite --build-base build/$TARGET/test/$suite --stage-id stage1-$TARGET --suite $suite --mode $mode --target $TARGET --host $TARGET --quiet --channel dev
 done
 
 # Check codegen for the standard library

--- a/scripts/rmc-regression.sh
+++ b/scripts/rmc-regression.sh
@@ -8,6 +8,16 @@ fi
 set -o pipefail
 set -o nounset
 
+# Test for platform
+PLATFORM=$(uname -sp)
+if [[ $PLATFORM == "Linux x86_64" ]]
+then
+  TARGET="x86_64-unknown-linux-gnu"
+elif [[ $PLATFORM == "Darwin i386" ]]
+then
+  TARGET="x86_64-apple-darwin"
+fi
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export PATH=$SCRIPT_DIR:$PATH
 EXTRA_X_PY_BUILD_ARGS="${EXTRA_X_PY_BUILD_ARGS:-}"
@@ -30,10 +40,29 @@ check-cbmc-viewer-version.py --major 2 --minor 5
 # Build tool for linking RMC pointer restrictions
 cargo build --release --manifest-path src/tools/rmc-link-restrictions/Cargo.toml 
 
-# Standalone rmc tests, expected tests, and cargo tests
-./x.py build -i src/tools/compiletest --stage 0
-export COMPILETEST_FORCE_STAGE0=1  # We don't care about the stage anymore. Remove this once we replace ./x.py test
-./x.py test -i --stage 0 rmc firecracker prusti smack expected cargo-rmc rmc-docs rmc-fixme
+# Build compiletest
+cargo build --release --manifest-path src/tools/compiletest/Cargo.toml
+
+# Declare testing suite information (suite and mode)
+TESTS=(
+    "rmc rmc"
+    "firecracker rmc"
+    "prusti rmc"
+    "smack rmc"
+    "expected expected"
+    "cargo-rmc cargo-rmc"
+    "rmc-docs rmc"
+    "rmc-fixme rmc-fixme"
+)
+
+# Extract testing suite information and run compiletest
+for testp in "${TESTS[@]}"; do
+  testl=($testp)
+  suite=${testl[0]}
+  mode=${testl[1]}
+  echo "Check compiletest suite=$suite mode=$mode ($TARGET -> $TARGET)"
+  ./target/release/compiletest --rmc-dir-path /home/ubuntu/rmc-dash/scripts --src-base /home/ubuntu/rmc-dash/src/test/$suite --build-base /home/ubuntu/rmc-dash/build/$TARGET/test/$suite --stage-id stage1-$TARGET --suite $suite --mode $mode --target $TARGET --host $TARGET --quiet --channel dev
+done
 
 # Check codegen for the standard library
 time "$SCRIPT_DIR"/std-lib-regression.sh

--- a/scripts/rmc-regression.sh
+++ b/scripts/rmc-regression.sh
@@ -61,7 +61,14 @@ for testp in "${TESTS[@]}"; do
   suite=${testl[0]}
   mode=${testl[1]}
   echo "Check compiletest suite=$suite mode=$mode ($TARGET -> $TARGET)"
-  ./target/release/compiletest --rmc-dir-path scripts --src-base src/test/$suite --build-base build/$TARGET/test/$suite --stage-id stage1-$TARGET --suite $suite --mode $mode --target $TARGET --host $TARGET --quiet --channel dev
+  # Note: `cargo-rmc` tests fail if we do not add `$(pwd)` to `--build-base`
+  # Tracking issue: https://github.com/model-checking/rmc/issues/755
+  ./target/release/compiletest --rmc-dir-path scripts --src-base src/test/$suite \
+                               --build-base $(pwd)/build/$TARGET/test/$suite \
+                               --stage-id stage1-$TARGET \
+                               --suite $suite --mode $mode \
+                               --target $TARGET --host $TARGET \
+                               --quiet --channel dev
 done
 
 # Check codegen for the standard library

--- a/scripts/rmc-regression.sh
+++ b/scripts/rmc-regression.sh
@@ -51,7 +51,7 @@ TESTS=(
     "smack rmc"
     "expected expected"
     "cargo-rmc cargo-rmc"
-    "rmc-docs rmc"
+    "rmc-docs cargo-rmc"
     "rmc-fixme rmc-fixme"
 )
 

--- a/src/tools/compiletest/rust-toolchain.toml
+++ b/src/tools/compiletest/rust-toolchain.toml
@@ -1,0 +1,1 @@
+../../rmc-compiler/rust-toolchain.toml


### PR DESCRIPTION
### Description of changes: 

Moves `compiletest` out of `x.py`

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing regression.

* Is this a refactor change? Yes.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
