### PR TITLE
Remove dependency on rustc bootstrap 

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -32,14 +32,6 @@ jobs:
       - name: Install Rust toolchain
         run: ./scripts/setup/install_rustup.sh
 
-      - name: Set config.toml file
-        run: |
-          ./configure \
-            --enable-debug \
-            --set=llvm.download-ci-llvm=true \
-            --set=rust.debug-assertions-std=false \
-            --set=rust.deny-warnings=false
-
       - name: Update submodules
         run: |
           # Since we download cached artifacts, we can skip checking out llvm locally in CI
@@ -49,8 +41,7 @@ jobs:
       - name: Build Kani and Kani Library
         run: |
           export RUST_BACKTRACE=1
-          cd src/kani-compiler
-          cargo build
+          cargo build -p kani-compiler
 
       - name: Execute Kani regression
         run: ./scripts/kani-regression.sh
@@ -61,7 +52,9 @@ jobs:
 
       - name: Generate book runner report
         if: ${{ matrix.os == 'ubuntu-20.04' }}
-        run: ./x.py run -i --stage 1 bookrunner
+        run: cargo run -p bookrunner
+        env:
+            DOC_RUST_LANG_ORG_CHANNEL: nightly
 
       - name: Print book runner text results
         if: ${{ matrix.os == 'ubuntu-20.04' }}

--- a/scripts/kani-regression.sh
+++ b/scripts/kani-regression.sh
@@ -31,17 +31,17 @@ check-cbmc-viewer-version.py --major 2 --minor 5
 ${SCRIPT_DIR}/kani-fmt.sh --check
 
 # Build Kani compiler and Kani library
-(cd "${KANI_DIR}/src/kani-compiler"; cargo build)
+cargo build -p kani-compiler
 
 # Unit tests
-(cd src/kani-compiler/cbmc; cargo test)
-(cd src/kani-compiler; cargo test)
+cargo test -p cbmc
+cargo test -p kani-compiler
 
 # Build tool for linking Kani pointer restrictions
-cargo build --release --manifest-path src/tools/kani-link-restrictions/Cargo.toml
+cargo build --release -p kani-link-restrictions
 
 # Build compiletest
-(cd "${KANI_DIR}/src/tools/compiletest"; cargo build --release)
+cargo build --release -p compiletest
 
 # Declare testing suite information (suite and mode)
 TESTS=(


### PR DESCRIPTION
### Description of changes: 

Replace the last call to bootstrap by direct call to cargo. I also did a few cosmetic changes to our scripts to use target packages instead of changing the current directory.

### Resolved issues:

Resolves #641 

### Call-outs:

The initial version of this PR includes two commits, but only the second commit is relevant.

The first commit is an update to the toolchain which is covered in this PR (#764) but it is required for the second one. Once I merge the original PR, this should go away.

### Testing:

* How is this change tested? N/A

* Is this a refactor change? Maybe

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
