### PR TITLE
Update rust toolchain version to 2022-01-19

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 [toolchain]
-channel = "nightly-2022-01-11"
+channel = "nightly-2022-01-19"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/place.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/place.rs
@@ -205,7 +205,7 @@ impl<'tcx> GotocCtx<'tcx> {
                     // if we fall here, then we are handling either a struct or a union
                     ty::Adt(def, _) => {
                         let field = &def.variants.raw[0].fields[f.index()];
-                        res.member(&field.ident.name.to_string(), &self.symbol_table)
+                        res.member(&field.name.to_string(), &self.symbol_table)
                     }
                     ty::Closure(..) => res.member(&f.index().to_string(), &self.symbol_table),
                     ty::Generator(..) => self.codegen_unimplemented(
@@ -220,7 +220,7 @@ impl<'tcx> GotocCtx<'tcx> {
             // if we fall here, then we are handling an enum
             TypeOrVariant::Variant(v) => {
                 let field = &v.fields[f.index()];
-                res.member(&field.ident.name.to_string(), &self.symbol_table)
+                res.member(&field.name.to_string(), &self.symbol_table)
             }
         }
     }
@@ -431,7 +431,7 @@ impl<'tcx> GotocCtx<'tcx> {
                             Variants::Single { .. } => before.goto_expr,
                             Variants::Multiple { tag_encoding, .. } => match tag_encoding {
                                 TagEncoding::Direct => {
-                                    let case_name = variant.ident.name.to_string();
+                                    let case_name = variant.name.to_string();
                                     before
                                         .goto_expr
                                         .member("cases", &self.symbol_table)

--- a/src/kani-compiler/rustc_codegen_kani/src/codegen/statement.rs
+++ b/src/kani-compiler/rustc_codegen_kani/src/codegen/statement.rs
@@ -572,14 +572,6 @@ impl<'tcx> GotocCtx<'tcx> {
             }
             StatementKind::StorageLive(_) => Stmt::skip(Location::none()), // TODO: fix me
             StatementKind::StorageDead(_) => Stmt::skip(Location::none()), // TODO: fix me
-            StatementKind::LlvmInlineAsm(_) => self
-                .codegen_unimplemented(
-                    "InlineAsm",
-                    Type::empty(),
-                    Location::none(),
-                    "https://github.com/model-checking/rmc/issues/2",
-                )
-                .as_stmt(Location::none()),
             StatementKind::CopyNonOverlapping(box mir::CopyNonOverlapping {
                 ref src,
                 ref dst,


### PR DESCRIPTION
### Description of changes: 

Updating the rust toolchain after merging rustc. I used the head of the nightly to merge so the rust toolchain and the rustc code are in sync.

### Resolved issues:

Resolves #762.

### Call-outs:

I decided to merge early in the sprint because last time I didn't synchronize the merge and the rust toolchain update. This is blocking us from using cargo build for the bookrunner instead of the bootstrap script.

### Testing:

* How is this change tested? Everywhere

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
