### PR TITLE
Get VS Code working again

### DIFF
--- a/kani-docs/src/dev-documentation.md
+++ b/kani-docs/src/dev-documentation.md
@@ -96,16 +96,16 @@ git log --graph --oneline origin/upstream-rustc..origin/main
 git diff --stat origin/upstream-rustc..origin/main
 ```
 
-## Setup RustAnalyzer in VSCode
+## Set up `rust-analyzer` in VSCode
 
-Add the following to your `settings.json`
+Add the following to the `rust-analyzer` extension settings in `settings.json`:
 ```
     "rust-analyzer.updates.channel": "nightly",
     "rust-analyzer.rustcSource": "discover",
     "rust-analyzer.workspace.symbol.search.scope": "workspace_and_dependencies",
 ```
 
-Ensure that any packages that use rustc data-structures have the following line set in their `cargo.toml`
+Ensure that any packages that use `rustc` data structures have the following line set in their `Cargo.toml`
 
 ```
 [package.metadata.rust-analyzer]

--- a/kani-docs/src/dev-documentation.md
+++ b/kani-docs/src/dev-documentation.md
@@ -96,6 +96,29 @@ git log --graph --oneline origin/upstream-rustc..origin/main
 git diff --stat origin/upstream-rustc..origin/main
 ```
 
+## Setup RustAnalyzer in VSCode
+
+Add the following to your `settings.json`
+```
+    "rust-analyzer.updates.channel": "nightly",
+    "rust-analyzer.rustcSource": "discover",
+    "rust-analyzer.workspace.symbol.search.scope": "workspace_and_dependencies",
+```
+
+Ensure that any packages that use rustc data-structures have the following line set in their `cargo.toml`
+
+```
+[package.metadata.rust-analyzer]
+# This package uses rustc crates.
+rustc_private=true
+```
+
+You may also need to install the `rustc-dev` package using rustup
+
+```
+rustup toolchain install nightly --component rustc-dev   
+```
+
 ## Kani command cheat sheet
 
 These can help understand what Kani is generating or encountering on an example or test file:

--- a/src/kani-compiler/rustc_codegen_kani/Cargo.toml
+++ b/src/kani-compiler/rustc_codegen_kani/Cargo.toml
@@ -25,3 +25,6 @@ kani_queries = { path = "../kani_queries" }
 kani_restrictions = { path = "../../../library/kani_restrictions" }
 rustc-demangle = "0.1.21"
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
+
+[package.metadata.rust-analyzer]
+rustc_private=true

--- a/src/tools/bookrunner/Cargo.toml
+++ b/src/tools/bookrunner/Cargo.toml
@@ -14,3 +14,7 @@ walkdir = "2.3.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.5"
+
+[package.metadata.rust-analyzer]
+# This package uses rustc crates.
+rustc_private=true


### PR DESCRIPTION
### Description of changes: 

Currently, VSCode doesn't autocomplete / give definitions of code inside `rustc`. This set of patches/instructions seems to fix that.

### Resolved issues:

Resolves #ISSUE-NUMBER


### Call-outs:

This works on my machine, but it would be great to have some way of checking this in CI.

### Testing:

* How is this change tested? Works on my machine.

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
